### PR TITLE
🐛 Fix Bug With Resizing

### DIFF
--- a/src/modules/bpmn-io/bpmn-io.ts
+++ b/src/modules/bpmn-io/bpmn-io.ts
@@ -56,6 +56,7 @@ export class BpmnIo {
   private lastCanvasRight: number = 350;
   private lastPpWidth: number = this.ppWidth;
   private _ppHiddenBecauseLackOfSpace: boolean = false;
+  private _propertyPanelHasNoSpace: boolean = false;
 
   private toggleMinimap: boolean = false;
   private minimapToggle: any;
@@ -218,7 +219,7 @@ export class BpmnIo {
 
   public togglePanel(): void {
     if (this.toggled === true) {
-      if (this._ppHiddenBecauseLackOfSpace) {
+      if (this._propertyPanelHasNoSpace) {
         this.notificationService.showNotification(NotificationType.ERROR, 'There is not enough space for the property panel!');
         return;
       }
@@ -311,16 +312,29 @@ export class BpmnIo {
 
     const notEnoughSpaceForPp: boolean = this.maxWidth < this.minWidth;
     if (notEnoughSpaceForPp) {
-      this._ppHiddenBecauseLackOfSpace = true;
-      this.toggled = false;
-      this.togglePanel();
+      if (this._propertyPanelHasNoSpace) {
+        return;
+      }
+
+      this._propertyPanelHasNoSpace = true;
+
+      if (this.toggled === false) {
+        this._ppHiddenBecauseLackOfSpace = true;
+        this.togglePanel();
+      }
+
       return;
     }
 
-    if (this._ppHiddenBecauseLackOfSpace) {
-      this._ppHiddenBecauseLackOfSpace = false;
-      this.toggled = true;
-      this.togglePanel();
+    if (this._propertyPanelHasNoSpace) {
+      this._propertyPanelHasNoSpace = false;
+
+      if (this._ppHiddenBecauseLackOfSpace) {
+        this.toggled = true;
+        this._ppHiddenBecauseLackOfSpace = false;
+        this.togglePanel();
+      }
+
       return;
     }
 


### PR DESCRIPTION
## What did you change?

This PR fixes that the Property Panel will not get shown when it was hidden by the user. Changing the size of the browser does not matter.

Fixes #407 

## How can others test the changes?

This can **not** be tested with the electron app!

- Hide the Property Panel
- Make the browser window as small as possible
- Make it bigger
- Notice that the property panel will still be hidden

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
