### PR TITLE
Rework Event System of Property Panel

### DIFF
--- a/src/contracts/propertypanel/IIndextab.ts
+++ b/src/contracts/propertypanel/IIndextab.ts
@@ -8,5 +8,5 @@ export interface IIndextab {
   elementInPanel: IShape;
   canHandleElement: boolean;
   sections: Array<ISection>;
-  checkElement(element: IShape): boolean;
+  isSuitableForElement(element: IShape): boolean;
 }

--- a/src/contracts/propertypanel/IIndextab.ts
+++ b/src/contracts/propertypanel/IIndextab.ts
@@ -1,10 +1,11 @@
-import { IModdleElement } from '../bpmnmodeler/bpmnElements/IModdleElement';
+import {IModdleElement} from '../bpmnmodeler/bpmnElements/IModdleElement';
 import {IShape} from '../bpmnmodeler/IShape';
 import {ISection} from './ISection';
 
 export interface IIndextab {
   title: string;
   path: string;
+  elementInPanel: IShape;
   canHandleElement: boolean;
   sections: Array<ISection>;
   checkElement(element: IShape): boolean;

--- a/src/contracts/propertypanel/IIndextab.ts
+++ b/src/contracts/propertypanel/IIndextab.ts
@@ -7,5 +7,5 @@ export interface IIndextab {
   path: string;
   canHandleElement: boolean;
   sections: Array<ISection>;
-  checkElement(element: IModdleElement): boolean;
+  checkElement(element: IShape): boolean;
 }

--- a/src/contracts/propertypanel/IPageModel.ts
+++ b/src/contracts/propertypanel/IPageModel.ts
@@ -1,5 +1,7 @@
 import {IBpmnModeler} from '../bpmnmodeler/IBpmnModeler';
+import {IShape} from '../bpmnmodeler/IShape';
 
 export interface IPageModel {
   modeler: IBpmnModeler;
+  elementInPanel: IShape;
 }

--- a/src/contracts/propertypanel/ISection.ts
+++ b/src/contracts/propertypanel/ISection.ts
@@ -8,5 +8,5 @@ export interface ISection {
   path: string;
   canHandleElement: boolean;
   activate(model: IPageModel): void;
-  checkElement(element: IShape): boolean;
+  isSuitableForElement(element: IShape): boolean;
 }

--- a/src/contracts/propertypanel/ISection.ts
+++ b/src/contracts/propertypanel/ISection.ts
@@ -8,5 +8,5 @@ export interface ISection {
   path: string;
   canHandleElement: boolean;
   activate(model: IPageModel): void;
-  checkElement(element: IModdleElement): boolean;
+  checkElement(element: IShape): boolean;
 }

--- a/src/modules/property-panel/indextabs/extensions/extensions.html
+++ b/src/modules/property-panel/indextabs/extensions/extensions.html
@@ -4,5 +4,5 @@
     <compose repeat.for="section of sections"
       view-model=".${section.path}"
       view=".${section.path}.html"
-      model.bind="{modeler : modeler}"></compose>
+      model.bind="{modeler : modeler, elementInPanel : elementInPanel}"></compose>
 </template>

--- a/src/modules/property-panel/indextabs/extensions/extensions.html
+++ b/src/modules/property-panel/indextabs/extensions/extensions.html
@@ -4,5 +4,5 @@
     <compose repeat.for="section of sections"
       view-model=".${section.path}"
       view=".${section.path}.html"
-      model.bind="{modeler : modeler, elementInPanel : elementInPanel}"></compose>
+      model.bind="{modeler: modeler, elementInPanel: elementInPanel}"></compose>
 </template>

--- a/src/modules/property-panel/indextabs/extensions/extensions.ts
+++ b/src/modules/property-panel/indextabs/extensions/extensions.ts
@@ -19,7 +19,7 @@ export class Extensions implements IIndextab {
     ];
   }
 
