### PR TITLE
✨ :sparkles: Add SVG, PNG and JPEG as export option

### DIFF
--- a/aurelia_project/aurelia.json
+++ b/aurelia_project/aurelia.json
@@ -239,6 +239,27 @@
               "build/toastr.min.css"
             ],
             "deps": ["jquery"]
+          },
+          {
+            "name": "canvg-browser",
+            "path": "../node_modules/canvg-browser",
+            "main": "index.js",
+            "exports": "canvg"
+          },
+          {
+            "name": "rgbcolor",
+            "path": "../node_modules/rgbcolor",
+            "main": "index.js"
+          },
+          {
+            "name": "stackblur",
+            "path": "../node_modules/stackblur",
+            "main": "index.js"
+          },
+          {
+            "name": "xmldom",
+            "path": "../node_modules/xmldom",
+            "main": "dom-parser.js"
           }
         ]
       }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "bluebird": "^3.5.1",
     "bootstrap": "^3.3.7",
     "browser-sync": "^2.13.0",
+    "canvg-browser": "^1.0.0",
     "connect-history-api-fallback": "^1.2.0",
     "debounce": "^1.0.2",
     "debug": "^3.1.0",

--- a/src/contracts/bpmnmodeler/IBpmnModeler.ts
+++ b/src/contracts/bpmnmodeler/IBpmnModeler.ts
@@ -3,6 +3,8 @@ export interface IBpmnModeler {
   attachTo(wrapper: HTMLElement): void;
   saveXML(options: any,
           callback: (error: Error, result: String) => void): void;
+  saveSVG(options: any,
+          callback: (error: Error, result: String) => void): void;
   importXML(xml: string,
             errorHandler: (err: Error) => void): void;
 }

--- a/src/modules/bpmn-io/bpmn-io.ts
+++ b/src/modules/bpmn-io/bpmn-io.ts
@@ -55,7 +55,7 @@ export class BpmnIo {
         } else {
           resolve(result);
         }
-      })
+      });
     });
   }
 

--- a/src/modules/bpmn-io/bpmn-io.ts
+++ b/src/modules/bpmn-io/bpmn-io.ts
@@ -47,4 +47,16 @@ export class BpmnIo {
     });
   }
 
+  public getSVG(): Promise<string> {
+    return new Promise((resolve: Function, reject: Function): void => {
+      this.modeler.saveSVG({}, (err: Error, result: string) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(result);
+        }
+      })
+    });
+  }
+
 }

--- a/src/modules/processdef-detail/processdef-detail.html
+++ b/src/modules/processdef-detail/processdef-detail.html
@@ -46,10 +46,22 @@
         <button disabled.bind="process.draft" class="btn btn-danger" click.delegate="deleteProcess()">
           <i class="glyphicon glyphicon-trash"></i> Delete Process
         </button>
-        <a ref="exportButton" class="btn btn-primary export-button" click.delegate="exportDiagram()">
-          <i ref="exportSpinner" class="glyphicon glyphicon-repeat fa-spin hidden"></i>
-          <i class="glyphicon glyphicon-export"></i> Export Diagram
-        </a>
+        <div class="btn-group">
+          <a ref="exportButton" class="btn btn-primary export-button" click.delegate="exportBPMN()">
+            <i ref="exportSpinner" class="glyphicon glyphicon-repeat fa-spin hidden"></i>
+            <i class="glyphicon glyphicon-export"></i> Export Diagram
+          </a>
+          <a ref="exportDropdown" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <span class="caret"></span>
+            <span class="sr-only">Toggle Dropdown</span>
+          </a>
+          <ul class="dropdown-menu">
+            <li><a href="#" click.delegate="exportBPMN()">BPMN (default)</a></li>
+            <li><a href="#" click.delegate="exportSVG()">SVG</a></li>
+            <li><a href="#" click.delegate="exportPNG()">PNG</a></li>
+            <li><a href="#" click.delegate="exportJPEG()">JPEG</a></li>
+          </ul>
+        </div>
         <import-process-button desired-process-import-key.bind="process.key" callback.bind="onModdlelImported.bind($this)"></import-process-button>
         <span if.bind="process.latest" class="processdef-detail__draft-latest--true">Latest</span>
         <span if.bind="process.draft" class="processdef-detail__draft-latest--true">Draft</span>

