### PR TITLE
Add Electron Autoupdate Functionality

### DIFF
--- a/dev-app-update.yml
+++ b/dev-app-update.yml
@@ -1,0 +1,3 @@
+owner: process-engine
+repo: bpmn-studio
+provider: github

--- a/electron_app/electron.js
+++ b/electron_app/electron.js
@@ -1,9 +1,13 @@
 const electron = require('electron');
-const {autoUpdater} = require('electron-updater');
+const autoUpdater = require('electron-updater').autoUpdater;
 const app = electron.app;
 const notifier = require('electron-notifications');
 
 let mainWindow = null;
+
+const installButtonText = 'Install';
+const dismissButtonText = 'Dismiss';
+
 function createWindow () {
   if (mainWindow !== null) {
     return;
@@ -21,7 +25,7 @@ function createWindow () {
   autoUpdater.addListener('error', (error) => {
     const notification = notifier.notify('Update error', {
       message: 'Update failed',
-      buttons: ['Dismiss'],
+      buttons: [dismissButtonText],
     });
     notification.on('buttonClicked', (text, buttonIndex, options) => {
       notification.close();
@@ -31,7 +35,7 @@ function createWindow () {
   autoUpdater.addListener('update-available', (info) => {
     notifier.notify('Update available', {
       message: 'Started downloading',
-      buttons: ['Dismiss'],
+      buttons: [dismissButtonText],
     });
   });
 
@@ -39,11 +43,12 @@ function createWindow () {
     const notification = notifier.notify('Update ready', {
       message: 'Update ready for installation',
       duration: '60000',
-      buttons: ['Install', 'Dismiss'],
+      buttons: [installButtonText, dismissButtonText],
     });
 
     notification.on('buttonClicked', (text, buttonIndex, options) => {
-      if (text == 'Install') {
+      const installButtonClicked = text === installButtonText;
+      if (installButtonClicked) {
         autoUpdater.quitAndInstall();
       } else {
         notification.close();

--- a/electron_app/electron.js
+++ b/electron_app/electron.js
@@ -31,6 +31,7 @@ function createWindow () {
   autoUpdater.addListener('update-available', (info) => {
     notifier.notify('Update available', {
       message: 'Started downloading',
+      buttons: ['Dismiss'],
     });
   });
 

--- a/electron_app/electron.js
+++ b/electron_app/electron.js
@@ -1,5 +1,7 @@
 const electron = require('electron');
+const {autoUpdater} = require('electron-updater');
 const app = electron.app;
+const notifier = require('electron-notifications');
 
 let mainWindow = null;
 function createWindow () {
@@ -8,10 +10,47 @@ function createWindow () {
   }
 
   mainWindow = new electron.BrowserWindow({width: 800, height: 600});
+
   mainWindow.loadURL(`file://${__dirname}/../index.html`);
   mainWindow.on('closed', () => {
     mainWindow = null;
   });
+
+  autoUpdater.checkForUpdates();
+
+  autoUpdater.addListener('error', (error) => {
+    const notification = notifier.notify('Update error', {
+      message: 'Update failed',
+      buttons: ['Dismiss'],
+    });
+    notification.on('buttonClicked', (text, buttonIndex, options) => {
+      notification.close();
+    });
+  });
+
+  autoUpdater.addListener('update-available', (info) => {
+    notifier.notify('Update available', {
+      message: 'Started downloading',
+    });
+  });
+
+  autoUpdater.addListener('update-downloaded', (info) => {
+    const notification = notifier.notify('Update ready', {
+      message: 'Update ready for installation',
+      duration: '60000',
+      buttons: ['Install', 'Dismiss'],
+    });
+
+    notification.on('buttonClicked', (text, buttonIndex, options) => {
+      if (text == 'Install') {
+        autoUpdater.quitAndInstall();
+      } else {
+        notification.close();
+      }
+    })
+  });
+
+
 }
 
 app.on('ready', createWindow);

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "bpmn-studio",
   "description": "An Aurelia application for designing BPMN diagrams, which can also be connected to a process engine to execute these diagrams.",
   "version": "1.0.0-rc9",
+  "main": "electron_app/electron.js",
   "scripts": {
     "start": "./bin/bpmn-studio.js",
     "start_dev": "au run --watch",
@@ -11,7 +12,9 @@
     "integration-test": "au e2e",
     "lint": "tslint --project .",
     "test": "echo 'Currently there a no tests specified'",
-    "electron": "electron electron_app/electron.js"
+    "electron-start-dev": "electron electron_app/electron.js",
+    "electron-build": "build",
+    "electron-shipit": "build -p always"
   },
   "files": [
     "scripts",
@@ -21,14 +24,15 @@
   ],
   "bin": "./bin/bpmn-studio.js",
   "repository": {
-    "type": "???",
-    "url": "???"
+    "type": "git",
+    "url": "git+https://github.com/process-engine/bpmn-studio"
   },
   "license": "MIT",
   "dependencies": {
+    "electron-notifications": "^1.0.0",
+    "electron-updater": "^2.19.1",
     "node-http-server": "^8.1.2",
-    "open": "0.0.5",
-    "electron": "^1.7.9"
+    "open": "0.0.5"
   },
   "peerDependencies": {},
   "devDependencies": {
@@ -58,6 +62,8 @@
     "downloadjs": "1.4.4",
     "event-stream": "^3.3.3",
     "eventemitter2": "^4.1.2",
+    "electron": "^1.7.9",
+    "electron-builder": "^19.54.0",
     "faye": "^1.2.4",
     "fetch-ponyfill": "^4.1.0",
     "font-awesome": "^4.7.0",


### PR DESCRIPTION
## What did you change?

This branch adds the autoupdate functionallity for electron apps.

Closes #77 
Closes #126 
Closes #124 
Closes #122

## How can others test these changes?

1. checkout bpmn-studio
2. run `npm install`
3. downgrade version to rc8
4. get an apple macos developer certificate
5. run `npm run electron-build`
6. open ...-mac.zip file in /dist folder
7. run the app

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
