### PR TITLE
🐛:bug: Fix Warning when Changing Element

### DIFF
--- a/src/modules/property-panel/property-panel.html
+++ b/src/modules/property-panel/property-panel.html
@@ -1,7 +1,7 @@
 <template>
   <require from="./property-panel.css"></require>
   <div class="property-panel">
-    <b class="element-id-label">${elementInPanel.businessObject.id}</b>
+    <b class="element-id-label">${selectedElementId}</b>
     <div class="btn-group indextab-dropdown">
       <a class="btn btn-default indextab-button">${currentIndextabTitle}</a>
       <a ref="indextabDropdown" class="btn btn-default dropdown-toggle dropdown_button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/src/modules/property-panel/property-panel.ts
+++ b/src/modules/property-panel/property-panel.ts
@@ -28,6 +28,7 @@ export class PropertyPanel {
   private eventBus: IEventBus;
   private currentIndextabTitle: string = this.generalIndextab.title;
   private indextabs: Array<IIndextab>;
+  private selectedElementId: string;
 
   public attached(): void {
     this.moddle = this.modeler.get('moddle');
@@ -50,12 +51,14 @@ export class PropertyPanel {
 
       if (elementWasClickedOn || elementIsShapeInPanel) {
         this.elementInPanel = event.element;
+        this.selectedElementId = this.elementInPanel.businessObject.id;
       }
 
       const selectedElementChanged: boolean = event.type === 'selection.changed' && event.newSelection.length !== 0;
 
       if (selectedElementChanged) {
         this.elementInPanel = event.newSelection[0];
+        this.selectedElementId = this.elementInPanel.businessObject.id;
       }
 
       this.updateIndexTabsSuitability();


### PR DESCRIPTION
## What did you change?

I fixed a warning caused by the selected-element-id-label.

<img width="370" alt="bildschirmfoto 2018-02-21 um 17 01 18" src="https://user-images.githubusercontent.com/20394992/36490619-ee1b086a-1728-11e8-9901-122fe0d605f5.png">


## How can others test the changes?

- open up BPMN-Studio
- have a look at the console and see no more warnings

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
