### PR TITLE
:recycle: Add window-reload to window menu in Electron app

### DIFF
--- a/electron_app/electron.js
+++ b/electron_app/electron.js
@@ -191,36 +191,48 @@ getPort({port: 8000, host: '0.0.0.0'})
             type: "separator"
           },
           {
-            label: "Open Dev Tools", accelerator: "Command+Alt+I", click: function() {
-              mainWindow.webContents.toggleDevTools();
-            }
-          },
-          {
-            label: "Quit", accelerator: "Command+Q", click: function() {
-            app.quit();
-          }}
-      ]}, {
-      label: "Edit",
-      submenu: [
-          {
-            label: "Undo", accelerator: "CmdOrCtrl+Z", selector: "undo:"
-          },
-          {
-            label: "Redo", accelerator: "CmdOrCtrl+Shift+Z", selector: "redo:"
-          },
-          {
-            type: "separator"
-          },
-          {
-            label: "Copy", accelerator: "CmdOrCtrl+C", selector: "copy:"
-          },
-          {
-            label: "Paste", accelerator: "CmdOrCtrl+V", selector: "paste:"
-          },
-          {
-            label: "Select All", accelerator: "CmdOrCtrl+A", selector: "selectAll:"
+            label: "Quit", role: "quit"
           }
-      ]}
+      ]}, {
+        label: "Edit",
+        submenu: [
+            {
+              label: "Undo", accelerator: "CmdOrCtrl+Z", selector: "undo:"
+            },
+            {
+              label: "Redo", accelerator: "CmdOrCtrl+Shift+Z", selector: "redo:"
+            },
+            {
+              type: "separator"
+            },
+            {
+              label: "Copy", accelerator: "CmdOrCtrl+C", selector: "copy:"
+            },
+            {
+              label: "Paste", accelerator: "CmdOrCtrl+V", selector: "paste:"
+            },
+            {
+              label: "Select All", accelerator: "CmdOrCtrl+A", selector: "selectAll:"
+            }
+        ]}, {
+          label: "Window",
+          submenu: [
+            {
+              role: "minimize"
+            },
+            {
+              role: "close"
+            },
+            {
+              type: "separator"
+            },
+            {
+              role: "reload"
+            },
+            {
+              role: "toggledevtools"
+            }
+        ]}
     ];
 
     electron.Menu.setApplicationMenu(electron.Menu.buildFromTemplate(template));


### PR DESCRIPTION
## What did you change?

Behandelt #387 und fügt ein "Window"-Menü hinzu, dass die in #387 beschriebene Reload-Funktion beinhaltet.

## How can others test the changes?

- Electron App starten.
- Das Menü erscheint in der nativen Menüleiste.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
