### PR TITLE
Fix firefox-specific css bug.

### DIFF
--- a/src/modules/property-panel/property-panel.html
+++ b/src/modules/property-panel/property-panel.html
@@ -4,8 +4,9 @@
     <b class="element-id-label">${selectedElementId}</b>
 
     <div class="indextab-dropdown dropdown">
-      <button class="btn btn-default dropdown-toggle indextab-dropdown__button" data-toggle="dropdown">${currentIndextabTitle}
+      <button class="btn btn-default dropdown-toggle indextab-dropdown__button" data-toggle="dropdown">
         <i class="glyphicon glyphicon-chevron-down indextab-dropdown__glyhicon"></i>
+        ${currentIndextabTitle}
       </button>
       <ul class="dropdown-menu">
         <li repeat.for="indextab of indextabs">


### PR DESCRIPTION
There is this 8 y/o Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=488725

<img width="348" alt="screen shot 2018-03-08 at 14 25 31" src="https://user-images.githubusercontent.com/21304781/37155828-a13b9466-22e4-11e8-8615-660868aa81f1.png">

Button has css property `white-space: nowrap`, which causes a bug in
Firefox in combination with floats(such as the chevron).
Causes a linebreak, when both text and the chevron should be in same line.
Swapping text and chevron makes it work.

Another solution would be setting whitespace to normal on the button-element.

## What did you change?
Swapped two lines of HTML in order to fix a firefox specific bug.

## How can others test the changes?
- checkout this branch
- `au build`
- `npm run`
- open localhost:8080, open details of a diagram, look at dropdownbutton in property panel with firefox.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
