### PR TITLE
:bug: Readd Main Menu

### DIFF
--- a/electron_app/electron.js
+++ b/electron_app/electron.js
@@ -74,6 +74,19 @@ function createWindow () {
   });
 
   var template = [{
+    label: "BPMN-Studio",
+    submenu: [
+        {
+          label: "About BPMN-Studio", selector: "orderFrontStandardAboutPanel:"
+        },
+        {
+          type: "separator"
+        },
+        {
+          label: "Quit", accelerator: "Command+Q", click: function() {
+          app.quit();
+        }}
+    ]}, {
     label: "Edit",
     submenu: [
         {


### PR DESCRIPTION
## What did you change?

I readded the 'bpmn-studio', because otherwise the 'edit' menu was used as 'bpmn-studio' menu.

<img width="135" alt="old_main_menu" src="https://user-images.githubusercontent.com/20394992/37527982-ac33ae80-2933-11e8-8535-04c5dcdf8cff.png">
<img width="193" alt="new_main_menu" src="https://user-images.githubusercontent.com/20394992/37528170-366fdce0-2934-11e8-9861-e88950a859f5.png">


## How can others test the changes?

- Build the electron app
- Have a look at the menu bar and the 'edit' and 'bpmn-studio' menu

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