-  public checkElement(element: IModdleElement): boolean {
+  public checkElement(element: IShape): boolean {
 
     if (!element) {
       return false;

--- a/src/modules/property-panel/indextabs/extensions/extensions.ts
+++ b/src/modules/property-panel/indextabs/extensions/extensions.ts
@@ -20,14 +20,14 @@ export class Extensions implements IIndextab {
     ];
   }
 
-  public checkElement(element: IShape): boolean {
+  public isSuitableForElement(element: IShape): boolean {
 
     if (!element) {
       return false;
     }
 
     return this.sections.some((section: ISection) => {
-      return section.checkElement(element);
+      return section.isSuitableForElement(element);
     });
   }
 }

--- a/src/modules/property-panel/indextabs/extensions/extensions.ts
+++ b/src/modules/property-panel/indextabs/extensions/extensions.ts
@@ -7,6 +7,7 @@ import {BasicsSection} from './sections/basics/basics';
 export class Extensions implements IIndextab {
   public title: string = 'Extensions';
   public path: string = '/indextabs/extensions/extensions';
+  public elementInPanel: IShape;
   public canHandleElement: boolean = true;
 
   private basicsSection: ISection = new BasicsSection();

--- a/src/modules/property-panel/indextabs/extensions/sections/basics/basics.ts
+++ b/src/modules/property-panel/indextabs/extensions/sections/basics/basics.ts
@@ -35,7 +35,7 @@ export class BasicsSection implements ISection {
   }
 
   public isSuitableForElement(element: IShape): boolean {
-    if (!element.businessObject) {
+    if (element.businessObject === undefined) {
       return false;
     }
 

--- a/src/modules/property-panel/indextabs/extensions/sections/basics/basics.ts
+++ b/src/modules/property-panel/indextabs/extensions/sections/basics/basics.ts
@@ -34,7 +34,7 @@ export class BasicsSection implements ISection {
     this.init();
   }
 
-  public checkElement(element: IShape): boolean {
+  public isSuitableForElement(element: IShape): boolean {
     if (!element.businessObject) {
       return false;
     }

--- a/src/modules/property-panel/indextabs/extensions/sections/basics/basics.ts
+++ b/src/modules/property-panel/indextabs/extensions/sections/basics/basics.ts
@@ -26,25 +26,12 @@ export class BasicsSection implements ISection {
   private propertyElement: IPropertyElement;
 
   public async activate(model: IPageModel): Promise<void> {
-    this.eventBus = model.modeler.get('eventBus');
+    this.businessObjInPanel = model.elementInPanel.businessObject;
+
     this.moddle = model.modeler.get('moddle');
     this.modeler = model.modeler;
 
-    const selectedEvents: Array<IShape> = this.modeler.get('selection')._selectedElements;
-    if (selectedEvents[0]) {
-      this.businessObjInPanel = selectedEvents[0].businessObject;
-      this.init();
-    }
-
-    this.eventBus.on(['element.click', 'shape.changed'], (event: IEvent) => {
-      if (event.newSelection && event.newSelection.length !== 0) {
-        this.businessObjInPanel = event.newSelection[0].businessObject;
-        this.init();
-      } else if (event.element) {
-        this.businessObjInPanel = event.element.businessObject;
-        this.init();
-      }
-    });
+    this.init();
   }
 
   public checkElement(element: IShape): boolean {

--- a/src/modules/property-panel/indextabs/extensions/sections/basics/basics.ts
+++ b/src/modules/property-panel/indextabs/extensions/sections/basics/basics.ts
@@ -47,6 +47,15 @@ export class BasicsSection implements ISection {
     });
   }
 
+  public checkElement(element: IShape): boolean {
+    if (!element.businessObject) {
+      return false;
+    }
+
+    return (element.businessObject.$type !== 'bpmn:Process') &&
+        (element.businessObject.$type !== 'bpmn:Collaboration');
+  }
+
   private init(): void {
     this.propertyElement = this.getPropertyElement();
     this.selectedElement = this.businessObjInPanel;
@@ -135,10 +144,6 @@ export class BasicsSection implements ISection {
 
   private changeValue(index: number): void {
     this.propertyElement.values[index].value = this.newValues[index];
-  }
-
-  public checkElement(element: IModdleElement): boolean {
-    return (element.$type !== 'bpmn:Process') && (element.$type !== 'bpmn:Collaboration');
   }
 
 }

--- a/src/modules/property-panel/indextabs/extensions/sections/basics/basics.ts
+++ b/src/modules/property-panel/indextabs/extensions/sections/basics/basics.ts
@@ -39,8 +39,10 @@ export class BasicsSection implements ISection {
       return false;
     }
 
-    return (element.businessObject.$type !== 'bpmn:Process') &&
-        (element.businessObject.$type !== 'bpmn:Collaboration');
+    const elementHasExtensions: boolean = (element.businessObject.$type !== 'bpmn:Process') &&
+                                      (element.businessObject.$type !== 'bpmn:Collaboration');
+
+    return elementHasExtensions;
   }
 
   private init(): void {

--- a/src/modules/property-panel/indextabs/forms/forms.html
+++ b/src/modules/property-panel/indextabs/forms/forms.html
@@ -8,7 +8,7 @@
           <compose
             view-model=".${section.path}"
             view=".${section.path}.html"
-            model.bind="{modeler : modeler, elementInPanel : elementInPanel}"
+            model.bind="{modeler: modeler, elementInPanel: elementInPanel}"
             containerless></compose>
         </div>
       </div>

--- a/src/modules/property-panel/indextabs/forms/forms.html
+++ b/src/modules/property-panel/indextabs/forms/forms.html
@@ -8,7 +8,7 @@
           <compose
             view-model=".${section.path}"
             view=".${section.path}.html"
-            model.bind="{modeler : modeler}"
+            model.bind="{modeler : modeler, elementInPanel : elementInPanel}"
             containerless></compose>
         </div>
       </div>

--- a/src/modules/property-panel/indextabs/forms/forms.html
+++ b/src/modules/property-panel/indextabs/forms/forms.html
@@ -3,9 +3,14 @@
   <require from="../../styles/registers.css"></require>
     <div>
       <!-- <h4><span class="register_label_border label label-default">${title}</span></h4> -->
-      <compose repeat.for="section of sections"
-        view-model=".${section.path}"
-        view=".${section.path}.html"
-        model.bind="{modeler : modeler}"></compose>
+      <div repeat.for="section of sections">
+        <div if.bind="section.canHandleElement">
+          <compose
+            view-model=".${section.path}"
+            view=".${section.path}.html"
+            model.bind="{modeler : modeler}"
+            containerless></compose>
+        </div>
+      </div>
     </div>
 </template>

--- a/src/modules/property-panel/indextabs/forms/forms.ts
+++ b/src/modules/property-panel/indextabs/forms/forms.ts
@@ -10,11 +10,12 @@ import {BasicsSection} from './sections/basics/basics';
 export class Forms implements IIndextab {
   public title: string = 'Forms';
   public path: string = '/indextabs/forms/forms';
+  public elementInPanel: IShape;
+  public canHandleElement: boolean = false;
+
   private eventBus: IEventBus;
 
   private basicsSection: ISection = new BasicsSection();
-
-  public canHandleElement: boolean = false;
 
   public sections: Array<ISection> = [
     this.basicsSection,

--- a/src/modules/property-panel/indextabs/forms/forms.ts
+++ b/src/modules/property-panel/indextabs/forms/forms.ts
@@ -20,13 +20,18 @@ export class Forms implements IIndextab {
     this.basicsSection,
   ];
 
-  public checkElement(element: IModdleElement): boolean {
+  public checkElement(element: IShape): boolean {
     if (!element) {
       return false;
     }
 
+    this.sections.forEach((section: ISection) => {
+      section.canHandleElement = section.checkElement(element);
+      console.log(section.canHandleElement);
+    });
+
     return this.sections.some((section: ISection) => {
-      return section.checkElement(element);
+      return section.canHandleElement;
     });
   }
 

--- a/src/modules/property-panel/indextabs/forms/forms.ts
+++ b/src/modules/property-panel/indextabs/forms/forms.ts
@@ -21,13 +21,17 @@ export class Forms implements IIndextab {
     this.basicsSection,
   ];
 
-  public checkElement(element: IShape): boolean {
+  public activate(model: IPageModel): void {
+    this.elementInPanel = model.elementInPanel;
+  }
+
+  public isSuitableForElement(element: IShape): boolean {
     if (!element) {
       return false;
     }
 
     this.sections.forEach((section: ISection) => {
-      section.canHandleElement = section.checkElement(element);
+      section.canHandleElement = section.isSuitableForElement(element);
     });
 
     return this.sections.some((section: ISection) => {

--- a/src/modules/property-panel/indextabs/forms/forms.ts
+++ b/src/modules/property-panel/indextabs/forms/forms.ts
@@ -27,7 +27,6 @@ export class Forms implements IIndextab {
 
     this.sections.forEach((section: ISection) => {
       section.canHandleElement = section.checkElement(element);
-      console.log(section.canHandleElement);
     });
 
     return this.sections.some((section: ISection) => {

--- a/src/modules/property-panel/indextabs/forms/sections/basics/basics.html
+++ b/src/modules/property-panel/indextabs/forms/sections/basics/basics.html
@@ -1,7 +1,7 @@
 <template>
   <require from="./basics.css"></require>
   <require from="../../../../styles/sections.css"></require>
-  <div class="section"  show.bind="canHandleElement">
+  <div class="section">
     <div class="section__content section__border col-md-11">
       <h4><label class="header-label">Forms</label></h4>
       <div class="section__btn-group">

--- a/src/modules/property-panel/indextabs/forms/sections/basics/basics.ts
+++ b/src/modules/property-panel/indextabs/forms/sections/basics/basics.ts
@@ -48,7 +48,6 @@ export class BasicsSection implements ISection {
         this.businessObjInPanel = event.element.businessObject;
       }
       this.init();
-      console.log(this.canHandleElement);
     });
   }
 

--- a/src/modules/property-panel/indextabs/forms/sections/basics/basics.ts
+++ b/src/modules/property-panel/indextabs/forms/sections/basics/basics.ts
@@ -41,7 +41,7 @@ export class BasicsSection implements ISection {
     this.init();
   }
 
-  public checkElement(element: IShape): boolean {
+  public isSuitableForElement(element: IShape): boolean {
     if (!element.businessObject) {
       return false;
     }

--- a/src/modules/property-panel/indextabs/forms/sections/basics/basics.ts
+++ b/src/modules/property-panel/indextabs/forms/sections/basics/basics.ts
@@ -15,7 +15,7 @@ import {IBpmnModdle,
 export class BasicsSection implements ISection {
 
   public path: string = '/sections/basics/basics';
-  public canHandleElement: boolean = false;
+  public canHandleElement: boolean = true;
   private isFormSelected: boolean = false;
 
   private businessObjInPanel: IFormElement;
@@ -48,12 +48,20 @@ export class BasicsSection implements ISection {
         this.businessObjInPanel = event.element.businessObject;
       }
       this.init();
+      console.log(this.canHandleElement);
     });
+  }
+
+  public checkElement(element: IShape): boolean {
+    if (!element.businessObject) {
+      return false;
+    }
+
+    return element.businessObject.$type === 'bpmn:UserTask';
   }
 
   private init(): void {
     this.isFormSelected = false;
-    this.canHandleElement = this.checkElement(this.businessObjInPanel);
     if (this.canHandleElement) {
       this.formElement = this.getFormElement();
       this.reloadForms();
@@ -87,14 +95,6 @@ export class BasicsSection implements ISection {
       if (form.$type === `camunda:FormField`) {
         this.forms.push(form);
       }
-    }
-  }
-
-  public checkElement(element: IModdleElement): boolean {
-    if (element.$type === 'bpmn:UserTask') {
-      return true;
-    } else {
-      return false;
     }
   }
 

--- a/src/modules/property-panel/indextabs/forms/sections/basics/basics.ts
+++ b/src/modules/property-panel/indextabs/forms/sections/basics/basics.ts
@@ -19,7 +19,6 @@ export class BasicsSection implements ISection {
   private isFormSelected: boolean = false;
 
   private businessObjInPanel: IFormElement;
-  private eventBus: IEventBus;
   private moddle: IBpmnModdle;
   private modeler: IBpmnModeler;
 
@@ -34,21 +33,12 @@ export class BasicsSection implements ISection {
   private activeListElementId: string;
 
   public async activate(model: IPageModel): Promise<void> {
-    this.eventBus = model.modeler.get('eventBus');
+    this.businessObjInPanel = model.elementInPanel.businessObject;
+
     this.moddle = model.modeler.get('moddle');
     this.modeler = model.modeler;
-    const selectedEvents: Array<IShape> = this.modeler.get('selection')._selectedElements;
-    if (selectedEvents[0]) {
-      this.businessObjInPanel = selectedEvents[0].businessObject;
-      this.init();
-    }
 
-    this.eventBus.on(['element.click', 'shape.changed', 'selection.changed'], (event: IEvent) => {
-      if (event.element) {
-        this.businessObjInPanel = event.element.businessObject;
-      }
-      this.init();
-    });
+    this.init();
   }
 
   public checkElement(element: IShape): boolean {

--- a/src/modules/property-panel/indextabs/general/general.html
+++ b/src/modules/property-panel/indextabs/general/general.html
@@ -7,7 +7,7 @@
           <compose
             view-model=".${section.path}"
             view=".${section.path}.html"
-            model.bind="{modeler : modeler, elementInPanel : elementInPanel}"
+            model.bind="{modeler: modeler, elementInPanel: elementInPanel}"
             containerless></compose>
         </div>
       </div>

--- a/src/modules/property-panel/indextabs/general/general.html
+++ b/src/modules/property-panel/indextabs/general/general.html
@@ -3,7 +3,7 @@
   <require from="../../styles/registers.css"></require>
       <!-- <h4><span class="register_label_border label label-default">${title}</span></h4> -->
       <div repeat.for="section of sections">
-        <div if.bind="section.checkElement(elementInPanel)">
+        <div if.bind="section.isSuitableForElement(elementInPanel)">
           <compose
             view-model=".${section.path}"
             view=".${section.path}.html"

--- a/src/modules/property-panel/indextabs/general/general.html
+++ b/src/modules/property-panel/indextabs/general/general.html
@@ -1,15 +1,15 @@
 <template>
   <require from="./general.css"></require>
   <require from="../../styles/registers.css"></require>
-    <div show.bind="canHandleElement"></div>
       <!-- <h4><span class="register_label_border label label-default">${title}</span></h4> -->
       <div repeat.for="section of sections">
-        <div if.bind="section.canHandleElement">
-        <compose
-          view-model=".${section.path}"
-          view=".${section.path}.html"
-          model.bind="{modeler : modeler}"
-          containerless></compose>
+        <div>
+          <compose
+            view-model=".${section.path}"
+            view=".${section.path}.html"
+            model.bind="{modeler : modeler}"
+            if.bind="section.canHandleElement"
+            containerless></compose>
         </div>
       </div>
     </div>

--- a/src/modules/property-panel/indextabs/general/general.html
+++ b/src/modules/property-panel/indextabs/general/general.html
@@ -7,7 +7,7 @@
           <compose
             view-model=".${section.path}"
             view=".${section.path}.html"
-            model.bind="{modeler : modeler}"
+            model.bind="{modeler : modeler, elementInPanel : elementInPanel}"
             if.bind="section.canHandleElement"
             containerless></compose>
         </div>

--- a/src/modules/property-panel/indextabs/general/general.html
+++ b/src/modules/property-panel/indextabs/general/general.html
@@ -3,12 +3,11 @@
   <require from="../../styles/registers.css"></require>
       <!-- <h4><span class="register_label_border label label-default">${title}</span></h4> -->
       <div repeat.for="section of sections">
-        <div>
+        <div if.bind="section.checkElement(elementInPanel)">
           <compose
             view-model=".${section.path}"
             view=".${section.path}.html"
             model.bind="{modeler : modeler, elementInPanel : elementInPanel}"
-            if.bind="section.canHandleElement"
             containerless></compose>
         </div>
       </div>

--- a/src/modules/property-panel/indextabs/general/general.ts
+++ b/src/modules/property-panel/indextabs/general/general.ts
@@ -61,13 +61,6 @@ export class General implements IIndextab {
 
     this.eventBus = model.modeler.get('eventBus');
     this.eventBus.on(['element.click', 'shape.changed', 'selection.changed'], (event: IEvent) => {
-      if (event.type === 'element.click') {
-        this.elementInPanel = event.element;
-      }
-      if (event.type === 'shape.changed' && event.element.type !== 'label') {
-        this.elementInPanel = event.element;
-      }
-
       this.sections.forEach((section: ISection) => {
         section.canHandleElement = section.checkElement(this.elementInPanel);
       });

--- a/src/modules/property-panel/indextabs/general/general.ts
+++ b/src/modules/property-panel/indextabs/general/general.ts
@@ -18,9 +18,9 @@ import {SignalEventSection} from './sections/signal-event/signal-event';
 export class General implements IIndextab {
   public title: string = 'General';
   public path: string = '/indextabs/general/general';
+  public elementInPanel: IShape;
 
   private eventBus: IEventBus;
-  private elementInPanel: IShape;
 
   public basicsSection: ISection = new BasicsSection();
   public poolSection: ISection = new PoolSection();
@@ -57,6 +57,8 @@ export class General implements IIndextab {
   }
 
   public activate(model: IPageModel): void {
+    this.elementInPanel = model.elementInPanel;
+
     this.eventBus = model.modeler.get('eventBus');
 
     this.eventBus.on(['element.click', 'shape.changed'], (event: IEvent) => {

--- a/src/modules/property-panel/indextabs/general/general.ts
+++ b/src/modules/property-panel/indextabs/general/general.ts
@@ -46,9 +46,9 @@ export class General implements IIndextab {
 
   public canHandleElement: boolean = true;
 
-  public checkElement(element: IShape): boolean {
+  public isSuitableForElement(element: IShape): boolean {
     this.sections.forEach((section: ISection) => {
-      section.canHandleElement = section.checkElement(element);
+      section.canHandleElement = section.isSuitableForElement(element);
     });
 
     return this.sections.some((section: ISection) => {

--- a/src/modules/property-panel/indextabs/general/general.ts
+++ b/src/modules/property-panel/indextabs/general/general.ts
@@ -20,7 +20,7 @@ export class General implements IIndextab {
   public path: string = '/indextabs/general/general';
 
   private eventBus: IEventBus;
-  private elementInPanel: IModdleElement;
+  private elementInPanel: IShape;
 
   public basicsSection: ISection = new BasicsSection();
   public poolSection: ISection = new PoolSection();
@@ -46,18 +46,25 @@ export class General implements IIndextab {
 
   public canHandleElement: boolean = true;
 
-  public checkElement(element: IModdleElement): boolean {
-    return true;
+  public checkElement(element: IShape): boolean {
+    this.sections.forEach((section: ISection) => {
+      section.canHandleElement = section.checkElement(element);
+    });
+
+    return this.sections.some((section: ISection) => {
+      return section.canHandleElement;
+    });
   }
+
   public activate(model: IPageModel): void {
     this.eventBus = model.modeler.get('eventBus');
 
     this.eventBus.on(['element.click', 'shape.changed'], (event: IEvent) => {
       if (event.type === 'element.click') {
-        this.elementInPanel = event.element.businessObject;
+        this.elementInPanel = event.element;
       }
       if (event.type === 'shape.changed' && event.element.type !== 'label') {
-        this.elementInPanel = event.element.businessObject;
+        this.elementInPanel = event.element;
       }
       if (this.elementInPanel) {
         this.sections.forEach((section: ISection) => {

--- a/src/modules/property-panel/indextabs/general/general.ts
+++ b/src/modules/property-panel/indextabs/general/general.ts
@@ -58,14 +58,6 @@ export class General implements IIndextab {
 
   public activate(model: IPageModel): void {
     this.elementInPanel = model.elementInPanel;
-
-    this.eventBus = model.modeler.get('eventBus');
-    this.eventBus.on(['element.click', 'shape.changed', 'selection.changed'], (event: IEvent) => {
-      this.sections.forEach((section: ISection) => {
-        section.canHandleElement = section.checkElement(this.elementInPanel);
-      });
-
-    });
   }
 
 }

--- a/src/modules/property-panel/indextabs/general/general.ts
+++ b/src/modules/property-panel/indextabs/general/general.ts
@@ -60,19 +60,18 @@ export class General implements IIndextab {
     this.elementInPanel = model.elementInPanel;
 
     this.eventBus = model.modeler.get('eventBus');
-
-    this.eventBus.on(['element.click', 'shape.changed'], (event: IEvent) => {
+    this.eventBus.on(['element.click', 'shape.changed', 'selection.changed'], (event: IEvent) => {
       if (event.type === 'element.click') {
         this.elementInPanel = event.element;
       }
       if (event.type === 'shape.changed' && event.element.type !== 'label') {
         this.elementInPanel = event.element;
       }
-      if (this.elementInPanel) {
-        this.sections.forEach((section: ISection) => {
-          section.canHandleElement = section.checkElement(this.elementInPanel);
-        });
-      }
+
+      this.sections.forEach((section: ISection) => {
+        section.canHandleElement = section.checkElement(this.elementInPanel);
+      });
+
     });
   }
 

--- a/src/modules/property-panel/indextabs/general/sections/basics/basics.ts
+++ b/src/modules/property-panel/indextabs/general/sections/basics/basics.ts
@@ -80,6 +80,10 @@ export class BasicsSection implements ISection {
 
   }
 
+  public checkElement(element: IShape): boolean {
+    return true;
+  }
+
   private init(): void {
     if (!this.businessObjInPanel) {
       return;
@@ -97,10 +101,6 @@ export class BasicsSection implements ISection {
       xml = diagrammXML;
     });
     return xml;
-  }
-
-  public checkElement(element: IModdleElement): boolean {
-    return true;
   }
 
   private updateDocumentation(): void {

--- a/src/modules/property-panel/indextabs/general/sections/basics/basics.ts
+++ b/src/modules/property-panel/indextabs/general/sections/basics/basics.ts
@@ -34,7 +34,8 @@ export class BasicsSection implements ISection {
   }
 
   public activate(model: IPageModel): void {
-    this.eventBus = model.modeler.get('eventBus');
+    this.elementInPanel = model.elementInPanel;
+    this.businessObjInPanel = model.elementInPanel.businessObject;
     this.modeling = model.modeler.get('modeling');
     this.moddle = model.modeler.get('moddle');
     this.modeler = model.modeler;
@@ -43,44 +44,17 @@ export class BasicsSection implements ISection {
       this.validateForm(event);
     });
 
-    const selectedEvents: Array<IShape> = this.modeler.get('selection')._selectedElements;
-    if (selectedEvents[0]) {
-      this.businessObjInPanel = selectedEvents[0].businessObject;
-      this.elementInPanel = selectedEvents[0];
-      this.init();
-    }
+    this.init();
 
-    this.eventBus.on(['element.click', 'shape.changed', 'selection.changed'], (event: IEvent) => {
-      if (this.validationError) {
-        this.businessObjInPanel.id = this.elementInPanel.id;
-        this.validationController.validate();
-      }
-
-      if (event.type === 'selection.changed' && event.newSelection.length !== 0) {
-        this.elementInPanel = event.newSelection[0];
-        this.businessObjInPanel = this.elementInPanel.businessObject;
-      }
-      if (event.type === 'shape.changed' &&
-          event.element.id === this.elementInPanel.id) {
-
-          this.elementInPanel = event.element;
-          this.businessObjInPanel = event.element.businessObject;
-      }
-      if (event.type === 'element.click' && event.element) {
-        this.elementInPanel = event.element;
-        this.businessObjInPanel = event.element.businessObject;
-      }
-
-      this.init();
-
-      ValidationRules.ensure((businessObject: IModdleElement) => businessObject.id).required()
+    ValidationRules.ensure((businessObject: IModdleElement) => businessObject.id).required()
       .withMessage(`Id cannot be blank.`)
       .on(this.businessObjInPanel || {});
-    });
-
   }
 
   public checkElement(element: IShape): boolean {
+    if (!element) {
+      return false;
+    }
     return true;
   }
 

--- a/src/modules/property-panel/indextabs/general/sections/basics/basics.ts
+++ b/src/modules/property-panel/indextabs/general/sections/basics/basics.ts
@@ -51,8 +51,8 @@ export class BasicsSection implements ISection {
       .on(this.businessObjInPanel || {});
   }
 
-  public checkElement(element: IShape): boolean {
-    if (!element) {
+  public isSuitableForElement(element: IShape): boolean {
+    if (element === undefined || element === null) {
       return false;
     }
     return true;

--- a/src/modules/property-panel/indextabs/general/sections/call-activity/call-activity.html
+++ b/src/modules/property-panel/indextabs/general/sections/call-activity/call-activity.html
@@ -1,7 +1,7 @@
 <template>
   <require from="./call-activity.css"></require>
   <require from="../../../../styles/sections.css"></require>
-  <div class="section" show.bind="canHandleElement">
+  <div class="section">
     <div class="section__content section__border col-md-11">
       <label><em>Call Activity</em></label><br>
       <div class="section__btn-group">

--- a/src/modules/property-panel/indextabs/general/sections/call-activity/call-activity.ts
+++ b/src/modules/property-panel/indextabs/general/sections/call-activity/call-activity.ts
@@ -20,14 +20,12 @@ export class CallActivitySection implements ISection {
     this.modeler = model.modeler;
   }
 
-  public checkElement(element: IShape): boolean {
-    if (element &&
-        element.businessObject &&
-        element.businessObject.$type === 'bpmn:CallActivity') {
-          return true;
-        } else {
-          return false;
-        }
+  public isSuitableForElement(element: IShape): boolean {
+    const elementIsCallActivity: boolean = element !== undefined
+                                        && element.businessObject !== undefined
+                                        && element.businessObject.$type === 'bpmn:CallActivity';
+
+    return elementIsCallActivity;
   }
 
   private clearCalledElement(): void {

--- a/src/modules/property-panel/indextabs/general/sections/call-activity/call-activity.ts
+++ b/src/modules/property-panel/indextabs/general/sections/call-activity/call-activity.ts
@@ -23,30 +23,27 @@ export class CallActivitySection implements ISection {
     const selectedEvents: Array<IShape> = this.modeler.get('selection')._selectedElements;
     if (selectedEvents[0]) {
       this.businessObjInPanel = selectedEvents[0].businessObject;
-      this.init();
     }
 
     this.eventBus.on(['element.click', 'shape.changed', 'selection.changed'], (event: IEvent) => {
+
       if (event.newSelection && event.newSelection.length !== 0) {
         this.businessObjInPanel = event.newSelection[0].businessObject;
       } else if (event.element) {
         this.businessObjInPanel = event.element.businessObject;
       }
-      this.init();
     });
+
   }
 
-  private init(): void {
-    this.canHandleElement = this.checkElement(this.businessObjInPanel);
-  }
-
-  public checkElement(element: IModdleElement): boolean {
+  public checkElement(element: IShape): boolean {
     if (element &&
-        element.$type === 'bpmn:CallActivity') {
-      return true;
-    } else {
-      return false;
-    }
+        element.businessObject &&
+        element.businessObject.$type === 'bpmn:CallActivity') {
+          return true;
+        } else {
+          return false;
+        }
   }
 
   private clearCalledElement(): void {

--- a/src/modules/property-panel/indextabs/general/sections/call-activity/call-activity.ts
+++ b/src/modules/property-panel/indextabs/general/sections/call-activity/call-activity.ts
@@ -13,27 +13,11 @@ export class CallActivitySection implements ISection {
   public canHandleElement: boolean = false;
 
   private businessObjInPanel: ICallActivityElement;
-  private eventBus: IEventBus;
   private modeler: IBpmnModeler;
 
   public async activate(model: IPageModel): Promise<void> {
-    this.eventBus = model.modeler.get('eventBus');
+    this.businessObjInPanel = model.elementInPanel.businessObject;
     this.modeler = model.modeler;
-
-    const selectedEvents: Array<IShape> = this.modeler.get('selection')._selectedElements;
-    if (selectedEvents[0]) {
-      this.businessObjInPanel = selectedEvents[0].businessObject;
-    }
-
-    this.eventBus.on(['element.click', 'shape.changed', 'selection.changed'], (event: IEvent) => {
-
-      if (event.newSelection && event.newSelection.length !== 0) {
-        this.businessObjInPanel = event.newSelection[0].businessObject;
-      } else if (event.element) {
-        this.businessObjInPanel = event.element.businessObject;
-      }
-    });
-
   }
 
   public checkElement(element: IShape): boolean {

--- a/src/modules/property-panel/indextabs/general/sections/error-event/error-event.html
+++ b/src/modules/property-panel/indextabs/general/sections/error-event/error-event.html
@@ -1,7 +1,7 @@
 <template>
   <require from="./error-event.css"></require>
   <require from="../../../../styles/sections.css"></require>
-  <div class="section" show.bind="canHandleElement">
+  <div class="section">
     <div class="section__content section__border col-md-11">
       <label class="section__input-label">Error: </label>
       <select class="form-control" value.bind="selectedId" change.delegate="updateError()">
@@ -30,7 +30,7 @@
       </div>
     </div>
     <div class="section__special col-md-1">
-      <button class="addErrorButton btn btn-xs btn-primary" click.delegate="addError()">+</button>      
+      <button class="addErrorButton btn btn-xs btn-primary" click.delegate="addError()">+</button>
     </div>
   </div>
 </template>

--- a/src/modules/property-panel/indextabs/general/sections/error-event/error-event.ts
+++ b/src/modules/property-panel/indextabs/general/sections/error-event/error-event.ts
@@ -46,20 +46,25 @@ export class ErrorEventSection implements ISection {
     this.init();
   }
 
-  public checkElement(element: IShape): boolean {
-    if (element &&
-        element.businessObject &&
-        element.businessObject.eventDefinitions &&
-        element.businessObject.eventDefinitions[0].$type === 'bpmn:ErrorEventDefinition') {
-          if (element.businessObject.$type === 'bpmn:EndEvent') {
-            this.isEndEvent = true;
-          } else if (element.businessObject.$type === 'bpmn:BoundaryEvent') {
-            this.isEndEvent = false;
-          }
-          return true;
-    } else {
-      return false;
+  public isSuitableForElement(element: IShape): boolean {
+    if (this.elementIsErrorEvent(element)) {
+      this.isEndEvent = this.elementIsEndEvent(element);
+      return true;
     }
+    return false;
+  }
+
+  private elementIsErrorEvent(element: IShape): boolean {
+    return element !== undefined
+        && element.businessObject !== undefined
+        && element.businessObject.eventDefinitions !== undefined
+        && element.businessObject.eventDefinitions[0].$type === 'bpmn:ErrorEventDefinition';
+  }
+
+  private elementIsEndEvent(element: IShape): boolean {
+    return element !== undefined
+        && element.businessObject !== undefined
+        && element.businessObject.$type === 'bpmn:EndEvent';
   }
 
   private init(): void {

--- a/src/modules/property-panel/indextabs/general/sections/error-event/error-event.ts
+++ b/src/modules/property-panel/indextabs/general/sections/error-event/error-event.ts
@@ -21,7 +21,6 @@ export class ErrorEventSection implements ISection {
   public canHandleElement: boolean = false;
 
   private businessObjInPanel: IErrorElement;
-  private eventBus: IEventBus;
   private moddle: IBpmnModdle;
   private modeler: IBpmnModeler;
   private generalService: GeneralService;
@@ -38,25 +37,13 @@ export class ErrorEventSection implements ISection {
   }
 
   public async activate(model: IPageModel): Promise<void> {
-    this.eventBus = model.modeler.get('eventBus');
+    this.businessObjInPanel = model.elementInPanel.businessObject;
+
     this.moddle = model.modeler.get('moddle');
     this.modeler = model.modeler;
     this.errors = await this.getErrors();
 
-    const selectedEvents: Array<IShape> = this.modeler.get('selection')._selectedElements;
-    if (selectedEvents[0]) {
-      this.businessObjInPanel = selectedEvents[0].businessObject;
-      this.init();
-    }
-
-    this.eventBus.on(['element.click', 'shape.changed', 'selection.changed'], (event: IEvent) => {
-      if (event.newSelection && event.newSelection.length !== 0) {
-        this.businessObjInPanel = event.newSelection[0].businessObject;
-      } else if (event.element) {
-        this.businessObjInPanel = event.element.businessObject;
-      }
-      this.init();
-    });
+    this.init();
   }
 
   public checkElement(element: IShape): boolean {

--- a/src/modules/property-panel/indextabs/general/sections/error-event/error-event.ts
+++ b/src/modules/property-panel/indextabs/general/sections/error-event/error-event.ts
@@ -55,9 +55,24 @@ export class ErrorEventSection implements ISection {
       } else if (event.element) {
         this.businessObjInPanel = event.element.businessObject;
       }
-
       this.init();
     });
+  }
+
+  public checkElement(element: IShape): boolean {
+    if (element &&
+        element.businessObject &&
+        element.businessObject.eventDefinitions &&
+        element.businessObject.eventDefinitions[0].$type === 'bpmn:ErrorEventDefinition') {
+          if (element.businessObject.$type === 'bpmn:EndEvent') {
+            this.isEndEvent = true;
+          } else if (element.businessObject.$type === 'bpmn:BoundaryEvent') {
+            this.isEndEvent = false;
+          }
+          return true;
+    } else {
+      return false;
+    }
   }
 
   private init(): void {
@@ -71,21 +86,6 @@ export class ErrorEventSection implements ISection {
           this.selectedError = null;
           this.selectedId = null;
         }
-    }
-    this.canHandleElement = this.checkElement(this.businessObjInPanel);
-  }
-
-  public checkElement(element: IModdleElement): boolean {
-    if (element.eventDefinitions &&
-        element.eventDefinitions[0].$type === 'bpmn:ErrorEventDefinition') {
-          if (element.$type === 'bpmn:EndEvent') {
-            this.isEndEvent = true;
-          } else if (element.$type === 'bpmn:BoundaryEvent') {
-            this.isEndEvent = false;
-          }
-          return true;
-    } else {
-      return false;
     }
   }
 

--- a/src/modules/property-panel/indextabs/general/sections/escalation-event/escalation-event.html
+++ b/src/modules/property-panel/indextabs/general/sections/escalation-event/escalation-event.html
@@ -1,7 +1,7 @@
 <template>
   <require from="./escalation-event.css"></require>
   <require from="../../../../styles/sections.css"></require>
-  <div class="section" show.bind="canHandleElement">
+  <div class="section">
     <div class="section__content section__border col-md-11">
       <label class="section__input-label">Escalation: </label>
       <select class="form-control" value.bind="selectedId" change.delegate="updateEscalation()">
@@ -30,7 +30,7 @@
       </div>
     </div>
     <div class="section__special col-md-1">
-      <button class="addEscalationButton btn btn-xs btn-primary" click.delegate="addEscalation()">+</button>      
+      <button class="addEscalationButton btn btn-xs btn-primary" click.delegate="addEscalation()">+</button>
     </div>
   </div>
 </template>

--- a/src/modules/property-panel/indextabs/general/sections/escalation-event/escalation-event.ts
+++ b/src/modules/property-panel/indextabs/general/sections/escalation-event/escalation-event.ts
@@ -59,6 +59,22 @@ export class EscalationEventSection implements ISection {
     });
   }
 
+  public checkElement(element: IShape): boolean {
+    if (element &&
+        element.businessObject &&
+        element.businessObject.eventDefinitions &&
+        element.businessObject.eventDefinitions[0].$type === 'bpmn:EscalationEventDefinition') {
+        if (element.businessObject.$type === 'bpmn:EndEvent') {
+          this.isBoundaryEvent = false;
+        } else if (element.businessObject.$type === 'bpmn:BoundaryEvent') {
+          this.isBoundaryEvent = true;
+        }
+        return true;
+    } else {
+      return false;
+    }
+  }
+
   private init(): void {
     if (this.businessObjInPanel.eventDefinitions
       && this.businessObjInPanel.eventDefinitions[0].$type === 'bpmn:EscalationEventDefinition') {
@@ -74,20 +90,6 @@ export class EscalationEventSection implements ISection {
       }
     }
     this.canHandleElement = this.checkElement(this.businessObjInPanel);
-  }
-
-  public checkElement(element: IModdleElement): boolean {
-    if (element.eventDefinitions
-      && element.eventDefinitions[0].$type === 'bpmn:EscalationEventDefinition') {
-        if (element.$type === 'bpmn:EndEvent') {
-          this.isBoundaryEvent = false;
-        } else if (element.$type === 'bpmn:BoundaryEvent') {
-          this.isBoundaryEvent = true;
-        }
-        return true;
-    } else {
-      return false;
-    }
   }
 
   private getXML(): string {

--- a/src/modules/property-panel/indextabs/general/sections/escalation-event/escalation-event.ts
+++ b/src/modules/property-panel/indextabs/general/sections/escalation-event/escalation-event.ts
@@ -21,7 +21,6 @@ export class EscalationEventSection implements ISection {
   public canHandleElement: boolean = false;
 
   private businessObjInPanel: IEscalationElement;
-  private eventBus: IEventBus;
   private moddle: IBpmnModdle;
   private modeler: IBpmnModeler;
   private generalService: GeneralService;
@@ -38,25 +37,13 @@ export class EscalationEventSection implements ISection {
   }
 
   public async activate(model: IPageModel): Promise<void> {
-    this.eventBus = model.modeler.get('eventBus');
+    this.businessObjInPanel = model.elementInPanel.businessObject;
+
     this.moddle = model.modeler.get('moddle');
     this.modeler = model.modeler;
     this.escalations = await this.getEscalations();
 
-    const selectedEvents: Array<IShape> = this.modeler.get('selection')._selectedElements;
-    if (selectedEvents[0]) {
-      this.businessObjInPanel = selectedEvents[0].businessObject;
-      this.init();
-    }
-
-    this.eventBus.on(['element.click', 'shape.changed', 'selection.changed'], (event: IEvent) => {
-      if (event.newSelection && event.newSelection.length !== 0) {
-        this.businessObjInPanel = event.newSelection[0].businessObject;
-      } else if (event.element) {
-        this.businessObjInPanel = event.element.businessObject;
-      }
-      this.init();
-    });
+    this.init();
   }
 
   public checkElement(element: IShape): boolean {

--- a/src/modules/property-panel/indextabs/general/sections/escalation-event/escalation-event.ts
+++ b/src/modules/property-panel/indextabs/general/sections/escalation-event/escalation-event.ts
@@ -46,20 +46,26 @@ export class EscalationEventSection implements ISection {
     this.init();
   }
 
-  public checkElement(element: IShape): boolean {
-    if (element &&
-        element.businessObject &&
-        element.businessObject.eventDefinitions &&
-        element.businessObject.eventDefinitions[0].$type === 'bpmn:EscalationEventDefinition') {
-        if (element.businessObject.$type === 'bpmn:EndEvent') {
-          this.isBoundaryEvent = false;
-        } else if (element.businessObject.$type === 'bpmn:BoundaryEvent') {
-          this.isBoundaryEvent = true;
-        }
-        return true;
-    } else {
-      return false;
+  public isSuitableForElement(element: IShape): boolean {
+
+    if (this.elementIsEscalationEvent(element)) {
+      this.isBoundaryEvent = this.elementIsBoundaryEvent(element);
+      return true;
     }
+    return false;
+  }
+
+  private elementIsEscalationEvent(element: IShape): boolean {
+    return element !== undefined
+        && element.businessObject !== undefined
+        && element.businessObject.eventDefinitions !== undefined
+        && element.businessObject.eventDefinitions[0].$type === 'bpmn:EscalationEventDefinition';
+  }
+
+  private elementIsBoundaryEvent(element: IShape): boolean {
+    return element !== undefined
+        && element.businessObject !== undefined
+        && element.businessObject.$type === 'bpmn:BoundaryEvent';
   }
 
   private init(): void {

--- a/src/modules/property-panel/indextabs/general/sections/escalation-event/escalation-event.ts
+++ b/src/modules/property-panel/indextabs/general/sections/escalation-event/escalation-event.ts
@@ -89,7 +89,6 @@ export class EscalationEventSection implements ISection {
         this.selectedId = null;
       }
     }
-    this.canHandleElement = this.checkElement(this.businessObjInPanel);
   }
 
   private getXML(): string {

--- a/src/modules/property-panel/indextabs/general/sections/flow/flow.html
+++ b/src/modules/property-panel/indextabs/general/sections/flow/flow.html
@@ -1,12 +1,12 @@
 <template>
   <require from="./flow.css"></require>
   <require from="../../../../styles/sections.css"></require>
-  <div class="section" show.bind="canHandleElement">
+  <div class="section">
     <div class="section__content section__border col-md-11">
       <div class="section__btn-group">
         <label class="section__input-label">Condition: </label>
         <input type="text" class="form-control" value.bind="condition">
-        <span class="glyphicon glyphicon-remove-circle section__btn-group--clear-btn" click.delegate="clearCondition()"></span>    
+        <span class="glyphicon glyphicon-remove-circle section__btn-group--clear-btn" click.delegate="clearCondition()"></span>
       </div>
     </div>
     <div class="section__special col-md-1">

--- a/src/modules/property-panel/indextabs/general/sections/flow/flow.ts
+++ b/src/modules/property-panel/indextabs/general/sections/flow/flow.ts
@@ -45,23 +45,25 @@ export class FlowSection implements ISection {
     });
   }
 
+  public checkElement(elementShape: IShape): boolean {
+    if (elementShape) {
+      const element: IFlowElement = elementShape.businessObject;
+      if (element &&
+          element.$type === 'bpmn:SequenceFlow' &&
+          (element.targetRef.$type === 'bpmn:ExclusiveGateway' ||
+          element.sourceRef.$type === 'bpmn:ExclusiveGateway')) {
+        return true;
+    } else {
+      return false;
+    }
+  }
+
   private init(): void {
     if (this.businessObjInPanel.conditionExpression) {
       this.condition = this.businessObjInPanel.conditionExpression.body;
     }
 
     this.canHandleElement = this.checkElement(this.businessObjInPanel);
-  }
-
-  public checkElement(element: IFlowElement): boolean {
-    if (element &&
-        element.$type === 'bpmn:SequenceFlow' &&
-        (element.targetRef.$type === 'bpmn:ExclusiveGateway' ||
-         element.sourceRef.$type === 'bpmn:ExclusiveGateway')) {
-      return true;
-    } else {
-      return false;
-    }
   }
 
   private conditionChanged(newValue: string, oldValue: string): void {

--- a/src/modules/property-panel/indextabs/general/sections/flow/flow.ts
+++ b/src/modules/property-panel/indextabs/general/sections/flow/flow.ts
@@ -46,15 +46,16 @@ export class FlowSection implements ISection {
   }
 
   public checkElement(elementShape: IShape): boolean {
-    if (elementShape) {
-      const element: IFlowElement = elementShape.businessObject;
-      if (element &&
-          element.$type === 'bpmn:SequenceFlow' &&
-          (element.targetRef.$type === 'bpmn:ExclusiveGateway' ||
-          element.sourceRef.$type === 'bpmn:ExclusiveGateway')) {
-        return true;
-    } else {
-      return false;
+      if (elementShape) {
+        const element: IFlowElement = elementShape.businessObject;
+        if (element &&
+            element.$type === 'bpmn:SequenceFlow' &&
+            (element.targetRef.$type === 'bpmn:ExclusiveGateway' ||
+            element.sourceRef.$type === 'bpmn:ExclusiveGateway')) {
+          return true;
+      } else {
+        return false;
+      }
     }
   }
 
@@ -62,8 +63,6 @@ export class FlowSection implements ISection {
     if (this.businessObjInPanel.conditionExpression) {
       this.condition = this.businessObjInPanel.conditionExpression.body;
     }
-
-    this.canHandleElement = this.checkElement(this.businessObjInPanel);
   }
 
   private conditionChanged(newValue: string, oldValue: string): void {

--- a/src/modules/property-panel/indextabs/general/sections/flow/flow.ts
+++ b/src/modules/property-panel/indextabs/general/sections/flow/flow.ts
@@ -29,19 +29,25 @@ export class FlowSection implements ISection {
     this.modeler = model.modeler;
   }
 
-  public checkElement(elementShape: IShape): boolean {
-    if (elementShape) {
+  public isSuitableForElement(elementShape: IShape): boolean {
+    if (elementShape !== undefined && elementShape !== null) {
       const element: IFlowElement = elementShape.businessObject;
-      if (element &&
-          element.$type === 'bpmn:SequenceFlow' &&
-          (element.targetRef.$type === 'bpmn:ExclusiveGateway' ||
-          element.sourceRef.$type === 'bpmn:ExclusiveGateway')) {
-        return true;
-      } else {
+      if (!this.elementIsFlow(element)) {
         return false;
       }
+      const flowPointsAtExclusiveGateway: boolean = element.targetRef.$type === 'bpmn:ExclusiveGateway';
+      const flowStartsAtExclusiveGateway: boolean = element.sourceRef.$type === 'bpmn:ExclusiveGateway';
+
+      const flowHasCondition: boolean = flowPointsAtExclusiveGateway || flowStartsAtExclusiveGateway;
+
+      return flowHasCondition;
     }
-    return false;
+  }
+
+  private elementIsFlow(element: IFlowElement): boolean {
+    return element !== undefined
+          && element !== null
+          && element.$type === 'bpmn:SequenceFlow';
   }
 
   private init(): void {

--- a/src/modules/property-panel/indextabs/general/sections/flow/flow.ts
+++ b/src/modules/property-panel/indextabs/general/sections/flow/flow.ts
@@ -30,17 +30,18 @@ export class FlowSection implements ISection {
   }
 
   public checkElement(elementShape: IShape): boolean {
-      if (elementShape) {
-        const element: IFlowElement = elementShape.businessObject;
-        if (element &&
-            element.$type === 'bpmn:SequenceFlow' &&
-            (element.targetRef.$type === 'bpmn:ExclusiveGateway' ||
-            element.sourceRef.$type === 'bpmn:ExclusiveGateway')) {
-          return true;
+    if (elementShape) {
+      const element: IFlowElement = elementShape.businessObject;
+      if (element &&
+          element.$type === 'bpmn:SequenceFlow' &&
+          (element.targetRef.$type === 'bpmn:ExclusiveGateway' ||
+          element.sourceRef.$type === 'bpmn:ExclusiveGateway')) {
+        return true;
       } else {
         return false;
       }
     }
+    return false;
   }
 
   private init(): void {

--- a/src/modules/property-panel/indextabs/general/sections/flow/flow.ts
+++ b/src/modules/property-panel/indextabs/general/sections/flow/flow.ts
@@ -17,32 +17,16 @@ export class FlowSection implements ISection {
   public canHandleElement: boolean = false;
 
   private businessObjInPanel: IFlowElement;
-  private eventBus: IEventBus;
   private modeler: IBpmnModeler;
   private moddle: IBpmnModdle;
 
   @observable private condition: string;
 
   public activate(model: IPageModel): void {
-    this.eventBus = model.modeler.get('eventBus');
+    this.businessObjInPanel = model.elementInPanel.businessObject;
+
     this.moddle = model.modeler.get('moddle');
     this.modeler = model.modeler;
-
-    const selectedEvents: Array<IShape> = this.modeler.get('selection')._selectedElements;
-    if (selectedEvents[0]) {
-      this.businessObjInPanel = selectedEvents[0].businessObject;
-      this.init();
-    }
-
-    this.eventBus.on(['element.click', 'shape.changed', 'selection.changed'], (event: IEvent) => {
-      if (event.newSelection && event.newSelection.length !== 0) {
-        this.businessObjInPanel = event.newSelection[0].businessObject;
-        this.init();
-      } else if (event.element) {
-        this.businessObjInPanel = event.element.businessObject;
-        this.init();
-      }
-    });
   }
 
   public checkElement(elementShape: IShape): boolean {

--- a/src/modules/property-panel/indextabs/general/sections/message-event/message-event.html
+++ b/src/modules/property-panel/indextabs/general/sections/message-event/message-event.html
@@ -1,7 +1,7 @@
 <template>
   <require from="./message-event.css"></require>
   <require from="../../../../styles/sections.css"></require>
-  <div class="section" show.bind="canHandleElement">
+  <div class="section">
     <div class="section__content section__border col-md-11">
       <label class="section__input-label">Message: </label>
       <select ref="msgDropdown" class="form-control" value.bind="selectedId" change.delegate="updateMessage()">
@@ -13,7 +13,7 @@
         <div class="section__btn-group">
           <label class="section__input-labell">Message Name: </label>
           <input type="text" class="form-control" value.bind="selectedMessage.name" change.delegate="updateName()">
-          <span class="glyphicon glyphicon-remove-circle section__btn-group--clear-btn" click.delegate="clearName()"></span>          
+          <span class="glyphicon glyphicon-remove-circle section__btn-group--clear-btn" click.delegate="clearName()"></span>
         </div>
       </div>
     </div>

--- a/src/modules/property-panel/indextabs/general/sections/message-event/message-event.ts
+++ b/src/modules/property-panel/indextabs/general/sections/message-event/message-event.ts
@@ -58,6 +58,17 @@ export class MessageEventSection implements ISection {
     });
   }
 
+  public checkElement(element: IShape): boolean {
+    if (element &&
+        element.businessObject &&
+        element.businessObject.eventDefinitions &&
+        element.businessObject.eventDefinitions[0].$type === 'bpmn:MessageEventDefinition') {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
   private init(): void {
     if (this.businessObjInPanel.eventDefinitions
       && this.businessObjInPanel.eventDefinitions[0].$type === 'bpmn:MessageEventDefinition') {
@@ -72,15 +83,6 @@ export class MessageEventSection implements ISection {
         }
     }
     this.canHandleElement = this.checkElement(this.businessObjInPanel);
-  }
-
-  public checkElement(element: IModdleElement): boolean {
-    if (element.eventDefinitions &&
-        element.eventDefinitions[0].$type === 'bpmn:MessageEventDefinition') {
-      return true;
-    } else {
-      return false;
-    }
   }
 
   private getXML(): string {

--- a/src/modules/property-panel/indextabs/general/sections/message-event/message-event.ts
+++ b/src/modules/property-panel/indextabs/general/sections/message-event/message-event.ts
@@ -82,7 +82,6 @@ export class MessageEventSection implements ISection {
           this.selectedId = null;
         }
     }
-    this.canHandleElement = this.checkElement(this.businessObjInPanel);
   }
 
   private getXML(): string {

--- a/src/modules/property-panel/indextabs/general/sections/message-event/message-event.ts
+++ b/src/modules/property-panel/indextabs/general/sections/message-event/message-event.ts
@@ -45,15 +45,15 @@ export class MessageEventSection implements ISection {
     this.init();
   }
 
-  public checkElement(element: IShape): boolean {
-    if (element &&
-        element.businessObject &&
-        element.businessObject.eventDefinitions &&
-        element.businessObject.eventDefinitions[0].$type === 'bpmn:MessageEventDefinition') {
-      return true;
-    } else {
-      return false;
-    }
+  public isSuitableForElement(element: IShape): boolean {
+    return this.elementIsMessageEvent(element);
+  }
+
+  private elementIsMessageEvent(element: IShape): boolean {
+    return element !== undefined
+        && element.businessObject !== undefined
+        && element.businessObject.eventDefinitions !== undefined
+        && element.businessObject.eventDefinitions[0].$type === 'bpmn:MessageEventDefinition';
   }
 
   private init(): void {

--- a/src/modules/property-panel/indextabs/general/sections/message-event/message-event.ts
+++ b/src/modules/property-panel/indextabs/general/sections/message-event/message-event.ts
@@ -21,7 +21,6 @@ export class MessageEventSection implements ISection {
   public canHandleElement: boolean = false;
 
   private businessObjInPanel: IMessageElement;
-  private eventBus: IEventBus;
   private moddle: IBpmnModdle;
   private modeler: IBpmnModeler;
   private msgDropdown: HTMLSelectElement;
@@ -36,26 +35,14 @@ export class MessageEventSection implements ISection {
   }
 
   public async activate(model: IPageModel): Promise<void> {
-    this.eventBus = model.modeler.get('eventBus');
+    this.businessObjInPanel = model.elementInPanel.businessObject;
+
     this.moddle = model.modeler.get('moddle');
     this.modeler = model.modeler;
 
     this.messages = await this.getMessages();
 
-    const selectedEvents: Array<IShape> = this.modeler.get('selection')._selectedElements;
-    if (selectedEvents[0]) {
-      this.businessObjInPanel = selectedEvents[0].businessObject;
-      this.init();
-    }
-
-    this.eventBus.on(['element.click', 'shape.changed', 'selection.changed'], (event: IEvent) => {
-      if (event.newSelection && event.newSelection.length !== 0) {
-        this.businessObjInPanel = event.newSelection[0].businessObject;
-      } else if (event.element) {
-        this.businessObjInPanel = event.element.businessObject;
-      }
-      this.init();
-    });
+    this.init();
   }
 
   public checkElement(element: IShape): boolean {

--- a/src/modules/property-panel/indextabs/general/sections/pool/pool.html
+++ b/src/modules/property-panel/indextabs/general/sections/pool/pool.html
@@ -1,7 +1,7 @@
 <template>
   <require from="./pool.css"></require>
   <require from="../../../../styles/sections.css"></require>
-  <div class="section" show.bind="canHandleElement">
+  <div class="section">
     <div class="section__content section__border col-md-11">
       <div class="section__btn-group">
         <label class="section__input-label">Version Tag: </label>
@@ -11,12 +11,12 @@
       <div class="section__btn-group">
         <label class="section__input-label">Process Id: </label>
         <input type="text" class="form-control" value.bind="businessObjInPanel.processRef.id">
-        <span class="glyphicon glyphicon-remove-circle section__btn-group--clear-btn" click.delegate="clearId()"></span>         
+        <span class="glyphicon glyphicon-remove-circle section__btn-group--clear-btn" click.delegate="clearId()"></span>
       </div>
       <div class="section__btn-group">
         <label class="section__input-label">Process Name: </label>
         <input type="text" class="form-control" value.bind="businessObjInPanel.processRef.name">
-        <span class="glyphicon glyphicon-remove-circle section__btn-group--clear-btn" click.delegate="clearName()"></span>        
+        <span class="glyphicon glyphicon-remove-circle section__btn-group--clear-btn" click.delegate="clearName()"></span>
       </div>
     </div>
     <div class="section__special col-md-1">

--- a/src/modules/property-panel/indextabs/general/sections/pool/pool.ts
+++ b/src/modules/property-panel/indextabs/general/sections/pool/pool.ts
@@ -32,16 +32,19 @@ export class PoolSection implements ISection {
     });
   }
 
-  private init(): void {
-    this.canHandleElement = this.checkElement(this.businessObjInPanel);
-  }
+  public checkElement(element: IShape): boolean {
 
-  public checkElement(element: IModdleElement): boolean {
-    if (element && element.$type === 'bpmn:Participant') {
+    if (element &&
+        element.businessObject &&
+        element.businessObject.$type === 'bpmn:Participant') {
       return true;
     } else {
       return false;
     }
+  }
+
+  private init(): void {
+    this.canHandleElement = this.checkElement(this.businessObjInPanel);
   }
 
   private clearVersion(): void {

--- a/src/modules/property-panel/indextabs/general/sections/pool/pool.ts
+++ b/src/modules/property-panel/indextabs/general/sections/pool/pool.ts
@@ -31,7 +31,6 @@ export class PoolSection implements ISection {
   }
 
   public checkElement(element: IShape): boolean {
-
     if (element &&
         element.businessObject &&
         element.businessObject.$type === 'bpmn:Participant') {

--- a/src/modules/property-panel/indextabs/general/sections/pool/pool.ts
+++ b/src/modules/property-panel/indextabs/general/sections/pool/pool.ts
@@ -23,12 +23,10 @@ export class PoolSection implements ISection {
     const selectedEvents: Array<IShape> = this.modeler.get('selection')._selectedElements;
     if (selectedEvents[0]) {
       this.businessObjInPanel = selectedEvents[0].businessObject;
-      this.init();
     }
 
     this.eventBus.on(['element.click', 'shape.changed'], (event: IEvent) => {
       this.businessObjInPanel = event.element.businessObject;
-      this.init();
     });
   }
 
@@ -41,10 +39,6 @@ export class PoolSection implements ISection {
     } else {
       return false;
     }
-  }
-
-  private init(): void {
-    this.canHandleElement = this.checkElement(this.businessObjInPanel);
   }
 
   private clearVersion(): void {

--- a/src/modules/property-panel/indextabs/general/sections/pool/pool.ts
+++ b/src/modules/property-panel/indextabs/general/sections/pool/pool.ts
@@ -20,14 +20,14 @@ export class PoolSection implements ISection {
     this.modeler = model.modeler;
   }
 
-  public checkElement(element: IShape): boolean {
-    if (element &&
-        element.businessObject &&
-        element.businessObject.$type === 'bpmn:Participant') {
-      return true;
-    } else {
-      return false;
-    }
+  public isSuitableForElement(element: IShape): boolean {
+    return this.elementIsParticipant(element);
+  }
+
+  private elementIsParticipant(element: IShape): boolean {
+    return element !== undefined
+        && element.businessObject !== undefined
+        && element.businessObject.$type === 'bpmn:Participant';
   }
 
   private clearVersion(): void {

--- a/src/modules/property-panel/indextabs/general/sections/pool/pool.ts
+++ b/src/modules/property-panel/indextabs/general/sections/pool/pool.ts
@@ -13,21 +13,11 @@ export class PoolSection implements ISection {
   public canHandleElement: boolean = false;
 
   private businessObjInPanel: IPoolElement;
-  private eventBus: IEventBus;
   private modeler: IBpmnModeler;
 
   public activate(model: IPageModel): void {
-    this.eventBus = model.modeler.get('eventBus');
+    this.businessObjInPanel = model.elementInPanel.businessObject;
     this.modeler = model.modeler;
-
-    const selectedEvents: Array<IShape> = this.modeler.get('selection')._selectedElements;
-    if (selectedEvents[0]) {
-      this.businessObjInPanel = selectedEvents[0].businessObject;
-    }
-
-    this.eventBus.on(['element.click', 'shape.changed'], (event: IEvent) => {
-      this.businessObjInPanel = event.element.businessObject;
-    });
   }
 
   public checkElement(element: IShape): boolean {

--- a/src/modules/property-panel/indextabs/general/sections/script-task/script-task.html
+++ b/src/modules/property-panel/indextabs/general/sections/script-task/script-task.html
@@ -1,7 +1,7 @@
 <template>
   <require from="./script-task.css"></require>
   <require from="../../../../styles/sections.css"></require>
-  <div class="section" show.bind="canHandleElement">
+  <div class="section">
     <div class="section__content section__border col-md-11">
       <label><em>Script Task</em></label><br>
       <div class="section__btn-group">
@@ -12,12 +12,12 @@
       <div class="section__btn-group">
         <label class="section__input-label">Script: </label>
         <input type="text" class="form-control" value.bind="businessObjInPanel.script">
-        <span class="glyphicon glyphicon-remove-circle section__btn-group--clear-btn" click.delegate="clearScript()"></span>        
+        <span class="glyphicon glyphicon-remove-circle section__btn-group--clear-btn" click.delegate="clearScript()"></span>
       </div>
       <div class="section__btn-group">
         <label class="section__input-label">Result Variable: </label>
         <input type="text" class="form-control" value.bind="businessObjInPanel.resultVariable">
-        <span class="glyphicon glyphicon-remove-circle section__btn-group--clear-btn" click.delegate="clearVariable()"></span>        
+        <span class="glyphicon glyphicon-remove-circle section__btn-group--clear-btn" click.delegate="clearVariable()"></span>
       </div>
     </div>
     <div class="section__special col-md-1">

--- a/src/modules/property-panel/indextabs/general/sections/script-task/script-task.ts
+++ b/src/modules/property-panel/indextabs/general/sections/script-task/script-task.ts
@@ -23,7 +23,6 @@ export class ScriptTaskSection implements ISection {
     const selectedEvents: Array<IShape> = this.modeler.get('selection')._selectedElements;
     if (selectedEvents[0]) {
       this.businessObjInPanel = selectedEvents[0].businessObject;
-      this.init();
     }
 
     this.eventBus.on(['element.click', 'shape.changed', 'selection.changed'], (event: IEvent) => {
@@ -32,7 +31,6 @@ export class ScriptTaskSection implements ISection {
       } else if (event.element) {
         this.businessObjInPanel = event.element.businessObject;
       }
-      this.init();
     });
   }
 
@@ -44,10 +42,6 @@ export class ScriptTaskSection implements ISection {
     } else {
       return false;
     }
-  }
-
-  private init(): void {
-    this.canHandleElement = this.checkElement(this.businessObjInPanel);
   }
 
   private clearFormat(): void {

--- a/src/modules/property-panel/indextabs/general/sections/script-task/script-task.ts
+++ b/src/modules/property-panel/indextabs/general/sections/script-task/script-task.ts
@@ -20,14 +20,14 @@ export class ScriptTaskSection implements ISection {
     this.modeler = model.modeler;
   }
 
-  public checkElement(element: IShape): boolean {
-    if (element &&
-        element.businessObject &&
-        element.businessObject.$type === 'bpmn:ScriptTask') {
-      return true;
-    } else {
-      return false;
-    }
+  public isSuitableForElement(element: IShape): boolean {
+    return this.elementIsScriptTask(element);
+  }
+
+  private elementIsScriptTask(element: IShape): boolean {
+    return element !== undefined
+        && element.businessObject !== undefined
+        && element.businessObject.$type === 'bpmn:ScriptTask';
   }
 
   private clearFormat(): void {

--- a/src/modules/property-panel/indextabs/general/sections/script-task/script-task.ts
+++ b/src/modules/property-panel/indextabs/general/sections/script-task/script-task.ts
@@ -36,17 +36,18 @@ export class ScriptTaskSection implements ISection {
     });
   }
 
-  private init(): void {
-    this.canHandleElement = this.checkElement(this.businessObjInPanel);
-  }
-
-  public checkElement(element: IModdleElement): boolean {
+  public checkElement(element: IShape): boolean {
     if (element &&
-        element.$type === 'bpmn:ScriptTask') {
+        element.businessObject &&
+        element.businessObject.$type === 'bpmn:ScriptTask') {
       return true;
     } else {
       return false;
     }
+  }
+
+  private init(): void {
+    this.canHandleElement = this.checkElement(this.businessObjInPanel);
   }
 
   private clearFormat(): void {

--- a/src/modules/property-panel/indextabs/general/sections/script-task/script-task.ts
+++ b/src/modules/property-panel/indextabs/general/sections/script-task/script-task.ts
@@ -13,25 +13,11 @@ export class ScriptTaskSection implements ISection {
   public canHandleElement: boolean = false;
 
   private businessObjInPanel: IScriptTaskElement;
-  private eventBus: IEventBus;
   private modeler: IBpmnModeler;
 
   public async activate(model: IPageModel): Promise<void> {
-    this.eventBus = model.modeler.get('eventBus');
+    this.businessObjInPanel = model.elementInPanel.businessObject;
     this.modeler = model.modeler;
-
-    const selectedEvents: Array<IShape> = this.modeler.get('selection')._selectedElements;
-    if (selectedEvents[0]) {
-      this.businessObjInPanel = selectedEvents[0].businessObject;
-    }
-
-    this.eventBus.on(['element.click', 'shape.changed', 'selection.changed'], (event: IEvent) => {
-      if (event.newSelection && event.newSelection.length !== 0) {
-        this.businessObjInPanel = event.newSelection[0].businessObject;
-      } else if (event.element) {
-        this.businessObjInPanel = event.element.businessObject;
-      }
-    });
   }
 
   public checkElement(element: IShape): boolean {

--- a/src/modules/property-panel/indextabs/general/sections/signal-event/signal-event.html
+++ b/src/modules/property-panel/indextabs/general/sections/signal-event/signal-event.html
@@ -1,7 +1,7 @@
 <template>
   <require from="./signal-event.css"></require>
   <require from="../../../../styles/sections.css"></require>
-  <div class="section" show.bind="canHandleElement">
+  <div class="section">
     <div class="section__content section__border col-md-11">
       <label class="section__input-label">Signal: </label>
       <select class="form-control" value.bind="selectedId" change.delegate="updateSignal()">
@@ -13,7 +13,7 @@
         <div class="section__btn-group">
           <label class="section__input-label">Signal Name: </label>
           <input type="text" class="form-control" value.bind="selectedSignal.name" change.delegate="updateName()">
-          <span class="glyphicon glyphicon-remove-circle section__btn-group--clear-btn" click.delegate="clearName()"></span>          
+          <span class="glyphicon glyphicon-remove-circle section__btn-group--clear-btn" click.delegate="clearName()"></span>
         </div>
       </div>
    </div>

--- a/src/modules/property-panel/indextabs/general/sections/signal-event/signal-event.ts
+++ b/src/modules/property-panel/indextabs/general/sections/signal-event/signal-event.ts
@@ -81,7 +81,6 @@ export class SignalEventSection implements ISection {
           this.selectedId = null;
         }
     }
-    this.canHandleElement = this.checkElement(this.businessObjInPanel);
   }
 
   private getXML(): string {

--- a/src/modules/property-panel/indextabs/general/sections/signal-event/signal-event.ts
+++ b/src/modules/property-panel/indextabs/general/sections/signal-event/signal-event.ts
@@ -35,7 +35,6 @@ export class SignalEventSection implements ISection {
 
   public async activate(model: IPageModel): Promise<void> {
     this.businessObjInPanel = model.elementInPanel.businessObject;
-
     this.moddle = model.modeler.get('moddle');
     this.modeler = model.modeler;
 

--- a/src/modules/property-panel/indextabs/general/sections/signal-event/signal-event.ts
+++ b/src/modules/property-panel/indextabs/general/sections/signal-event/signal-event.ts
@@ -21,7 +21,6 @@ export class SignalEventSection implements ISection {
   public canHandleElement: boolean = false;
 
   private businessObjInPanel: ISignalElement;
-  private eventBus: IEventBus;
   private moddle: IBpmnModdle;
   private modeler: IBpmnModeler;
   private generalService: GeneralService;
@@ -35,26 +34,14 @@ export class SignalEventSection implements ISection {
   }
 
   public async activate(model: IPageModel): Promise<void> {
-    this.eventBus = model.modeler.get('eventBus');
+    this.businessObjInPanel = model.elementInPanel.businessObject;
+
     this.moddle = model.modeler.get('moddle');
     this.modeler = model.modeler;
 
     this.signals = await this.getSignals();
 
-    const selectedEvents: Array<IShape> = this.modeler.get('selection')._selectedElements;
-    if (selectedEvents[0]) {
-      this.businessObjInPanel = selectedEvents[0].businessObject;
-      this.init();
-    }
-
-    this.eventBus.on(['element.click', 'shape.changed', 'selection.changed'], (event: IEvent) => {
-      if (event.newSelection && event.newSelection.length !== 0) {
-        this.businessObjInPanel = event.newSelection[0].businessObject;
-      } else if (event.element) {
-        this.businessObjInPanel = event.element.businessObject;
-      }
-      this.init();
-    });
+    this.init();
   }
 
   public checkElement(element: IShape): boolean {

--- a/src/modules/property-panel/indextabs/general/sections/signal-event/signal-event.ts
+++ b/src/modules/property-panel/indextabs/general/sections/signal-event/signal-event.ts
@@ -43,15 +43,15 @@ export class SignalEventSection implements ISection {
     this.init();
   }
 
-  public checkElement(element: IShape): boolean {
-    if (element &&
-        element.businessObject &&
-        element.businessObject.eventDefinitions &&
-        element.businessObject.eventDefinitions[0].$type === 'bpmn:SignalEventDefinition') {
-      return true;
-    } else {
-      return false;
-    }
+  public isSuitableForElement(element: IShape): boolean {
+    return this.elementIsSignalEvent(element);
+  }
+
+  private elementIsSignalEvent(element: IShape): boolean {
+    return element !== undefined
+        && element.businessObject !== undefined
+        && element.businessObject.eventDefinitions !== undefined
+        && element.businessObject.eventDefinitions[0].$type === 'bpmn:SignalEventDefinition';
   }
 
   private init(): void {

--- a/src/modules/property-panel/indextabs/general/sections/signal-event/signal-event.ts
+++ b/src/modules/property-panel/indextabs/general/sections/signal-event/signal-event.ts
@@ -57,6 +57,17 @@ export class SignalEventSection implements ISection {
     });
   }
 
+  public checkElement(element: IShape): boolean {
+    if (element &&
+        element.businessObject &&
+        element.businessObject.eventDefinitions &&
+        element.businessObject.eventDefinitions[0].$type === 'bpmn:SignalEventDefinition') {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
   private init(): void {
     if (this.businessObjInPanel.eventDefinitions
       && this.businessObjInPanel.eventDefinitions[0].$type === 'bpmn:SignalEventDefinition') {
@@ -71,15 +82,6 @@ export class SignalEventSection implements ISection {
         }
     }
     this.canHandleElement = this.checkElement(this.businessObjInPanel);
-  }
-
-  public checkElement(element: IModdleElement): boolean {
-    if (element.eventDefinitions &&
-        element.eventDefinitions[0].$type === 'bpmn:SignalEventDefinition') {
-      return true;
-    } else {
-      return false;
-    }
   }
 
   private getXML(): string {

--- a/src/modules/property-panel/property-panel.html
+++ b/src/modules/property-panel/property-panel.html
@@ -14,8 +14,11 @@
       </ul>
     </div>
     <div repeat.for="indextab of indextabs">
-      <compose view-model=".${indextab.path}" view=".${indextab.path}.html"
-        model.bind="{ modeler : modeler }" if.bind="indextab.canHandleElement && indextab.title === currentIndextabTitle" containerless></compose>
+      <compose view-model=".${indextab.path}"
+        view=".${indextab.path}.html"
+        model.bind="{modeler : modeler, elementInPanel : elementInPanel}"
+        if.bind="indextab.canHandleElement && indextab.title === currentIndextabTitle"
+        containerless></compose>
     </div>
   </div>
 </template>

--- a/src/modules/property-panel/property-panel.html
+++ b/src/modules/property-panel/property-panel.html
@@ -16,7 +16,7 @@
     <div repeat.for="indextab of indextabs">
       <compose view-model=".${indextab.path}"
         view=".${indextab.path}.html"
-        model.bind="{modeler : modeler, elementInPanel : elementInPanel}"
+        model.bind="{modeler: modeler, elementInPanel: elementInPanel}"
         if.bind="indextab.canHandleElement && indextab.title === currentIndextabTitle"
         containerless></compose>
     </div>

--- a/src/modules/property-panel/property-panel.ts
+++ b/src/modules/property-panel/property-panel.ts
@@ -21,7 +21,7 @@ export class PropertyPanel {
   public xml: string;
   private moddle: IBpmnModdle;
   private eventBus: IEventBus;
-  private elementInPanel: IModdleElement;
+  private elementInPanel: IShape;
 
   public generalIndextab: IIndextab = new General();
   public formsIndextab: IIndextab = new Forms();
@@ -32,14 +32,13 @@ export class PropertyPanel {
 
   public attached(): void {
     this.moddle = this.modeler.get('moddle');
+    this.eventBus = this.modeler.get('eventBus');
 
     this.indextabs = [
       this.generalIndextab,
       this.formsIndextab,
       this.extensionsIndextab,
     ];
-
-    this.eventBus = this.modeler.get('eventBus');
 
     this.indextabs.forEach((indextab: IIndextab) => {
       indextab.canHandleElement = indextab.checkElement(this.elementInPanel);
@@ -52,16 +51,17 @@ export class PropertyPanel {
 
     this.eventBus.on(['element.click', 'shape.changed', 'selection.changed'], (event: IEvent) => {
       if (event.type === 'element.click') {
-        this.elementInPanel = event.element.businessObject;
+        this.elementInPanel = event.element;
       }
       if (event.type === 'shape.changed' &&
           event.element.type !== 'label' &&
           event.element.id === this.elementInPanel.id) {
-        this.elementInPanel = event.element.businessObject;
+        this.elementInPanel = event.element;
       }
       if (event.type === 'selection.changed' && event.newSelection.length !== 0) {
-        this.elementInPanel = event.newSelection[0].businessObject;
+        this.elementInPanel = event.newSelection[0];
       }
+
       this.indextabs.forEach((indextab: IIndextab) => {
         indextab.canHandleElement = indextab.checkElement(this.elementInPanel);
         if (indextab.title === this.currentIndextabTitle && !indextab.canHandleElement) {

--- a/src/modules/property-panel/property-panel.ts
+++ b/src/modules/property-panel/property-panel.ts
@@ -40,27 +40,31 @@ export class PropertyPanel {
     ];
 
     this.indextabs.forEach((indextab: IIndextab) => {
-      indextab.canHandleElement = indextab.checkElement(this.elementInPanel);
+      indextab.canHandleElement = indextab.isSuitableForElement(this.elementInPanel);
       if (indextab.title === this.currentIndextabTitle && !indextab.canHandleElement) {
         this.currentIndextabTitle = this.generalIndextab.title;
       }
     });
 
     this.eventBus.on(['element.click', 'shape.changed', 'selection.changed'], (event: IEvent) => {
-      if (event.type === 'element.click') {
+
+      const elementWasClickedOn: boolean = event.type === 'element.clicked';
+      const elementIsValidShape: boolean = event.type === 'shape.changed' && event.element.type !== 'label';
+
+      const elementIsShapeInPanel: boolean = elementIsValidShape && event.element.id === this.elementInPanel.id;
+
+      if (elementWasClickedOn || elementIsShapeInPanel) {
         this.elementInPanel = event.element;
       }
-      if (event.type === 'shape.changed' &&
-          event.element.type !== 'label' &&
-          event.element.id === this.elementInPanel.id) {
-        this.elementInPanel = event.element;
-      }
-      if (event.type === 'selection.changed' && event.newSelection.length !== 0) {
+
+      const selectedElementChanged: boolean = event.type === 'selection.changed' && event.newSelection.length !== 0;
+
+      if (selectedElementChanged) {
         this.elementInPanel = event.newSelection[0];
       }
 
       this.indextabs.forEach((indextab: IIndextab) => {
-        indextab.canHandleElement = indextab.checkElement(this.elementInPanel);
+        indextab.canHandleElement = indextab.isSuitableForElement(this.elementInPanel);
         if (indextab.title === this.currentIndextabTitle && !indextab.canHandleElement) {
           this.currentIndextabTitle = this.generalIndextab.title;
         }

--- a/src/modules/property-panel/property-panel.ts
+++ b/src/modules/property-panel/property-panel.ts
@@ -46,8 +46,6 @@ export class PropertyPanel {
       }
     });
 
-    this.setFirstElement();
-
     this.eventBus.on(['element.click', 'shape.changed', 'selection.changed'], (event: IEvent) => {
       if (event.type === 'element.click') {
         this.elementInPanel = event.element;
@@ -68,6 +66,8 @@ export class PropertyPanel {
         }
       });
     });
+
+    this.setFirstElement();
 
   }
 

--- a/src/modules/property-panel/property-panel.ts
+++ b/src/modules/property-panel/property-panel.ts
@@ -19,14 +19,13 @@ export class PropertyPanel {
   public modeler: IBpmnModeler;
   @bindable()
   public xml: string;
-  private moddle: IBpmnModdle;
-  private eventBus: IEventBus;
-  private elementInPanel: IShape;
-
+  public elementInPanel: IShape;
   public generalIndextab: IIndextab = new General();
   public formsIndextab: IIndextab = new Forms();
   public extensionsIndextab: IIndextab = new Extensions();
 
+  private moddle: IBpmnModdle;
+  private eventBus: IEventBus;
   private currentIndextabTitle: string = this.generalIndextab.title;
   private indextabs: Array<IIndextab>;
 


### PR DESCRIPTION
## What did you change?

This branch reworks the event handling in the property panel. Instead of letting each section subscribe itself to the events, the property panel subscribes itself and passes the found element to the sections. The sections just check if they can handle the element.

## How can others test the changes?

- Checkout branch & start bpmn-studio
- Create a process & start by editing it (a lot)

Now you can see that the "old" features work like they should while the code is much cleaner.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [ ] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
