### PR TITLE
Fix svg contentType.

### DIFF
--- a/bin/bpmn-studio.js
+++ b/bin/bpmn-studio.js
@@ -8,7 +8,7 @@ config.root = __dirname + '/..';
 config.contentType.woff2 = 'application/font-woff2';
 config.contentType.woff = 'application/font-woff';
 config.contentType.ttf = 'application/x-font-ttf';
-config.contentType.svg = 'image/svg';
+config.contentType.svg = 'image/svg+xml';
 
 server.deploy(config, (result) => {
   const url = `http://localhost:${result.config.port}/`;


### PR DESCRIPTION
'image/svg' is no valid contenttype. This bug broke svgs.
Fixes #223 
## What did you change?
Changed contenttype of svgs

## How can others test the changes?
Start application with 'npm start' without processengine running. With this fix you will see the gears svg, without it you won't.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [ ] I've mentioned all **PRs, which relate to this one**