--- a/src/modules/processdef-detail/processdef-detail.ts
+++ b/src/modules/processdef-detail/processdef-detail.ts
@@ -142,24 +142,33 @@ export class ProcessDefDetail {
 
   public exportSVG(): void {
     this.disableAndHideControlsForImageExport();
-    this.bpmn.getSVG().then((svg: string) => {
+
+    this.bpmn.getSVG()
+    .then((svg: string) => {
       download(svg, `${this.process.name}.svg`, 'image/svg+xml');
+
       this.enableAndShowControlsForImageExport();
     });
   }
 
   public exportPNG(): void {
     this.disableAndHideControlsForImageExport();
-    this.bpmn.getSVG().then((svg: string) => {
+
+    this.bpmn.getSVG()
+    .then((svg: string) => {
       download(this.generateImageFromSVG('png', svg), `${this.process.name}.png`, 'image/png');
+
       this.enableAndShowControlsForImageExport();
     });
   }
 
   public exportJPEG(): void {
     this.disableAndHideControlsForImageExport();
-    this.bpmn.getSVG().then((svg: string) => {
+
+    this.bpmn.getSVG()
+    .then((svg: string) => {
       download(this.generateImageFromSVG('jpeg', svg), `${this.process.name}.jpeg`, 'image/jpeg');
+
       this.enableAndShowControlsForImageExport();
     });
   }

--- a/src/modules/processdef-detail/processdef-detail.ts
+++ b/src/modules/processdef-detail/processdef-detail.ts
@@ -8,6 +8,7 @@ import * as toastr from 'toastr';
 import {AuthenticationStateEvent, IChooseDialogOption, IProcessEngineService} from '../../contracts/index';
 import environment from '../../environment';
 import {BpmnIo} from '../bpmn-io/bpmn-io';
+import * as canvg from 'canvg-browser';
 
 interface RouteParameters {
   processDefId: string;
@@ -22,6 +23,7 @@ export class ProcessDefDetail {
   private _process: IProcessDefEntity;
   private bpmn: BpmnIo;
   private exportButton: HTMLButtonElement;
+  private exportDropdown: HTMLButtonElement;
   private exportSpinner: HTMLElement;
   private startButtonDropdown: HTMLDivElement;
   private startButton: HTMLElement;
@@ -129,14 +131,67 @@ export class ProcessDefDetail {
     });
   }
 
-  public exportDiagram(): void {
+  public exportBPMN(): void {
     this.exportButton.setAttribute('disabled', '');
+    this.exportDropdown.setAttribute('disabled', '');    
     this.exportSpinner.classList.remove('hidden');
     this.bpmn.getXML().then((xml: string) => {
       download(xml, `${this.process.name}.bpmn`, 'application/bpmn20-xml');
       this.exportButton.removeAttribute('disabled');
+      this.exportDropdown.removeAttribute('disabled');      
       this.exportSpinner.classList.add('hidden');
     });
+
+  }
+
+  public exportSVG(): void {
+    this.exportButton.setAttribute('disabled', '');
+    this.exportDropdown.setAttribute('disabled', '');
+    this.exportSpinner.classList.remove('hidden');
+    this.bpmn.getSVG().then((svg: string) => {
+      download(svg, `${this.process.name}.svg`, 'image/svg+xml');
+      this.exportButton.removeAttribute('disabled');
+      this.exportDropdown.removeAttribute('disabled');
+      this.exportSpinner.classList.add('hidden');
+    });
+  }
+
+  public exportPNG(): void {
+    this.exportButton.setAttribute('disabled', '');
+    this.exportDropdown.setAttribute('disabled', '');
+    this.exportSpinner.classList.remove('hidden');
+    this.bpmn.getSVG().then((svg: string) => {
+      download(this.generateImage('png', svg), `${this.process.name}.png`, 'image/png');      
+      this.exportButton.removeAttribute('disabled');
+      this.exportDropdown.removeAttribute('disabled');
+      this.exportSpinner.classList.add('hidden');
+    });
+  }
+
+  public exportJPEG(): void {
+    this.exportButton.setAttribute('disabled', '');
+    this.exportDropdown.setAttribute('disabled', '');
+    this.exportSpinner.classList.remove('hidden');
+    this.bpmn.getSVG().then((svg: string) => {
+      download(this.generateImage('jpeg', svg), `${this.process.name}.jpeg`, 'image/jpeg');      
+      this.exportButton.removeAttribute('disabled');
+      this.exportDropdown.removeAttribute('disabled');
+      this.exportSpinner.classList.add('hidden');
+    });
+  }
+
+  public generateImage(type, svg) {
+    let encoding = 'image/' + type,
+        context,
+        canvas;
+    canvas = document.createElement('canvas');
+    canvg(canvas, svg);
+    // make the background white for every format
+    context = canvas.getContext('2d');
+    context.globalCompositeOperation = 'destination-over';
+    context.fillStyle = 'white';
+    context.fillRect(0, 0, canvas.width, canvas.height);
+    return canvas.toDataURL(encoding);
   }
 
   public async publishDraft(): Promise<any> {

--- a/src/modules/processdef-detail/processdef-detail.ts
+++ b/src/modules/processdef-detail/processdef-detail.ts
@@ -3,12 +3,12 @@ import {IProcessDefEntity} from '@process-engine/process_engine_contracts';
 import {EventAggregator, Subscription} from 'aurelia-event-aggregator';
 import {bindable, computedFrom, inject} from 'aurelia-framework';
 import {Router} from 'aurelia-router';
+import * as canvg from 'canvg-browser';
 import * as download from 'downloadjs';
 import * as toastr from 'toastr';
 import {AuthenticationStateEvent, IChooseDialogOption, IProcessEngineService} from '../../contracts/index';
 import environment from '../../environment';
 import {BpmnIo} from '../bpmn-io/bpmn-io';
-import * as canvg from 'canvg-browser';
 
 interface RouteParameters {
   processDefId: string;
@@ -132,66 +132,51 @@ export class ProcessDefDetail {
   }
 
   public exportBPMN(): void {
-    this.exportButton.setAttribute('disabled', '');
-    this.exportDropdown.setAttribute('disabled', '');    
-    this.exportSpinner.classList.remove('hidden');
+    this.disableAndHideControlsForImageExport();
     this.bpmn.getXML().then((xml: string) => {
       download(xml, `${this.process.name}.bpmn`, 'application/bpmn20-xml');
-      this.exportButton.removeAttribute('disabled');
-      this.exportDropdown.removeAttribute('disabled');      
-      this.exportSpinner.classList.add('hidden');
+      this.enableAndShowControlsForImageExport();
     });
 
   }
 
   public exportSVG(): void {
-    this.exportButton.setAttribute('disabled', '');
-    this.exportDropdown.setAttribute('disabled', '');
-    this.exportSpinner.classList.remove('hidden');
+    this.disableAndHideControlsForImageExport();
     this.bpmn.getSVG().then((svg: string) => {
       download(svg, `${this.process.name}.svg`, 'image/svg+xml');
-      this.exportButton.removeAttribute('disabled');
-      this.exportDropdown.removeAttribute('disabled');
-      this.exportSpinner.classList.add('hidden');
+      this.enableAndShowControlsForImageExport();
     });
   }
 
   public exportPNG(): void {
-    this.exportButton.setAttribute('disabled', '');
-    this.exportDropdown.setAttribute('disabled', '');
-    this.exportSpinner.classList.remove('hidden');
+    this.disableAndHideControlsForImageExport();
     this.bpmn.getSVG().then((svg: string) => {
-      download(this.generateImage('png', svg), `${this.process.name}.png`, 'image/png');      
-      this.exportButton.removeAttribute('disabled');
-      this.exportDropdown.removeAttribute('disabled');
-      this.exportSpinner.classList.add('hidden');
+      download(this.generateImageFromSVG('png', svg), `${this.process.name}.png`, 'image/png');
+      this.enableAndShowControlsForImageExport();
     });
   }
 
   public exportJPEG(): void {
-    this.exportButton.setAttribute('disabled', '');
-    this.exportDropdown.setAttribute('disabled', '');
-    this.exportSpinner.classList.remove('hidden');
+    this.disableAndHideControlsForImageExport();
     this.bpmn.getSVG().then((svg: string) => {
-      download(this.generateImage('jpeg', svg), `${this.process.name}.jpeg`, 'image/jpeg');      
-      this.exportButton.removeAttribute('disabled');
-      this.exportDropdown.removeAttribute('disabled');
-      this.exportSpinner.classList.add('hidden');
+      download(this.generateImageFromSVG('jpeg', svg), `${this.process.name}.jpeg`, 'image/jpeg');
+      this.enableAndShowControlsForImageExport();
     });
   }
 
-  public generateImage(type, svg) {
-    let encoding = 'image/' + type,
-        context,
-        canvas;
-    canvas = document.createElement('canvas');
+  public generateImageFromSVG(desiredImageType: string, svg: any): string {
+    const encoding: string = `image/${desiredImageType}`;
+    const canvas: HTMLCanvasElement = document.createElement('canvas');
+    const context: CanvasRenderingContext2D = canvas.getContext('2d');
+
     canvg(canvas, svg);
     // make the background white for every format
-    context = canvas.getContext('2d');
     context.globalCompositeOperation = 'destination-over';
     context.fillStyle = 'white';
     context.fillRect(0, 0, canvas.width, canvas.height);
-    return canvas.toDataURL(encoding);
+
+    const image: string = canvas.toDataURL(encoding); // returns a base64 datastring
+    return image;
   }
 
   public async publishDraft(): Promise<any> {
@@ -201,6 +186,18 @@ export class ProcessDefDetail {
     }).catch((error: Error) => {
       toastr.error(`Error while publishing Draft: ${error.message}`);
     });
+  }
+
+  private disableAndHideControlsForImageExport(): void {
+    this.exportButton.setAttribute('disabled', '');
+    this.exportDropdown.setAttribute('disabled', '');
+    this.exportSpinner.classList.remove('hidden');
+  }
+
+  private enableAndShowControlsForImageExport(): void {
+    this.exportButton.removeAttribute('disabled');
+    this.exportDropdown.removeAttribute('disabled');
+    this.exportSpinner.classList.add('hidden');
   }
 
 }


### PR DESCRIPTION
## What did you change?

This PR adds the option to export a diagram as SVG, PNG or JPEG.
Closes #118 

## How can others test the changes?

![jan -17-2018 16-10-27](https://user-images.githubusercontent.com/17065920/35049730-44bb165e-fba1-11e7-9317-ec6a0427d4fe.gif)

- Checkout the branch
- Start bpmn-studio and navigate to the details page of a processdef
- Export the diagram as SVG, PNG or JPEG

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
