### PR TITLE
🐛 :bug: Fix setFirstElement function

### DIFF
--- a/src/contracts/bpmnmodeler/bpmnElements/IModdleElement.ts
+++ b/src/contracts/bpmnmodeler/bpmnElements/IModdleElement.ts
@@ -16,4 +16,6 @@ export interface IModdleElement {
   di?: IModdleElement;
   fill?: string;
   stroke?: string;
+  laneSets?: Array<IModdleElement>;
+  lanes?: Array<IModdleElement>;
 }

--- a/src/contracts/bpmnmodeler/bpmnElements/IProcessRef.ts
+++ b/src/contracts/bpmnmodeler/bpmnElements/IProcessRef.ts
@@ -1,9 +1,9 @@
 import { IModdleElement } from './IModdleElement';
 
 export interface IProcessRef extends IModdleElement {
-  extensionElement: Object;
-  flowElement: Array<Object>;
+  extensionElement: IModdleElement;
+  flowElement: Array<IModdleElement>;
   isExecutable: boolean;
-  laneSets: Array<Object>;
+  laneSets: Array<IModdleElement>;
   versionTag: string;
 }

--- a/src/modules/property-panel/property-panel.ts
+++ b/src/modules/property-panel/property-panel.ts
@@ -91,6 +91,8 @@ export class PropertyPanel {
         if (!startEvent && process.flowElements) {
           startEvent = process.flowElements[0];
         }
+      } else if (process.laneSets && process.laneSets[0].lanes) {
+        startEvent = process.laneSets[0].lanes[0];
       }
 
       if (!startEvent) {

--- a/src/modules/property-panel/property-panel.ts
+++ b/src/modules/property-panel/property-panel.ts
@@ -39,7 +39,8 @@ export class PropertyPanel {
       this.extensionsIndextab,
     ];
 
-    this.checkForEachIndexTabisSuitable();
+    this.updateIndexTabsSuitability();
+    this.checkIndexTabSuitability();
 
     this.eventBus.on(['element.click', 'shape.changed', 'selection.changed'], (event: IEvent) => {
 
@@ -58,7 +59,8 @@ export class PropertyPanel {
         this.elementInPanel = event.newSelection[0];
       }
 
-      this.checkForEachIndexTabisSuitable();
+      this.updateIndexTabsSuitability();
+      this.checkIndexTabSuitability();
     });
 
     this.setFirstElement();
@@ -119,13 +121,20 @@ export class PropertyPanel {
     }
   }
 
