### PR TITLE
:lipstick: Fix Minimum Height of Electron

### DIFF
--- a/electron_app/electron.js
+++ b/electron_app/electron.js
@@ -29,7 +29,7 @@ function createWindow () {
     height: 800,
     title: "BPMN-Studio",
     minWidth: 1000,
-    minHeight: 1000,
+    minHeight: 800,
   });
 
   mainWindow.loadURL(`file://${__dirname}/../index.html`);

--- a/electron_app/electron.js
+++ b/electron_app/electron.js
@@ -29,7 +29,7 @@ function createWindow () {
     height: 800,
     title: "BPMN-Studio",
     minWidth: 1000,
-    minHeight: 600,
+    minHeight: 1000,
   });
 
   mainWindow.loadURL(`file://${__dirname}/../index.html`);


### PR DESCRIPTION
## What did you change?

I increased the minimum height of the electron app, so that the left bar of the BPMN-Studio is fully accessible.

<img width="1112" alt="bpmn-studio_too_small" src="https://user-images.githubusercontent.com/20394992/37525550-7805f9ca-292d-11e8-9986-413ac81aed00.png">


## How can others test the changes?

- Build the electron app
- Resize it as small as possible

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
