### PR TITLE
:construction_worker: Add '--allow-same-version' Flag to npm version Command

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
       steps {
         sh('node --version')
         sh('npm run build')
-        sh("npm version ${full_electron_release_version_string} --no-git-tag-version --force")
+        sh("npm version ${full_electron_release_version_string} --allow-same-version --force --no-git-tag-version")
         stash(includes: 'node_modules/, scripts/, package.json', name: 'post_build')
       }
     }
@@ -174,7 +174,7 @@ pipeline {
 
             nodejs(configId: env.NPM_RC_FILE, nodeJSInstallationName: env.NODE_JS_VERSION) {
               sh('node --version')
-              sh("npm version ${publish_version} --no-git-tag-version --force")
+              sh("npm version ${publish_version} --allow-same-version --force --no-git-tag-version ")
               sh("npm publish --tag ${publish_tag} --ignore-scripts")
             }
           }


### PR DESCRIPTION
## What did you change?

Add the `--allow-same-version` Flag to `npm version` command.

This fixes a problem when Jenkins tries to set the version in the package.json, but its already set to the same version.

## How can others test the changes?


## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
