### PR TITLE
Add default cursor to color dropdown and improve color picker buttons

### DIFF
--- a/src/modules/diagram-tools-right/diagram-tools-right.html
+++ b/src/modules/diagram-tools-right/diagram-tools-right.html
@@ -5,7 +5,7 @@
       <a class="dropdown-toggle tool" title="Color Element" data-toggle="dropdown" click.delegate="updateCustomColors()">
         <i class="fa fa-eyedropper"></i>
       </a>
-      <ul class="dropdown-menu pull-left">
+      <ul class="dropdown-menu pull-left color-dropdown">
         <li><a click.delegate="setColorRed()"><i class="glyphicon glyphicon-stop red"></i> Red</a></li>
         <li><a click.delegate="setColorBlue()"><i class="glyphicon glyphicon-stop blue"></i> Blue</a></li>
         <li><a click.delegate="setColorGreen()"><i class="glyphicon glyphicon-stop green"></i> Green</a></li>

--- a/src/modules/diagram-tools-right/diagram-tools-right.scss
+++ b/src/modules/diagram-tools-right/diagram-tools-right.scss
@@ -35,7 +35,6 @@
   margin: 0;
   overflow: hidden;
   cursor: pointer;
-  padding: 0;
   display: inline-block;
   border: 0;
   background: 0;

--- a/src/modules/diagram-tools-right/diagram-tools-right.scss
+++ b/src/modules/diagram-tools-right/diagram-tools-right.scss
@@ -26,3 +26,8 @@
   color: black;
   box-shadow: none !important; //Overwrite Bootstrap btn-group class combination
 }
+
+.color-dropdown {
+  cursor: default;
+}
+

--- a/src/modules/diagram-tools-right/diagram-tools-right.scss
+++ b/src/modules/diagram-tools-right/diagram-tools-right.scss
@@ -31,3 +31,14 @@
   cursor: default;
 }
 
+.sp-replacer {
+  margin: 0;
+  overflow: hidden;
+  cursor: pointer;
+  padding: 0;
+  display: inline-block;
+  border: 0;
+  background: 0;
+  color: #333;
+  vertical-align: middle;
+}


### PR DESCRIPTION
## What did you change?

This PR fixes #441 and improves color picker button-style.

before:
![bildschirmfoto 2018-06-04 um 15 10 27](https://user-images.githubusercontent.com/17065920/40919531-05c65c3a-680a-11e8-8fda-b981eaafe444.png)

after:
![bildschirmfoto 2018-06-04 um 15 10 42](https://user-images.githubusercontent.com/17065920/40919543-0c12bdd6-680a-11e8-837a-41d8ce771205.png)


## How can others test the changes?

- checkout the branch
- `npm run build`
- `npm run electron-start-dev`
- open detail view of a process
- open the color dropdown

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
