### PR TITLE
♻️Use template instead of div for repeaters

### DIFF
--- a/src/modules/form-widget/form-widget.html
+++ b/src/modules/form-widget/form-widget.html
@@ -1,8 +1,8 @@
 <template>
   <require from="./form-widget.css"></require>
-  <div if.bind="widget">
+  <template if.bind="widget">
     <template repeat.for="field of widget.fields">
       <compose view-model="../dynamic-ui-${getFieldControl(field)}-element/dynamic-ui-${getFieldControl(field)}-element" model.bind="field"></compose>
     </template>  
-  </div>          
+  </template>          
 </template>

--- a/src/modules/form-widget/form-widget.html
+++ b/src/modules/form-widget/form-widget.html
@@ -1,8 +1,8 @@
 <template>
   <require from="./form-widget.css"></require>
   <div if.bind="widget">
-    <div repeat.for="field of widget.fields">
+    <template repeat.for="field of widget.fields">
       <compose view-model="../dynamic-ui-${getFieldControl(field)}-element/dynamic-ui-${getFieldControl(field)}-element" model.bind="field"></compose>
-    </div>  
+    </template>  
   </div>          
 </template>

--- a/src/modules/import-process-button/import-process-button.html
+++ b/src/modules/import-process-button/import-process-button.html
@@ -7,7 +7,7 @@
     <i class="fa fa-upload"></i>
   </button>
 
-  <div if.bind="chooseOptions">
+  <template if.bind="chooseOptions">
     <div class="modal fade in show" tabindex="-1" role="dialog">
       <div class="modal-dialog" role="document">
         <div class="modal-content">
@@ -25,5 +25,5 @@
       </div>
     </div>
     <div class="modal-backdrop fade in"></div>
-  </div>
+  </template>
 </template>

--- a/src/modules/navbar/navbar.html
+++ b/src/modules/navbar/navbar.html
@@ -57,16 +57,16 @@
       </div>
     </div>
     <div class="menu-bar__menu menu-bar__menu--right">
-      <div if.bind="showTools">
+      <template if.bind="showTools">
         <button class="menu-bar__menu-center--action-button menu-bar__menu-center--back-button back-button" click.delegate="navigateBack()" title="Navigate back">
           <i class="fa fa-arrow-circle-left"></i>
         </button>
-      </div>
-      <div if.bind="showTools">
+      </template>
+      <template if.bind="showTools">
         <button class="menu-bar__menu-center--action-button" ref="saveButton" click.delegate="saveDiagram()" disabled.bind="disableSaveButton" title="Save Diagram">
           <i class="fa fa-save"></i>
         </button>
-      </div>
+      </template>
       <div class="btn-group" if.bind="showTools">
         <button class="menu-bar__menu-center--action-button dropdown-toggle" title="Export Diagram" ref="exportButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           <i ref="exportIcon" class="fa fa-upload"></i>

--- a/src/modules/process-list/process-list.html
+++ b/src/modules/process-list/process-list.html
@@ -2,7 +2,7 @@
   <require from="./process-list.css"></require>
   <div class="process-list">
     <div class="container process-list-container">
-      <div if.bind="instances && instances.length > 0">
+      <template if.bind="instances && instances.length > 0">
         <table class="table table-striped table-bordered">
           <tr>
             <th>ProcessDefinitionName</th>
@@ -23,15 +23,15 @@
             <td><a href="#/process/${instance.id}/task">${instance.status}</a></td>
           </tr>
         </table>
-      </div>
+      </template>
       <div class="col-md-12 col-xs-12 pagination" show.bind="instances && instances.length > 0">
         <aubs-pagination page-size.bind="pageSize" total-items.bind="totalItems" current-page.bind="currentPage"
           boundary-links.bind="true">
         </aubs-pagination>
       </div>
-      <div if.bind="succesfullRequested && (!instances || instances.length === 0)">
+      <template if.bind="succesfullRequested && (!instances || instances.length === 0)">
         <h3>No process instances found</h3>
