### PR TITLE
🐛 Fix XML-View on large diagrams

### DIFF
--- a/src/modules/bpmn-xml-view/bpmn-xml-view.scss
+++ b/src/modules/bpmn-xml-view/bpmn-xml-view.scss
@@ -9,6 +9,7 @@ pre {
   word-break: unset;
   word-wrap: unset;
   background-color: unset;
+  display: grid;
 }
 
 .xml-view {

--- a/src/modules/bpmn-xml-view/bpmn-xml-view.scss
+++ b/src/modules/bpmn-xml-view/bpmn-xml-view.scss
@@ -9,7 +9,6 @@ pre {
   word-break: unset;
   word-wrap: unset;
   background-color: unset;
-  display: grid;
 }
 
 .xml-view {
@@ -42,5 +41,4 @@ td.hljs-ln-numbers {
 
 td.hljs-ln-code {
   padding-left: 10px;
-  white-space: pre !important;
 }

--- a/src/modules/process-solution-panel/process-solution-panel.scss
+++ b/src/modules/process-solution-panel/process-solution-panel.scss
@@ -11,7 +11,7 @@ body {
   width: 220px;
   border-right: 2px solid #dcdbdb;
   height: 100%;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .process-explorer__structure-item {


### PR DESCRIPTION
## What did you change?

This PR fixes the xml-view problem when loading large diagrams.

Closes #306  

## How can others test the changes?

- checkout the branch
- build the app
- open the app and navigate to the xml-view of a large process like `Reservierungsprozess.bpmn`

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
