### PR TITLE
🔊 :loud_sound: Add warning when unsupported form field type is used

### DIFF
--- a/src/modules/form-widget/form-widget.ts
+++ b/src/modules/form-widget/form-widget.ts
@@ -1,5 +1,6 @@
 import {FormWidgetFieldType, IFormWidgetConfig, SpecificFormWidgetField} from '@process-engine/consumer_client';
 import {bindable} from 'aurelia-framework';
+import * as toastr from 'toastr';
 
 export class FormWidget {
 
@@ -15,6 +16,7 @@ export class FormWidget {
       case FormWidgetFieldType.boolean:
         return 'checkbox';
       default:
+        toastr.error(`Not supported FromWidgetFieldType: ${field.type}`);
         return null;
     }
   }


### PR DESCRIPTION
## What did you change?

Adds a error message when a unsupported field is used in dynamic ui

## How can others test the changes?

- Use long type as field type
- start process with dynamic ui
- see error

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
