### PR TITLE
♻️Make Texts (Not) Selectable

### DIFF
--- a/src/modules/navbar/navbar.scss
+++ b/src/modules/navbar/navbar.scss
@@ -115,6 +115,10 @@ button {
   cursor: default;
 }
 
+.process-details-dropdown-menu {
+  user-select: text;
+}
+
 .menu__element {
   color: #5c5c5c;
   margin: 0 10px;

--- a/src/modules/navbar/navbar.scss
+++ b/src/modules/navbar/navbar.scss
@@ -3,6 +3,7 @@
   background-color: #f7f7f7;
   display: flex;
   border-bottom: 2px solid #dcdbdb;
+  user-select: none;
 }
 
 .bpmn-studio-navbar--macos {

--- a/src/modules/process-solution-panel/process-solution-panel.scss
+++ b/src/modules/process-solution-panel/process-solution-panel.scss
@@ -5,6 +5,7 @@
   border-right: 2px solid #dcdbdb;
   height: 100%;
   overflow-y: auto;
+  user-select: none;
 }
 
 .process-explorer__heading {

--- a/src/modules/property-panel/indextabs/extensions/extensions.html
+++ b/src/modules/property-panel/indextabs/extensions/extensions.html
@@ -1,8 +1,10 @@
 <template>
   <require from="./extensions.css"></require>
   <require from="../../styles/registers.css"></require>
+  <div class="index-tab">
     <compose repeat.for="section of sections"
       view-model=".${section.path}"
       view=".${section.path}.html"
       model.bind="{modeler: modeler, elementInPanel: elementInPanel}"></compose>
+  </div>
 </template>

--- a/src/modules/property-panel/indextabs/forms/forms.html
+++ b/src/modules/property-panel/indextabs/forms/forms.html
@@ -1,15 +1,15 @@
 <template>
   <require from="./forms.css"></require>
   <require from="../../styles/registers.css"></require>
-    <div>
-      <div repeat.for="section of sections">
-        <div if.bind="section.canHandleElement">
-          <compose
-            view-model=".${section.path}"
-            view=".${section.path}.html"
-            model.bind="{modeler: modeler, elementInPanel: elementInPanel}"
-            containerless></compose>
-        </div>
+  <div class="index-tab">
+    <div repeat.for="section of sections">
+      <div if.bind="section.canHandleElement">
+        <compose
+          view-model=".${section.path}"
+          view=".${section.path}.html"
+          model.bind="{modeler: modeler, elementInPanel: elementInPanel}"
+          containerless></compose>
       </div>
     </div>
+  </div>
 </template>

--- a/src/modules/property-panel/styles/registers.scss
+++ b/src/modules/property-panel/styles/registers.scss
@@ -4,4 +4,5 @@
 
 .index-tab {
   width: 100%;
+  user-select: none;
 }

--- a/src/modules/property-panel/styles/sections.scss
+++ b/src/modules/property-panel/styles/sections.scss
@@ -43,7 +43,6 @@
   padding: 5px 0;
 }
 
-
 .probs-table--details {
   margin-top: 20px;
 }


### PR DESCRIPTION
## What did you change?

This branch:

- Makes the texts in the navbar NOT selectable, makes the details selectable.
- Makes only the properties of the property-panel selectable.
- Makes so process-solution-panel not selectable.

## How can others test the changes?

Open a diagram in the detail-view and try to select the name of the index-tab of the property-panel for example.

## Issues

Closes #360

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
