### PR TITLE
🐛:bug: Fix Colorpicker When the ProcessDef gets Changed

### DIFF
--- a/aurelia_project/environments/dev.ts
+++ b/aurelia_project/environments/dev.ts
@@ -28,4 +28,19 @@ export default {
     minWidth: 190,
     maxWidth: 150,
   },
+  colorPickerSettings: {
+    loadTimeout: 10,
+    uiSettings: {
+      clickoutFiresChange: true,
+      showPalette: true,
+      palette: [],
+      localStorageKey: 'elementColors',
+      showInitial: true,
+      showInput: true,
+      allowEmpty: true,
+      showButtons: false,
+      showPaletteOnly: true,
+      togglePaletteOnly: true,
+    },
+  },
 };

--- a/aurelia_project/environments/prod.ts
+++ b/aurelia_project/environments/prod.ts
@@ -28,4 +28,19 @@ export default {
     minWidth: 190,
     maxWidth: 150,
   },
+  colorPickerSettings: {
+    loadTimeout: 10,
+    uiSettings: {
+      clickoutFiresChange: true,
+      showPalette: true,
+      palette: [],
+      localStorageKey: 'elementColors',
+      showInitial: true,
+      showInput: true,
+      allowEmpty: true,
+      showButtons: false,
+      showPaletteOnly: true,
+      togglePaletteOnly: true,
+    },
+  },
 };

--- a/aurelia_project/environments/stage.ts
+++ b/aurelia_project/environments/stage.ts
@@ -28,4 +28,19 @@ export default {
     minWidth: 190,
     maxWidth: 150,
   },
+  colorPickerSettings: {
+    loadTimeout: 10,
+    uiSettings: {
+      clickoutFiresChange: true,
+      showPalette: true,
+      palette: [],
+      localStorageKey: 'elementColors',
+      showInitial: true,
+      showInput: true,
+      allowEmpty: true,
+      showButtons: false,
+      showPaletteOnly: true,
+      togglePaletteOnly: true,
+    },
+  },
 };

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -28,4 +28,19 @@ export default {
     minWidth: 190,
     maxWidth: 150,
   },
+  colorPickerSettings: {
+    loadTimeout: 10,
+    uiSettings: {
+      clickoutFiresChange: true,
+      showPalette: true,
+      palette: [],
+      localStorageKey: 'elementColors',
+      showInitial: true,
+      showInput: true,
+      allowEmpty: true,
+      showButtons: false,
+      showPaletteOnly: true,
+      togglePaletteOnly: true,
+    },
+  },
 };

--- a/src/modules/processdef-detail/processdef-detail.html
+++ b/src/modules/processdef-detail/processdef-detail.html
@@ -78,7 +78,7 @@
             <li><a click.delegate="setColorPurple()"><i class="glyphicon glyphicon-stop purple"></i> Purple</a></li>
             <li><a click.delegate="setColorOrange()"><i class="glyphicon glyphicon-stop orange"></i> Orange</a></li>
             <li>
-              <a click.delegate="setColorPicked()">
+              <a if.bind="initialLoadingFinished" click.delegate="setColorPicked()">
                 <input id="colorpickerFill"></input>
                 <input id="colorpickerBorder"></input>
               </a>

--- a/src/modules/processdef-detail/processdef-detail.ts
+++ b/src/modules/processdef-detail/processdef-detail.ts
@@ -18,6 +18,7 @@ import {AuthenticationStateEvent,
         IModdleElement,
         IProcessEngineService,
         IShape} from '../../contracts/index';
+import environment from '../../environment';
 import {BpmnIo} from '../bpmn-io/bpmn-io';
 
 interface RouteParameters {
@@ -83,29 +84,6 @@ export class ProcessDefDetail {
       }),
     ];
 
-    const settings: any = {
-      clickoutFiresChange: true,
-      showPalette: true,
-      palette: [],
-      localStorageKey: 'elementColors',
-      showInitial: true,
-      showInput: true,
-      allowEmpty: true,
-      showButtons: false,
-      showPaletteOnly: true,
-      togglePaletteOnly: true,
-    };
-
-    $('#colorpickerBorder').spectrum(Object.assign({},
-      settings,
-      { move: (borderColor: any): void => this.updateBorderColor(borderColor) },
-    ));
-
-    $('#colorpickerFill').spectrum(Object.assign({},
-      settings,
-      { move: (fillColor: any): void => this.updateFillColor(fillColor) },
-    ));
-
     // setTimeout() gives us the callback queue, that causes
     // the initLoadingFinished boolean to become true as late as possible
     // so as soon as the view-model is fully attached
@@ -114,6 +92,22 @@ export class ProcessDefDetail {
     setTimeout(() => {
       this.initialLoadingFinished = true;
     }, 0);
+
+    setTimeout(() => {
+      this._activateColorPicker();
+    }, environment.colorPickerSettings.loadTimeout);
+  }
+
+  private _activateColorPicker(): void {
+    $('#colorpickerBorder').spectrum(Object.assign({},
+      environment.colorPickerSettings.uiSettings,
+      { move: (borderColor: any): void => this.updateBorderColor(borderColor) },
+    ));
+
+    $('#colorpickerFill').spectrum(Object.assign({},
+      environment.colorPickerSettings.uiSettings,
+      { move: (fillColor: any): void => this.updateFillColor(fillColor) },
+    ));
   }
 
   public detached(): void {


### PR DESCRIPTION
## What did you change?

The Colorpicker now gets displayed correctly also when the ProcessDef gets changed.

## How can others test the changes?

1. Open up the BPMN-Studio
2. Open up the Detail-View of any ProcessDef
3. Have a look at the Colorpicker
4. Go back to the ProcessDefList
5. Repeat Step 2 and 3 and see that it is still working

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