-      </div>
+      </template>
     </div>
     <div show.bind="!succesfullRequested" class="container">
       <img src="src/resources/images/gears.svg" class="loading-spinner">

--- a/src/modules/processdef-list/processdef-list.html
+++ b/src/modules/processdef-list/processdef-list.html
@@ -6,7 +6,7 @@
   <div class="process-def-list">
     <!-- Modal dialog for importing BPMN diagrams {{{ -->
     <!-- Import Dialog {{{ -->
-    <div if.bind="showDiagramNameDialog">
+    <template if.bind="showDiagramNameDialog">
       <div class="modal fade in show" tabindex="-1" role="dialog">
         <div class="modal-dialog" role="document">
           <div class="modal-content">
@@ -44,10 +44,10 @@
       <!-- Modal Gray Bacground {{{ -->
       <div class="modal-backdrop fade in"></div>
       <!-- }}} Modal Gray Bacground -->
-    </div>
+    </template>
     <!-- }}} Import Dialog -->
     <!-- Overwrite Dialog {{{ -->
-    <div if.bind="showOverwriteDialog">
+    <template if.bind="showOverwriteDialog">
       <div class="modal  fade in show" tabindex="-1" role="dialog">
         <div class="modal-dialog" role="document">
           <div class="modal-content">
@@ -70,7 +70,7 @@
       <!-- Modal Gray Bacground {{{ -->
       <div class="modal-backdrop fade in"></div>
       <!-- }}} Modal Gray Bacground -->
-    </div>
+    </template>
     <!-- }}} Overwrite Dialog -->
     <!-- }}} Modal dialog for importing BPMN diagrams -->
     <div class="processdef-list-container">

--- a/src/modules/processdef-start/processdef-start.html
+++ b/src/modules/processdef-start/processdef-start.html
@@ -3,15 +3,15 @@
   <require from="../dynamic-ui-wrapper/dynamic-ui-wrapper"></require>
   <div class="start-process">
     <div class="container start-process-container">
-      <div if.bind="process">
+      <template if.bind="process">
         <h3>Start process: ${process.name}</h3>
 
         <dynamic-ui-wrapper view-model.ref="dynamicUiWrapper"></dynamic-ui-wrapper>
-      </div>
+      </template>
 
-      <div if.bind="!process">
+      <template if.bind="!process">
         <h3>Process not found</h3>
-      </div>
+      </template>
     </div>
   </div>
 </template>

--- a/src/modules/property-panel/indextabs/forms/forms.html
+++ b/src/modules/property-panel/indextabs/forms/forms.html
@@ -2,14 +2,14 @@
   <require from="./forms.css"></require>
   <require from="../../styles/registers.css"></require>
   <div class="index-tab">
-    <div repeat.for="section of sections">
-      <div if.bind="section.canHandleElement">
+    <template repeat.for="section of sections">
+      <template if.bind="section.canHandleElement">
         <compose
           view-model=".${section.path}"
           view=".${section.path}.html"
           model.bind="{modeler: modeler, elementInPanel: elementInPanel}"
           containerless></compose>
-      </div>
-    </div>
+      </template>
+    </template>
   </div>
 </template>

--- a/src/modules/property-panel/indextabs/forms/sections/basics/basics.html
+++ b/src/modules/property-panel/indextabs/forms/sections/basics/basics.html
@@ -40,6 +40,13 @@
           <td>
             <input type="text" class="props-input" id="formId" value.bind="selectedForm.id & validateOnChange" placeholder="ID" change.delegate="updateId()">
           </td>
+          <td>	
+            <div show.bind="isFormSelected">	
+              <div if.bind="validationError">	
+                <span class="glyphicon glyphicon-remove"></span>	
+              </div>	
+            </div>	
+          </td>
         </tr>
         <tr>
           <th>Type</th>

--- a/src/modules/property-panel/indextabs/forms/sections/basics/basics.html
+++ b/src/modules/property-panel/indextabs/forms/sections/basics/basics.html
@@ -42,9 +42,9 @@
           </td>
           <td>	
             <div show.bind="isFormSelected">	
