### PR TITLE
✨ Automatic detection of free port

### DIFF
--- a/electron_app/electron.js
+++ b/electron_app/electron.js
@@ -46,7 +46,6 @@ getPort({port: 8000, host: '0.0.0.0'})
       mainWindow = null;
     });
 
-    mainWindow.toggleDevTools();
     autoUpdater.checkForUpdates();
 
     autoUpdater.addListener('error', (error) => {

--- a/electron_app/electron.js
+++ b/electron_app/electron.js
@@ -4,6 +4,7 @@ const path = require('path');
 const app = electron.app;
 const notifier = require('electron-notifications');
 const isDev = require('electron-is-dev');
+const getPort = require('get-port');
 
 if (!isDev) {
   const userDataFolder = process.env.APPDATA || (process.platform == 'darwin' ? process.env.HOME + '/Library/Preferences' : '/var/local');
@@ -12,105 +13,114 @@ if (!isDev) {
   process.env.CONFIG_PATH = path.join(__dirname, '..', '..', '..', 'config');
 }
 
-const pe = require('@process-engine/skeleton-electron');
+getPort({port: 8000, host: '0.0.0.0'})
+.then((port) => {
+  process.env.http__http_extension__server__port = port;
+  const pe = require('@process-engine/skeleton-electron');
 
-let mainWindow = null;
-
-const installButtonText = 'Install';
-const dismissButtonText = 'Dismiss';
-
-function createWindow () {
-  if (mainWindow !== null) {
-    return;
-  }
-
-  mainWindow = new electron.BrowserWindow({
-    width: 1000,
-    height: 800,
-    title: "BPMN-Studio",
-    minWidth: 1000,
-    minHeight: 800,
-    icon: path.join(__dirname, '../build/win_icon.png'),  // only for windows and linux
+  electron.ipcMain.on('get_host', (event) => {
+    event.returnValue = `localhost:${port}`;
   });
 
-  mainWindow.loadURL(`file://${__dirname}/../index.html`);
-  mainWindow.on('closed', () => {
-    mainWindow = null;
-  });
+  let mainWindow = null;
 
-  autoUpdater.checkForUpdates();
+  const installButtonText = 'Install';
+  const dismissButtonText = 'Dismiss';
 
-  autoUpdater.addListener('error', (error) => {
-    const notification = notifier.notify('Update error', {
-      message: 'Update failed',
-      buttons: [dismissButtonText],
-    });
-    notification.on('buttonClicked', (text, buttonIndex, options) => {
-      notification.close();
-    });
-  });
+  function createWindow () {
+    if (mainWindow !== null) {
+      return;
+    }
 
-  autoUpdater.addListener('update-available', (info) => {
-    notifier.notify('Update available', {
-      message: 'Started downloading',
-      buttons: [dismissButtonText],
-    });
-  });
-
-  autoUpdater.addListener('update-downloaded', (info) => {
-    const notification = notifier.notify('Update ready', {
-      message: 'Update ready for installation',
-      duration: '60000',
-      buttons: [installButtonText, dismissButtonText],
+    mainWindow = new electron.BrowserWindow({
+      width: 1000,
+      height: 800,
+      title: "BPMN-Studio",
+      minWidth: 1000,
+      minHeight: 800,
+      icon: path.join(__dirname, '../build/win_icon.png'),  // only for windows and linux
     });
 
-    notification.on('buttonClicked', (text, buttonIndex, options) => {
-      const installButtonClicked = text === installButtonText;
-      if (installButtonClicked) {
-        autoUpdater.quitAndInstall();
-      } else {
+    mainWindow.loadURL(`file://${__dirname}/../index.html`);
+    mainWindow.on('closed', () => {
+      mainWindow = null;
+    });
+
+    mainWindow.toggleDevTools();
+    autoUpdater.checkForUpdates();
+
+    autoUpdater.addListener('error', (error) => {
+      const notification = notifier.notify('Update error', {
+        message: 'Update failed',
+        buttons: [dismissButtonText],
+      });
+      notification.on('buttonClicked', (text, buttonIndex, options) => {
         notification.close();
-      }
-    })
-  });
+      });
+    });
 
-  var template = [{
-    label: "BPMN-Studio",
-    submenu: [
-        {
-          label: "About BPMN-Studio", selector: "orderFrontStandardAboutPanel:"
-        },
-        {
-          type: "separator"
-        },
-        {
-          label: "Quit", accelerator: "Command+Q", click: function() {
-          app.quit();
-        }}
-    ]}, {
-    label: "Edit",
-    submenu: [
-        {
-          label: "Cut", accelerator: "CmdOrCtrl+X", selector: "cut:"
-        },
-        {
-          label: "Copy", accelerator: "CmdOrCtrl+C", selector: "copy:"
-        },
-        {
-          label: "Paste", accelerator: "CmdOrCtrl+V", selector: "paste:"
-        },
-        {
-          label: "Select All", accelerator: "CmdOrCtrl+A", selector: "selectAll:"
+    autoUpdater.addListener('update-available', (info) => {
+      notifier.notify('Update available', {
+        message: 'Started downloading',
+        buttons: [dismissButtonText],
+      });
+    });
+
+    autoUpdater.addListener('update-downloaded', (info) => {
+      const notification = notifier.notify('Update ready', {
+        message: 'Update ready for installation',
+        duration: '60000',
+        buttons: [installButtonText, dismissButtonText],
+      });
+
+      notification.on('buttonClicked', (text, buttonIndex, options) => {
+        const installButtonClicked = text === installButtonText;
+        if (installButtonClicked) {
+          autoUpdater.quitAndInstall();
+        } else {
+          notification.close();
         }
-    ]}
-  ];
-  electron.Menu.setApplicationMenu(electron.Menu.buildFromTemplate(template));
-}
+      })
+    });
 
-app.on('ready', createWindow);
-app.on('activate', createWindow);
-app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') {
-    app.quit();
+    var template = [{
+      label: "BPMN-Studio",
+      submenu: [
+          {
+            label: "About BPMN-Studio", selector: "orderFrontStandardAboutPanel:"
+          },
+          {
+            type: "separator"
+          },
+          {
+            label: "Quit", accelerator: "Command+Q", click: function() {
+            app.quit();
+          }}
+      ]}, {
+      label: "Edit",
+      submenu: [
+          {
+            label: "Cut", accelerator: "CmdOrCtrl+X", selector: "cut:"
+          },
+          {
+            label: "Copy", accelerator: "CmdOrCtrl+C", selector: "copy:"
+          },
+          {
+            label: "Paste", accelerator: "CmdOrCtrl+V", selector: "paste:"
+          },
+          {
+            label: "Select All", accelerator: "CmdOrCtrl+A", selector: "selectAll:"
+          }
+      ]}
+    ];
+    electron.Menu.setApplicationMenu(electron.Menu.buildFromTemplate(template));
   }
+
+  app.on('ready', createWindow);
+  app.on('activate', createWindow);
+  app.on('window-all-closed', () => {
+    if (process.platform !== 'darwin') {
+      app.quit();
+    }
+  });
 });

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "electron-is-dev": "^0.3.0",
     "electron-notifications": "^1.0.0",
     "electron-updater": "^2.19.1",
+    "get-port": "^3.2.0",
     "highlight.js": "^9.12.0",
     "highlightjs-line-numbers.js": "^2.2.0",
     "node-http-server": "^8.1.2",

--- a/src/app.html
+++ b/src/app.html
@@ -28,5 +28,5 @@
   </nav>
 
   <router-view></router-view>
-  <span class="small baseroute-text">${environment.bpmnStudioClient.baseRoute}</span>
+  <span class="small baseroute-text">Connected to: ${environment.bpmnStudioClient.baseRoute}</span>
 </template>

--- a/src/app.html
+++ b/src/app.html
@@ -28,4 +28,5 @@
   </nav>
 
   <router-view></router-view>
+  <span class="small baseroute-text">${environment.bpmnStudioClient.baseRoute}</span>
 </template>

--- a/src/app.scss
+++ b/src/app.scss
@@ -5,3 +5,10 @@
   padding: 0 !important;
   margin-right: 5px;
 }
+
+.baseroute-text {
+  position: absolute;
+  left: 5px;
+  bottom: 5px;
+  color: #666666;
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,9 +1,11 @@
 import {Router, RouterConfiguration} from 'aurelia-router';
 import * as toastr from 'toastr';
+import environment from './environment';
 
 export class App {
 
   public router: Router;
+  public environment: any = environment;
 
   public configureRouter(config: RouterConfiguration, router: Router): void {
     this.router = router;

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,14 @@ export function configure(aurelia: Aurelia): void {
   aurelia.container.registerInstance('TokenRepository', tokenRepository);
 
   if (window.localStorage.getItem('baseRoute')) {
-    environment.bpmnStudioClient.baseRoute = window.localStorage.getItem('baseRoute');
+    const baseRoute: string = window.localStorage.getItem('baseRoute');
+    environment.bpmnStudioClient.baseRoute = baseRoute;
+    environment.processengine.routes.processes = `${baseRoute}/datastore/ProcessDef`;
+    environment.processengine.routes.iam = `${baseRoute}/iam`;
+    environment.processengine.routes.messageBus = `${baseRoute}/mb`;
+    environment.processengine.routes.processInstances = `${baseRoute}/datastore/Process`;
+    environment.processengine.routes.startProcess = `${baseRoute}/processengine/start`;
+    environment.processengine.routes.userTasks =  `${baseRoute}/datastore/UserTask`;
   }
 
   aurelia.use

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,12 @@ import {Aurelia} from 'aurelia-framework';
 import environment from './environment';
 import {TokenRepository} from './modules/token-repository/token.repository';
 
+if ((<any> window).nodeRequire) {
+  const ipcRenderer: any = (<any> window).nodeRequire('electron').ipcRenderer;
+  const newHost: string = ipcRenderer.sendSync('get_host');
+  localStorage.setItem('baseRoute', `http://${newHost}`);
+}
+
 export function configure(aurelia: Aurelia): void {
 
   const tokenRepository: TokenRepository = new TokenRepository();

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,16 +2,16 @@ import {Aurelia} from 'aurelia-framework';
 import environment from './environment';
 import {TokenRepository} from './modules/token-repository/token.repository';
 
-if ((<any> window).nodeRequire) {
-  const ipcRenderer: any = (<any> window).nodeRequire('electron').ipcRenderer;
-  const newHost: string = ipcRenderer.sendSync('get_host');
-  localStorage.setItem('baseRoute', `http://${newHost}`);
-}
-
 export function configure(aurelia: Aurelia): void {
 
   const tokenRepository: TokenRepository = new TokenRepository();
   aurelia.container.registerInstance('TokenRepository', tokenRepository);
+
+  if ((<any> window).nodeRequire) {
+    const ipcRenderer: any = (<any> window).nodeRequire('electron').ipcRenderer;
+    const newHost: string = ipcRenderer.sendSync('get_host');
+    localStorage.setItem('baseRoute', `http://${newHost}`);
+  }
 
   if (window.localStorage.getItem('baseRoute')) {
     const baseRoute: string = window.localStorage.getItem('baseRoute');


### PR DESCRIPTION
## What did you change?

**SEE [THIS DIFF](https://github.com/process-engine/bpmn-studio/pull/221/files?w=1) FOR A BETTER OVERVIEW!**
(in this diff, the lines where only the indentation changed are not shown)

I made the electron-version of the bpmn-studio automatically choose a free port to run the backend on, if 8000 is already in use.

This however overrides the "last used server"-functionality we currently have, because it works by setting the new backend-location as last used server before the bpm-studio starts.

I also added the current baseRoute as absolute-positioned label to the bottom-left of the application
![bildschirmfoto 2018-03-19 um 18 10 29](https://user-images.githubusercontent.com/20770029/37610776-d63e529c-2ba0-11e8-82a9-c98826b8d6b4.png)

Something like a server-history would be nice to improve this situation.

A lot of stuff in the electron.js was just inendet, because it needs to happen after the port was found to not create a race-condition. To see the changed files without the indention-changes, klick here:

https://github.com/process-engine/bpmn-studio/pull/221/files?w=1

## How can others test the changes?

- Start something on port 8000
- Start the electron-version of the bpmn-studio
- See how it still works
- Click the gear-icon and see how the server-port is not 8000 but something random

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
