### PR TITLE
🔥 Delete Section Border Class from HTML Files

### DIFF
--- a/src/modules/property-panel/indextabs/extensions/sections/basics/basics.html
+++ b/src/modules/property-panel/indextabs/extensions/sections/basics/basics.html
@@ -2,7 +2,7 @@
   <require from="./basics.css"></require>
   <require from="../../../../styles/sections.css"></require>
   <div class="extensions-section">
-    <div class="section__content section__border">
+    <div class="section__content">
         
       <h4><label class="header-label">Properties</label></h4>
       <label class="input-label">Add Properties </label>

--- a/src/modules/property-panel/indextabs/forms/sections/basics/basics.html
+++ b/src/modules/property-panel/indextabs/forms/sections/basics/basics.html
@@ -2,7 +2,7 @@
   <require from="./basics.css"></require>
   <require from="../../../../styles/sections.css"></require>
   <div class="section"  show.bind="canHandleElement">
-    <div class="section__content section__border col-md-11">
+    <div class="section__content col-md-11">
       <h4><label class="header-label">Forms</label></h4>
       <div class="section__btn-group">
         <label class="section__input-label">Form Key: </label>

--- a/src/modules/property-panel/indextabs/general/sections/basics/basics.html
+++ b/src/modules/property-panel/indextabs/general/sections/basics/basics.html
@@ -2,7 +2,7 @@
   <require from="./basics.css"></require>
   <require from="../../../../styles/sections.css"></require>
   <div class="section">
-    <div class="section__content section__border col-md-11">
+    <div class="section__content col-md-11">
       <div class="section__btn-group">
         <label class="section__input-label">Id: </label>
         <input type="text" id="id" class="form-control" value.bind="businessObjInPanel.id & validateOnChange" change.delegate="updateId()">

--- a/src/modules/property-panel/indextabs/general/sections/call-activity/call-activity.html
+++ b/src/modules/property-panel/indextabs/general/sections/call-activity/call-activity.html
@@ -2,7 +2,7 @@
   <require from="./call-activity.css"></require>
   <require from="../../../../styles/sections.css"></require>
   <div class="section" show.bind="canHandleElement">
-    <div class="section__content section__border col-md-11">
+    <div class="section__content col-md-11">
       <label><em>Call Activity</em></label><br>
       <div class="section__btn-group">
         <label class="section__input-label">Called Element: </label>

--- a/src/modules/property-panel/indextabs/general/sections/error-event/error-event.html
+++ b/src/modules/property-panel/indextabs/general/sections/error-event/error-event.html
@@ -2,7 +2,7 @@
   <require from="./error-event.css"></require>
   <require from="../../../../styles/sections.css"></require>
   <div class="section" show.bind="canHandleElement">
-    <div class="section__content section__border col-md-11">
+    <div class="section__content col-md-11">
       <label class="section__input-label">Error: </label>
       <select class="form-control" value.bind="selectedId" change.delegate="updateError()">
         <option model.bind="null">-Choose Error-</option>

--- a/src/modules/property-panel/indextabs/general/sections/escalation-event/escalation-event.html
+++ b/src/modules/property-panel/indextabs/general/sections/escalation-event/escalation-event.html
@@ -2,7 +2,7 @@
   <require from="./escalation-event.css"></require>
   <require from="../../../../styles/sections.css"></require>
   <div class="section" show.bind="canHandleElement">
-    <div class="section__content section__border col-md-11">
+    <div class="section__content col-md-11">
       <label class="section__input-label">Escalation: </label>
       <select class="form-control" value.bind="selectedId" change.delegate="updateEscalation()">
         <option model.bind="null">-Choose Escalation-</option>

--- a/src/modules/property-panel/indextabs/general/sections/flow/flow.html
+++ b/src/modules/property-panel/indextabs/general/sections/flow/flow.html
@@ -2,7 +2,7 @@
   <require from="./flow.css"></require>
   <require from="../../../../styles/sections.css"></require>
   <div class="section" show.bind="canHandleElement">
-    <div class="section__content section__border col-md-11">
+    <div class="section__content col-md-11">
       <div class="section__btn-group">
         <label class="section__input-label">Condition: </label>
         <input type="text" class="form-control" value.bind="condition">

--- a/src/modules/property-panel/indextabs/general/sections/message-event/message-event.html
+++ b/src/modules/property-panel/indextabs/general/sections/message-event/message-event.html
@@ -2,7 +2,7 @@
   <require from="./message-event.css"></require>
   <require from="../../../../styles/sections.css"></require>
   <div class="section" show.bind="canHandleElement">
-    <div class="section__content section__border col-md-11">
+    <div class="section__content col-md-11">
       <label class="section__input-label">Message: </label>
       <select ref="msgDropdown" class="form-control" value.bind="selectedId" change.delegate="updateMessage()">
         <option model.bind="null">-Choose Message-</option>

--- a/src/modules/property-panel/indextabs/general/sections/pool/pool.html
+++ b/src/modules/property-panel/indextabs/general/sections/pool/pool.html
@@ -2,7 +2,7 @@
   <require from="./pool.css"></require>
   <require from="../../../../styles/sections.css"></require>
   <div class="section" show.bind="canHandleElement">
-    <div class="section__content section__border col-md-11">
+    <div class="section__content col-md-11">
       <div class="section__btn-group">
         <label class="section__input-label">Version Tag: </label>
         <input type="text" class="form-control" value.bind="businessObjInPanel.processRef.versionTag">

--- a/src/modules/property-panel/indextabs/general/sections/script-task/script-task.html
+++ b/src/modules/property-panel/indextabs/general/sections/script-task/script-task.html
@@ -2,7 +2,7 @@
   <require from="./script-task.css"></require>
   <require from="../../../../styles/sections.css"></require>
   <div class="section" show.bind="canHandleElement">
-    <div class="section__content section__border col-md-11">
+    <div class="section__content col-md-11">
       <label><em>Script Task</em></label><br>
       <div class="section__btn-group">
         <label class="section__input-label">Script Format: </label>

--- a/src/modules/property-panel/indextabs/general/sections/signal-event/signal-event.html
+++ b/src/modules/property-panel/indextabs/general/sections/signal-event/signal-event.html
@@ -2,7 +2,7 @@
   <require from="./signal-event.css"></require>
   <require from="../../../../styles/sections.css"></require>
   <div class="section" show.bind="canHandleElement">
-    <div class="section__content section__border col-md-11">
+    <div class="section__content col-md-11">
       <label class="section__input-label">Signal: </label>
       <select class="form-control" value.bind="selectedId" change.delegate="updateSignal()">
         <option model.bind="null">-Choose Signal-</option>


### PR DESCRIPTION
## What did you change?

This PR removes the no longer existing `section__border` class from all HTML files it was still in.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
