### PR TITLE
:sparkles: Change Default Port and Check for Port Argument

### DIFF
--- a/bin/bpmn-studio.js
+++ b/bin/bpmn-studio.js
@@ -4,11 +4,22 @@ const server = require('node-http-server');
 const config = new server.Config;
 const open = require('open');
 
+const defaultPort = 17290;
+
 config.root = __dirname + '/..';
 config.contentType.woff2 = 'application/font-woff2';
 config.contentType.woff = 'application/font-woff';
 config.contentType.ttf = 'application/x-font-ttf';
 config.contentType.svg = 'image/svg+xml';
+
+for (let count = 0; count < process.argv.length; count++) {
+  if (process.argv[count].includes('port=')) {
+    config.port = process.argv[count].substr(5);
+    break;
+  } else {
+    config.port = defaultPort;
+  }
+}
 
 server.deploy(config, (result) => {
   const url = `http://localhost:${result.config.port}/`;

--- a/bin/bpmn-studio.js
+++ b/bin/bpmn-studio.js
@@ -4,7 +4,6 @@ const server = require('node-http-server');
 const config = new server.Config;
 const open = require('open');
 const argv = require('minimist')(process.argv.slice(2));
-console.dir(argv);
 
 const defaultPort = 17290;
 

--- a/bin/bpmn-studio.js
+++ b/bin/bpmn-studio.js
@@ -12,14 +12,10 @@ config.contentType.woff = 'application/font-woff';
 config.contentType.ttf = 'application/x-font-ttf';
 config.contentType.svg = 'image/svg+xml';
 
-for (let count = 0; count < process.argv.length; count++) {
-  if (process.argv[count].includes('port=')) {
-    config.port = process.argv[count].substr(5);
-    break;
-  } else {
-    config.port = defaultPort;
-  }
-}
+const customPort = process.argv.find((entry) => {
+  return entry.includes('port=');
+});
+config.port = customPort ? customPort.substr(5) : defaultPort;
 
 server.deploy(config, (result) => {
   const url = `http://localhost:${result.config.port}/`;

--- a/bin/bpmn-studio.js
+++ b/bin/bpmn-studio.js
@@ -46,6 +46,7 @@ function _applicationPortIsValid(port) {
   const boundariesInvalid = (!lowerPortBoundValid || !upperPortBoundValid);
 
   if (boundariesInvalid) {
+    console.log("Port is not in the supported range [1000, 65535]. Using default port.\n");
     return false;
   }
 

--- a/bin/bpmn-studio.js
+++ b/bin/bpmn-studio.js
@@ -33,13 +33,13 @@ server.deploy(config, (result) => {
  */
 function _getPortFromArgv() {
   const customPort = process.argv.find((entry) => {
-    return entry.includes('port=');
+    return entry.includes('--port=');
   });
 
   if (!customPort) {
     return "";
   }
 
-  const portNumber = customPort.substr(5);
+  const portNumber = customPort.substr(7);
   return portNumber;
 }

--- a/bin/bpmn-studio.js
+++ b/bin/bpmn-studio.js
@@ -12,10 +12,8 @@ config.contentType.woff = 'application/font-woff';
 config.contentType.ttf = 'application/x-font-ttf';
 config.contentType.svg = 'image/svg+xml';
 
-const customPort = process.argv.find((entry) => {
-  return entry.includes('port=');
-});
-config.port = customPort ? customPort.substr(5) : defaultPort;
+const port = _getPortFromArgv();
+config.port = port ? port : defaultPort;
 
 server.deploy(config, (result) => {
   const url = `http://localhost:${result.config.port}/`;
@@ -23,3 +21,25 @@ server.deploy(config, (result) => {
   console.log(`Press CRTL+C to exit.`);
   open(url);
 });
+
+/**
+ * Get the port from the argv.
+ *
+ * Example:
+ *
+ * > npm start port=12345
+ *
+ * 'port=12345' will be parsed to 12345; this will be the port of this application.
+ */
+function _getPortFromArgv() {
+  const customPort = process.argv.find((entry) => {
+    return entry.includes('port=');
+  });
+
+  if (!customPort) {
+    return "";
+  }
+
+  const portNumber = customPort.substr(5);
+  return portNumber;
+}

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "get-port": "^3.2.0",
     "highlight.js": "^9.12.0",
     "highlightjs-line-numbers.js": "^2.2.0",
+    "minimist": "^1.2.0",
     "node-http-server": "^8.1.2",
     "open": "0.0.5",
     "proxy-polyfill": "^0.1.7",


### PR DESCRIPTION
## What did you change?

This PR adds the possibility to change the default start port of bpmn-studio-web.
Also you can start the BPMN-Studio with a custom port:

`npm start -- --port=4444`

alternative:

`npm start -- --port 4444`

We use `minimist` to parse the argv.

Closes #285 
## How can others test the changes?

- checkout the branch
- `npm run build`
- `npm start` (should use port 17290)
- `npm start port="CUSTOM_PORT"`

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