-              <div if.bind="validationError">	
+              <template if.bind="validationError">	
                 <span class="glyphicon glyphicon-remove"></span>	
-              </div>	
+              </template>	
             </div>	
           </td>
         </tr>

--- a/src/modules/property-panel/indextabs/forms/sections/basics/basics.html
+++ b/src/modules/property-panel/indextabs/forms/sections/basics/basics.html
@@ -40,20 +40,6 @@
           <td>
             <input type="text" class="props-input" id="formId" value.bind="selectedForm.id & validateOnChange" placeholder="ID" change.delegate="updateId()">
           </td>
-          <td>
-            <div show.bind="isFormSelected">
-              <div class="id-tooltip-error" if.bind="validationError">
-                <div class="tooltip">
-                  <span class="glyphicon glyphicon-remove"></span>
-                  <span class="tooltiptext">
-                    <div repeat.for="error of validationController.errors">
-                      ${error}
-                    </div>
-                  </span>
-                </div>
-              </div>
-            </div>
-          </td>
         </tr>
         <tr>
           <th>Type</th>

--- a/src/modules/property-panel/indextabs/general/general.html
+++ b/src/modules/property-panel/indextabs/general/general.html
@@ -2,14 +2,14 @@
   <require from="./general.css"></require>
   <require from="../../styles/registers.css"></require>
   <div class="index-tab">
-    <div repeat.for="section of sections">
-      <div if.bind="section.isSuitableForElement(elementInPanel)">
+    <template repeat.for="section of sections">
+      <template if.bind="section.isSuitableForElement(elementInPanel)">
         <compose
           view-model=".${section.path}"
           view=".${section.path}.html"
           model.bind="{modeler: modeler, elementInPanel: elementInPanel}"
           containerless></compose>
-      </div>
-    </div>
+      </template>
+    </template>
   </div>
 </template>

--- a/src/modules/property-panel/indextabs/general/sections/basics/basics.html
+++ b/src/modules/property-panel/indextabs/general/sections/basics/basics.html
@@ -11,9 +11,9 @@
             <input type="text" class="props-input" id="elementId" value.bind="businessObjInPanel.id & validateOnChange" change.delegate="updateId()">
           </td>
           <td>	
-            <div if.bind="validationError">	
+            <template if.bind="validationError">	
               <span class="glyphicon glyphicon-remove"></span>	
-            </div>	
+            </template>	
           </td>
         </tr>
         <tr>

--- a/src/modules/property-panel/indextabs/general/sections/basics/basics.html
+++ b/src/modules/property-panel/indextabs/general/sections/basics/basics.html
@@ -10,18 +10,6 @@
           <td>
             <input type="text" class="props-input" id="elementId" value.bind="businessObjInPanel.id & validateOnChange" change.delegate="updateId()">
           </td>
-          <td>
-            <div class="id-tooltip-error" if.bind="validationError">
-              <div class="tooltip">
-                <span class="glyphicon glyphicon-remove"></span>
-                <span class="tooltiptext">
-                  <div repeat.for="error of validationController.errors">
-                    ${error}
-                  </div>
-                </span>
-              </div>
-            </div>
-          </td>
         </tr>
         <tr>
           <th>Name</th>

--- a/src/modules/property-panel/indextabs/general/sections/basics/basics.html
+++ b/src/modules/property-panel/indextabs/general/sections/basics/basics.html
@@ -10,6 +10,11 @@
           <td>
             <input type="text" class="props-input" id="elementId" value.bind="businessObjInPanel.id & validateOnChange" change.delegate="updateId()">
           </td>
+          <td>	
+            <div if.bind="validationError">	
+              <span class="glyphicon glyphicon-remove"></span>	
+            </div>	
+          </td>
         </tr>
         <tr>
           <th>Name</th>

