### PR TITLE
🐛 :bug: Add selection-changed event for rendering also elements if sele…

### DIFF
--- a/src/modules/property-panel/indextabs/general/general.ts
+++ b/src/modules/property-panel/indextabs/general/general.ts
@@ -49,15 +49,19 @@ export class General implements IIndextab {
   public checkElement(element: IModdleElement): boolean {
     return true;
   }
+
   public activate(model: IPageModel): void {
     this.eventBus = model.modeler.get('eventBus');
 
-    this.eventBus.on(['element.click', 'shape.changed'], (event: IEvent) => {
+    this.eventBus.on(['element.click', 'shape.changed', 'selection.changed'], (event: IEvent) => {
       if (event.type === 'element.click') {
         this.elementInPanel = event.element.businessObject;
       }
       if (event.type === 'shape.changed' && event.element.type !== 'label') {
         this.elementInPanel = event.element.businessObject;
+      }
+      if (event.type === 'selection.changed' && event.newSelection.length !== 0) {
+        this.elementInPanel = event.newSelection[0].businessObject;
       }
       if (this.elementInPanel) {
         this.sections.forEach((section: ISection) => {

--- a/src/modules/property-panel/indextabs/general/general.ts
+++ b/src/modules/property-panel/indextabs/general/general.ts
@@ -56,11 +56,9 @@ export class General implements IIndextab {
     this.eventBus.on(['element.click', 'shape.changed', 'selection.changed'], (event: IEvent) => {
       if (event.type === 'element.click') {
         this.elementInPanel = event.element.businessObject;
-      }
-      if (event.type === 'shape.changed' && event.element.type !== 'label') {
+      } else if (event.type === 'shape.changed' && event.element.type !== 'label') {
         this.elementInPanel = event.element.businessObject;
-      }
-      if (event.type === 'selection.changed' && event.newSelection.length !== 0) {
+      } else if (event.type === 'selection.changed' && event.newSelection.length !== 0) {
         this.elementInPanel = event.newSelection[0].businessObject;
       }
       if (this.elementInPanel) {


### PR DESCRIPTION
…ction has changed.

## What did you change?

This PR adds a selection changed event to the eventbus to render events also, if the selection has been changed.

## How can others test the changes?

- import a diagram with a signal startevent
- now the propertypanel shows the view for the signal event and not only for the startevent

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [ ] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
