### PR TITLE
Implement ctrl + s hotkey for saving

### DIFF
--- a/src/modules/bpmn-io/bpmn-io.ts
+++ b/src/modules/bpmn-io/bpmn-io.ts
@@ -1,4 +1,5 @@
 import * as bundle from '@process-engine/bpmn-js-custom-bundle';
+import { EventAggregator } from 'aurelia-event-aggregator';
 import {bindable, inject, observable} from 'aurelia-framework';
 import * as $ from 'jquery';
 import 'spectrum-colorpicker/spectrum';
@@ -15,7 +16,6 @@ import {ElementDistributeOptions,
       } from '../../contracts/index';
 import environment from '../../environment';
 import {NotificationService} from './../notification/notification.service';
-import { EventAggregator } from 'aurelia-event-aggregator';
 
 const sideBarRightSize: number = 35;
 

--- a/src/modules/bpmn-io/bpmn-io.ts
+++ b/src/modules/bpmn-io/bpmn-io.ts
@@ -288,26 +288,35 @@ export class BpmnIo {
   }
 
   /**
-   * Handles a keydown event and saves the diagramm, if the user presses a ctrl + s key combination.
-   * If using macos, this combination will be cmd + s.
+   * Handles a key down event and saves the diagram, if the user presses a CRTL + s key combination.
    *
-   * @param event passed key event.
+   * If using macOS, this combination will be CMD + s.
+   *
+   * Saving is triggered by emitting @see environment.events.processDefDetail.saveDiagram
+   *
+   * @param event Passed key event.
+   * @return void
    */
   private _saveHotkeyEventHandler = (event: KeyboardEvent): void  => {
 
-    // On mac os the 'common control key' is the meta instead of the control key. So we need to find
+    // On macOS the 'common control key' is the meta instead of the control key. So we need to find
     // out if on a mac, the meta key instead of the control key is pressed.
     const macRegex: RegExp = /.*mac*./i;
     const currentPlattform: string = navigator.platform;
     const currentPlattformIsMac: boolean = macRegex.test(currentPlattform);
     const metaKeyIsPressed: boolean = currentPlattformIsMac ? event.metaKey : event.ctrlKey;
 
-    // If both keys, meta and s, are pressed, save the diagram.
+    /*
+     * If both keys (meta and s) are pressed, save the diagram.
+     * A diagram is saved, by throwing a saveDiagram event.
+     *
+     * @see environment.events.processDefDetail.saveDiagram
+     */
     const sKeyIsPressed: boolean = event.key === 's';
     const userWantsToSave: boolean = metaKeyIsPressed && sKeyIsPressed;
 
     if (userWantsToSave) {
-      // Prevent the browser from handling the default action for ctrl + s.
+      // Prevent the browser from handling the default action for CTRL + s.
       event.preventDefault();
       this._eventAggregator.publish(environment.events.processDefDetail.saveDiagram);
     }

--- a/src/modules/bpmn-io/bpmn-io.ts
+++ b/src/modules/bpmn-io/bpmn-io.ts
@@ -22,6 +22,7 @@ const sideBarRightSize: number = 35;
 
 @inject('NotificationService', EventAggregator)
 export class BpmnIo {
+  // TODO: Refactor Private Member Names; Ref: //github.com/process-engine/bpmn-studio/issues/463
   private toggled: boolean = false;
   private toggleButtonPropertyPanel: HTMLButtonElement;
   private resizeButton: HTMLButtonElement;
@@ -62,7 +63,7 @@ export class BpmnIo {
    * To get more control over certain elements in the palette it would be nice to have
    * an aurelia-component for handling the logic behind it.
    *
-   * https://github.com/process-engine/bpmn-studio/issues/455
+   * TODO: https://github.com/process-engine/bpmn-studio/issues/455
    */
   public paletteContainer: HTMLDivElement;
 
@@ -93,6 +94,8 @@ export class BpmnIo {
     const minimapArea: any = this.canvasModel.getElementsByClassName('djs-minimap-map')[0];
     this.minimapToggle = this.canvasModel.getElementsByClassName('djs-minimap-toggle')[0];
 
+    // TODO: Refactor to CSS classes; Ref: https://github.com/process-engine/bpmn-studio/issues/462
+    //  Styling for Minimap {{{ //
     minimapArea.style.width = '350px';
     minimapArea.style.height = '200px';
     minimapViewport.style.fill = 'rgba(0, 208, 255, 0.13)';
@@ -106,6 +109,7 @@ export class BpmnIo {
     this.hideMinimap.textContent = 'Hide Minimap';
     this.minimapToggle.appendChild(this.hideMinimap);
     this.minimapToggle.addEventListener('click', this.toggleMinimapFunction);
+    //  }}} Styling for Minimap //
 
     window.addEventListener('resize', this.resizeEventHandler);
 

--- a/src/modules/bpmn-io/bpmn-io.ts
+++ b/src/modules/bpmn-io/bpmn-io.ts
@@ -1,9 +1,10 @@
 import * as bundle from '@process-engine/bpmn-js-custom-bundle';
-import { EventAggregator } from 'aurelia-event-aggregator';
+
+import {EventAggregator} from 'aurelia-event-aggregator';
 import {bindable, inject, observable} from 'aurelia-framework';
 import * as $ from 'jquery';
 import 'spectrum-colorpicker/spectrum';
-import {setTimeout} from 'timers';
+
 import {ElementDistributeOptions,
         IBpmnFunction,
         IBpmnModeler,


### PR DESCRIPTION
## What did you change?
I implemented the requested `ctrl + s` (on mac `cmd + s`) hotkey for saving a diagramm to the database. 

I wonder if I also should implement a "quick export" to a bpmn file like the camunda modeler uses (which is way more convenient for my personal use). 

## How can others test the changes?
* Open or create a new process
* Hit `ctrl + s` (or `cmd + s` on mac). 

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