--- a/src/modules/property-panel/indextabs/general/sections/basics/basics.scss
+++ b/src/modules/property-panel/indextabs/general/sections/basics/basics.scss
@@ -1,4 +1,10 @@
 .glyphicon-remove {
+  position: relative;	
+  display: inline-block;
+  margin-left: 5px;	
+  margin-top: 5px;
+  z-index: 0;	
+  opacity: 1;	  
   color: red;
   font-size: 15px;
 }

--- a/src/modules/property-panel/indextabs/general/sections/basics/basics.scss
+++ b/src/modules/property-panel/indextabs/general/sections/basics/basics.scss
@@ -1,32 +1,3 @@
-.tooltip {
-  position: relative;
-  display: inline-block;
-  opacity: 1;
-  margin-left: 5px;
-  z-index: 0;
-
-  .tooltiptext {
-    visibility: hidden;
-    width: 120px;
-    background-color: black;
-    color: #fff;
-    text-align: center;
-    padding: 5px 0;
-    border-radius: 6px;
-
-    position: absolute;
-    z-index: 1;
-    top: -5px;
-    right: 105%;
-  }
-
-  &:hover {
-    .tooltiptext {
-      visibility: visible;
-    }
-  }
-}
-
 .glyphicon-remove {
   color: red;
   font-size: 15px;

--- a/src/modules/property-panel/indextabs/general/sections/basics/basics.ts
+++ b/src/modules/property-panel/indextabs/general/sections/basics/basics.ts
@@ -19,13 +19,13 @@ export class BasicsSection implements ISection {
   public canHandleElement: boolean = true;
   public businessObjInPanel: IModdleElement;
   public elementDocumentation: string;
+  public validationError: boolean = false;
 
   private _modeling: IModeling;
   private _modeler: IBpmnModeler;
   private _bpmnModdle: IBpmnModdle;
   private _elementInPanel: IShape;
   private _previousProcessRefId: string;
-  private _validationError: boolean = false;
   private _validationController: ValidationController;
 
   constructor(controller?: ValidationController) {
@@ -33,7 +33,7 @@ export class BasicsSection implements ISection {
   }
 
   public activate(model: IPageModel): void {
-    if (this._validationError) {
+    if (this.validationError) {
       this.businessObjInPanel.id = this._previousProcessRefId;
       this._validationController.validate();
     }
@@ -56,7 +56,7 @@ export class BasicsSection implements ISection {
   }
 
   public detached(): void {
-    if (!this._validationError) {
+    if (!this.validationError) {
       return;
     }
     this.businessObjInPanel.id = this._previousProcessRefId;
@@ -119,13 +119,13 @@ export class BasicsSection implements ISection {
       return;
     }
 
-    this._validationError = false;
+    this.validationError = false;
     for (const result of event.results) {
       if (result.rule.property.displayName !== 'elementId') {
         continue;
       }
       if (result.valid === false) {
-        this._validationError = true;
+        this.validationError = true;
         document.getElementById(result.rule.property.displayName).style.border = '2px solid red';
       } else {
         document.getElementById(result.rule.property.displayName).style.border = '';

--- a/src/modules/property-panel/indextabs/general/sections/pool/pool.html
+++ b/src/modules/property-panel/indextabs/general/sections/pool/pool.html
@@ -17,9 +17,9 @@
             <input type="text" id="processId" class="props-input" value.bind="businessObjInPanel.processRef.id & validateOnChange" change.delegate="validate()">
           </td>
           <td>	
-            <div if.bind="validationError">	
+            <template if.bind="validationError">	
               <span class="glyphicon glyphicon-remove"></span>	
-            </div>	
+            </template>	
           </td>
         </tr>
         <tr>

--- a/src/modules/property-panel/indextabs/general/sections/pool/pool.html
+++ b/src/modules/property-panel/indextabs/general/sections/pool/pool.html
@@ -16,18 +16,6 @@
           <td>
             <input type="text" id="processId" class="props-input" value.bind="businessObjInPanel.processRef.id & validateOnChange" change.delegate="validate()">
           </td>
-          <td>
-            <div class="id-tooltip-error" if.bind="validationError">
-              <div class="tooltip">
-                <span class="glyphicon glyphicon-remove"></span>
-                <span class="tooltiptext">
-                  <div repeat.for="error of validationController.errors">
-                    ${error}
-                  </div>
-                </span>
-              </div>
-            </div>
-          </td>
         </tr>
         <tr>
           <th>Name</th>

--- a/src/modules/property-panel/indextabs/general/sections/pool/pool.html
+++ b/src/modules/property-panel/indextabs/general/sections/pool/pool.html
@@ -16,6 +16,11 @@
           <td>
             <input type="text" id="processId" class="props-input" value.bind="businessObjInPanel.processRef.id & validateOnChange" change.delegate="validate()">
           </td>
+          <td>	
+            <div if.bind="validationError">	
+              <span class="glyphicon glyphicon-remove"></span>	
+            </div>	
+          </td>
         </tr>
         <tr>
           <th>Name</th>

--- a/src/modules/property-panel/property-panel.html
+++ b/src/modules/property-panel/property-panel.html
@@ -1,12 +1,12 @@
 <template>
   <require from="./property-panel.css"></require>
   <div class="property-panel">
-    <div repeat.for="indextab of indextabs">
+    <template repeat.for="indextab of indextabs">
       <compose view-model=".${indextab.path}"
         view=".${indextab.path}.html"
         model.bind="{modeler: modeler, elementInPanel: elementInPanel}"
         if.bind="indextab.canHandleElement"
         containerless></compose>
-    </div>
+    </template>
   </div>
 </template>

--- a/src/modules/status-bar/status-bar.html
+++ b/src/modules/status-bar/status-bar.html
@@ -11,14 +11,14 @@
     </div>
     <div class="status-bar__center-bar"></div>
     <div class="status-bar__right-bar">
-      <div if.bind="showXMLButton">
+      <template if.bind="showXMLButton">
         <a class="status-bar__element" click.delegate="toggleXMLView()" if.bind="!xmlIsShown">
           <i class="fa fa-file-code-o"></i> Show XML
         </a>
         <a class="status-bar__element" click.delegate="toggleXMLView()" if.bind="xmlIsShown">
           <i class="fa fa-file-code-o"></i> Show Diagram
         </a>
-      </div>
+      </template>
       <a class="status-bar__element" click.delegate="navigateToSettings()">
         <i class="fa fa-wrench"></i> Settings
       </a>

--- a/src/modules/task-dynamic-ui/task-dynamic-ui.html
+++ b/src/modules/task-dynamic-ui/task-dynamic-ui.html
@@ -4,14 +4,14 @@
 
   <div class="container">
 
-    <div if.bind="userTask">
+    <template if.bind="userTask">
       <h3>${userTask.title}</h3>
-    </div>
+    </template>
     <dynamic-ui-wrapper view-model.ref="dynamicUiWrapper"></dynamic-ui-wrapper>
 
-    <div if.bind="!userTask">
+    <template if.bind="!userTask">
       <h3>UserTask not found</h3>
-    </div>
+    </template>
 
   </div>
 

--- a/src/modules/task-list/task-list.html
+++ b/src/modules/task-list/task-list.html
@@ -28,9 +28,9 @@
           </aubs-pagination>
         </div>
       </div>
-      <div if.bind="succesfullRequested && (!tasks || tasks.length === 0)">
+      <template if.bind="succesfullRequested && (!tasks || tasks.length === 0)">
         <h3>No tasks found</h3>
-      </div>
+      </template>
       <div show.bind="!succesfullRequested" class="container">
         <img src="src/resources/images/gears.svg" class="loading-spinner">
       </div>


### PR DESCRIPTION
## What did you change?

This PR fixes #457 and removes unused tooltips from html.
Also it uses "template" instead of "div" for if.bind.

## How can others test the changes?

- checkout the branch
- `npm run build`
- `npm run electron-start-dev`

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