-  private checkForEachIndexTabisSuitable(): void {
-    this.indextabs.forEach((indextab: IIndextab) => {
+  private updateIndexTabsSuitability(): void {
+    for (const indextab of this.indextabs) {
       indextab.canHandleElement = indextab.isSuitableForElement(this.elementInPanel);
-      if (indextab.title === this.currentIndextabTitle && !indextab.canHandleElement) {
-        this.currentIndextabTitle = this.generalIndextab.title;
-      }
+    }
+  }
+
+  private checkIndexTabSuitability(): void {
+    const currentIndexTab: IIndextab = this.indextabs.find((indextab: IIndextab) => {
+      return indextab.title === this.currentIndextabTitle;
     });
+
+    if (!currentIndexTab.canHandleElement) {
+      this.currentIndextabTitle = this.generalIndextab.title;
+    }
   }
 
 }

--- a/src/modules/property-panel/property-panel.ts
+++ b/src/modules/property-panel/property-panel.ts
@@ -102,8 +102,14 @@ export class PropertyPanel {
   }
 
   private processHasLanes(process: IModdleElement): boolean {
-    return  (process.laneSets !== undefined || process.laneSets !== null) &&
-            (process.laneSets[0].lanes !== undefined || process.laneSets[0].lanes !== null);
+    const processHasLaneSets: boolean = process.laneSets !== undefined && process.laneSets !== null;
+    if (!processHasLaneSets) {
+      return false;
+    }
+
+    const processHasLanes: boolean = process.laneSets[0].lanes !== undefined && process.laneSets[0].lanes !== null;
+
+    return processHasLanes;
   }
 
   private xmlChanged(newValue: string, oldValue: string): void {

--- a/src/modules/property-panel/property-panel.ts
+++ b/src/modules/property-panel/property-panel.ts
@@ -76,15 +76,17 @@ export class PropertyPanel {
         return element.$type === 'bpmn:Process';
       });
 
-      if (process.flowElements) {
+      const processHasFlowElements: boolean = process.flowElements !== undefined && process.flowElements !== null;
+
+      if (processHasFlowElements) {
         firstElement = process.flowElements.find((element: IModdleElement ) => {
           return element.$type === 'bpmn:StartEvent';
         });
 
-        if (!firstElement && process.flowElements) {
+        if (!firstElement) {
           firstElement = process.flowElements[0];
         }
-      } else if (process.laneSets && process.laneSets[0].lanes) {
+      } else if (this.processHasLanes(process)) {
         firstElement = process.laneSets[0].lanes[0];
       }
 
@@ -97,6 +99,11 @@ export class PropertyPanel {
 
       this.modeler.get('selection').select(elementInPanel);
     }));
+  }
+
+  private processHasLanes(process: IModdleElement): boolean {
+    return  (process.laneSets !== undefined || process.laneSets !== null) &&
+            (process.laneSets[0].lanes !== undefined || process.laneSets[0].lanes !== null);
   }
 
   private xmlChanged(newValue: string, oldValue: string): void {

--- a/src/modules/property-panel/property-panel.ts
+++ b/src/modules/property-panel/property-panel.ts
@@ -77,15 +77,24 @@ export class PropertyPanel {
   }
 
   private setFirstElement(): void {
+    let startEvent: IModdleElement;
     this.moddle.fromXML(this.xml, ((err: Error, definitions: IDefinition): void => {
       const process: IModdleElement = definitions.rootElements.find((element: IModdleElement) => {
         return element.$type === 'bpmn:Process';
       });
-      const startEvent: IModdleElement = process.flowElements.find((element: any ) => {
-        return element.$type === 'bpmn:StartEvent';
-      });
-      if (startEvent.$type !== 'bpmn:StartEvent') {
-        startEvent.id = process.flowElements[0].id;
+
+      if (process.flowElements) {
+        startEvent = process.flowElements.find((element: any ) => {
+          return element.$type === 'bpmn:StartEvent';
+        });
+
+        if (!startEvent && process.flowElements) {
+          startEvent = process.flowElements[0];
+        }
+      }
+
+      if (!startEvent) {
+        startEvent = process;
       }
 
       const elementRegistry: IElementRegistry = this.modeler.get('elementRegistry');

--- a/src/modules/property-panel/property-panel.ts
+++ b/src/modules/property-panel/property-panel.ts
@@ -39,12 +39,7 @@ export class PropertyPanel {
       this.extensionsIndextab,
     ];
 
-    this.indextabs.forEach((indextab: IIndextab) => {
-      indextab.canHandleElement = indextab.isSuitableForElement(this.elementInPanel);
-      if (indextab.title === this.currentIndextabTitle && !indextab.canHandleElement) {
-        this.currentIndextabTitle = this.generalIndextab.title;
-      }
-    });
+    this.checkForEachIndexTabisSuitable();
 
     this.eventBus.on(['element.click', 'shape.changed', 'selection.changed'], (event: IEvent) => {
 
@@ -63,12 +58,7 @@ export class PropertyPanel {
         this.elementInPanel = event.newSelection[0];
       }
 
-      this.indextabs.forEach((indextab: IIndextab) => {
-        indextab.canHandleElement = indextab.isSuitableForElement(this.elementInPanel);
-        if (indextab.title === this.currentIndextabTitle && !indextab.canHandleElement) {
-          this.currentIndextabTitle = this.generalIndextab.title;
-        }
-      });
+      this.checkForEachIndexTabisSuitable();
     });
 
     this.setFirstElement();
@@ -114,6 +104,15 @@ export class PropertyPanel {
       this.setFirstElement();
       this.updateIndextab(this.generalIndextab);
     }
+  }
+
+  private checkForEachIndexTabisSuitable(): void {
+    this.indextabs.forEach((indextab: IIndextab) => {
+      indextab.canHandleElement = indextab.isSuitableForElement(this.elementInPanel);
+      if (indextab.title === this.currentIndextabTitle && !indextab.canHandleElement) {
+        this.currentIndextabTitle = this.generalIndextab.title;
+      }
+    });
   }
 
 }

--- a/src/modules/property-panel/property-panel.ts
+++ b/src/modules/property-panel/property-panel.ts
@@ -77,30 +77,30 @@ export class PropertyPanel {
   }
 
   private setFirstElement(): void {
-    let startEvent: IModdleElement;
+    let firstElement: IModdleElement;
     this.moddle.fromXML(this.xml, ((err: Error, definitions: IDefinition): void => {
       const process: IModdleElement = definitions.rootElements.find((element: IModdleElement) => {
         return element.$type === 'bpmn:Process';
       });
 
       if (process.flowElements) {
-        startEvent = process.flowElements.find((element: any ) => {
+        firstElement = process.flowElements.find((element: IModdleElement ) => {
           return element.$type === 'bpmn:StartEvent';
         });
 
-        if (!startEvent && process.flowElements) {
-          startEvent = process.flowElements[0];
+        if (!firstElement && process.flowElements) {
+          firstElement = process.flowElements[0];
         }
       } else if (process.laneSets && process.laneSets[0].lanes) {
-        startEvent = process.laneSets[0].lanes[0];
+        firstElement = process.laneSets[0].lanes[0];
       }
 
-      if (!startEvent) {
-        startEvent = process;
+      if (!firstElement) {
+        firstElement = process;
       }
 
       const elementRegistry: IElementRegistry = this.modeler.get('elementRegistry');
-      const elementInPanel: IShape = elementRegistry.get(startEvent.id);
+      const elementInPanel: IShape = elementRegistry.get(firstElement.id);
 
       this.modeler.get('selection').select(elementInPanel);
     }));


### PR DESCRIPTION
## What did you change?

This PR selects now always an element (after import or first attach of detailview).
- first try to set the startevent
- then try to set another element
- if that fails, it selects the process 

## How can others test the changes?

- import a diagram with a startevent and other elements => startevent is selected
- import a diagram without a startevent => another element is selected
- import a diagram without any elements => process is selected

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
