### PR TITLE
:sparkles: Navigate to the Starting View After Process Execution Ends

### DIFF
--- a/src/modules/processdef-start/processdef-start.ts
+++ b/src/modules/processdef-start/processdef-start.ts
@@ -9,10 +9,11 @@ import {NotificationService} from './../notification/notification.service';
 
 @inject('ProcessEngineService', EventAggregator, Router, 'BpmnStudioClient', 'NotificationService')
 export class ProcessDefStart {
+  public dynamicUiWrapper: DynamicUiWrapper;
+
   private _processEngineService: IProcessEngineService;
   private _notificationService: NotificationService;
   private _eventAggregator: EventAggregator;
-  private _dynamicUiWrapper: DynamicUiWrapper;
   private _subscriptions: Array<Subscription>;
   private _processDefId: string;
   private _process: IProcessDefEntity;
@@ -44,7 +45,7 @@ export class ProcessDefStart {
         this._refreshProcess();
       }),
       this._eventAggregator.subscribe('render-dynamic-ui', (message: IUserTaskConfig) => {
-        this._dynamicUiWrapper.currentConfig = message;
+        this.dynamicUiWrapper.currentConfig = message;
       }),
       this._eventAggregator.subscribe('closed-process', (message: any) => {
         this._router.navigateBack();

--- a/src/modules/processdef-start/processdef-start.ts
+++ b/src/modules/processdef-start/processdef-start.ts
@@ -32,12 +32,21 @@ export class ProcessDefStart {
     this._notificationService = notificationService;
   }
 
+  // TODO: Add a usefull comment here; what does it do? what is it good for? when is this invoked?
   public async activate(routeParameters: {processDefId: string}): Promise<void> {
     this._processDefId = routeParameters.processDefId;
     await this._refreshProcess();
+    
+    /*
+     * Start the processinstance in the connected ProcessEngine.
+     */
     this._startProcess();
 
     this._subscriptions = [
+      /*
+       * If the user this login/logout we need to refresh the process; 
+       * mainly due to a possible the change in access rights.
+       */
       this._eventAggregator.subscribe(AuthenticationStateEvent.LOGIN, () => {
         this._refreshProcess();
       }),
@@ -47,6 +56,11 @@ export class ProcessDefStart {
       this._eventAggregator.subscribe('render-dynamic-ui', (message: IUserTaskConfig) => {
         this.dynamicUiWrapper.currentConfig = message;
       }),
+      /*
+       * The closed-process event is thrown at the end of a process run;
+       * we then use the router to navigate to the prvious view-- this could be the
+       * design view-- but any other last view will work as well.
+       */
       this._eventAggregator.subscribe('closed-process', (message: any) => {
         this._router.navigateBack();
       }),
@@ -76,5 +90,4 @@ export class ProcessDefStart {
   private _startProcess(): void {
     this._bpmnStudioClient.startProcessByKey(this.process.key);
   }
-
 }

--- a/src/modules/processdef-start/processdef-start.ts
+++ b/src/modules/processdef-start/processdef-start.ts
@@ -74,7 +74,7 @@ export class ProcessDefStart {
         this.dynamicUiWrapper.currentConfig = message;
       }),
       this.eventAggregator.subscribe('closed-process', (message: any) => {
-        this.router.navigateToRoute('processdef-list', { page: 1 });
+        this.router.navigate(`/processdef/${this.processDefId}/detail`);
       }),
     ];
   }

--- a/src/modules/processdef-start/processdef-start.ts
+++ b/src/modules/processdef-start/processdef-start.ts
@@ -32,7 +32,7 @@ export class ProcessDefStart {
     this._notificationService = notificationService;
   }
 
-  private async activate(routeParameters: {processDefId: string}): Promise<void> {
+  public async activate(routeParameters: {processDefId: string}): Promise<void> {
     this._processDefId = routeParameters.processDefId;
     await this._refreshProcess();
     this._startProcess();

--- a/src/modules/processdef-start/processdef-start.ts
+++ b/src/modules/processdef-start/processdef-start.ts
@@ -74,7 +74,7 @@ export class ProcessDefStart {
         this.dynamicUiWrapper.currentConfig = message;
       }),
       this.eventAggregator.subscribe('closed-process', (message: any) => {
-        this.router.navigate(`/processdef/${this.processDefId}/detail`);
+        this.router.navigateBack();
       }),
     ];
   }

--- a/src/modules/processdef-start/processdef-start.ts
+++ b/src/modules/processdef-start/processdef-start.ts
@@ -9,32 +9,51 @@ import {NotificationService} from './../notification/notification.service';
 
 @inject('ProcessEngineService', EventAggregator, Router, 'BpmnStudioClient', 'NotificationService')
 export class ProcessDefStart {
-  public solutionExplorerIsShown: boolean = false;
-
-  private processEngineService: IProcessEngineService;
-  private notificationService: NotificationService;
-  private eventAggregator: EventAggregator;
-  private dynamicUiWrapper: DynamicUiWrapper;
-  private subscriptions: Array<Subscription>;
-  private processDefId: string;
+  private _processEngineService: IProcessEngineService;
+  private _notificationService: NotificationService;
+  private _eventAggregator: EventAggregator;
+  private _dynamicUiWrapper: DynamicUiWrapper;
+  private _subscriptions: Array<Subscription>;
+  private _processDefId: string;
   private _process: IProcessDefEntity;
-  private router: Router;
-  private bpmnStudioClient: BpmnStudioClient;
+  private _router: Router;
+  private _bpmnStudioClient: BpmnStudioClient;
 
   constructor(processEngineService: IProcessEngineService,
               eventAggregator: EventAggregator,
               router: Router,
               bpmnStudioClient: BpmnStudioClient,
               notificationService: NotificationService) {
-    this.processEngineService = processEngineService;
-    this.eventAggregator = eventAggregator;
-    this.router = router;
-    this.bpmnStudioClient = bpmnStudioClient;
-    this.notificationService = notificationService;
+    this._processEngineService = processEngineService;
+    this._eventAggregator = eventAggregator;
+    this._router = router;
+    this._bpmnStudioClient = bpmnStudioClient;
+    this._notificationService = notificationService;
+  }
+
+  private async activate(routeParameters: {processDefId: string}): Promise<void> {
+    this._processDefId = routeParameters.processDefId;
+    await this._refreshProcess();
+    this._startProcess();
+
+    this._subscriptions = [
+      this._eventAggregator.subscribe(AuthenticationStateEvent.LOGIN, () => {
+        this._refreshProcess();
+      }),
+      this._eventAggregator.subscribe(AuthenticationStateEvent.LOGOUT, () => {
+        this._refreshProcess();
+      }),
+      this._eventAggregator.subscribe('render-dynamic-ui', (message: IUserTaskConfig) => {
+        this._dynamicUiWrapper.currentConfig = message;
+      }),
+      this._eventAggregator.subscribe('closed-process', (message: any) => {
+        this._router.navigateBack();
+      }),
+    ];
   }
 
   public detached(): void {
-    for (const subscription of this.subscriptions) {
+    for (const subscription of this._subscriptions) {
       subscription.dispose();
     }
   }
@@ -44,48 +63,17 @@ export class ProcessDefStart {
     return this._process;
   }
 
-  public startProcess(): void {
-    this.bpmnStudioClient.startProcessByKey(this.process.key);
-  }
-
-  // TODO: Delete this! It shouldn't be here.
-  public toggleSolutionExplorer(): void {
-    this.solutionExplorerIsShown = !this.solutionExplorerIsShown;
-  }
-
-  // TODO: Delete this! It shouldn't be here.
-  public goBack(): void {
-    this.router.navigateBack();
-  }
-
-  private async activate(routeParameters: {processDefId: string}): Promise<void> {
-    this.processDefId = routeParameters.processDefId;
-    await this.refreshProcess();
-    this.startProcess();
-
-    this.subscriptions = [
-      this.eventAggregator.subscribe(AuthenticationStateEvent.LOGIN, () => {
-        this.refreshProcess();
-      }),
-      this.eventAggregator.subscribe(AuthenticationStateEvent.LOGOUT, () => {
-        this.refreshProcess();
-      }),
-      this.eventAggregator.subscribe('render-dynamic-ui', (message: IUserTaskConfig) => {
-        this.dynamicUiWrapper.currentConfig = message;
-      }),
-      this.eventAggregator.subscribe('closed-process', (message: any) => {
-        this.router.navigateBack();
-      }),
-    ];
-  }
-
-  private async refreshProcess(): Promise<void> {
+  private async _refreshProcess(): Promise<void> {
     try {
-      this._process = await this.processEngineService.getProcessDefById(this.processDefId);
+      this._process = await this._processEngineService.getProcessDefById(this._processDefId);
     } catch (error) {
-      this.notificationService.showNotification(NotificationType.ERROR, `Failed to refresh process: ${error.message}`);
+      this._notificationService.showNotification(NotificationType.ERROR, `Failed to refresh process: ${error.message}`);
       throw error;
     }
+  }
+
+  private _startProcess(): void {
+    this._bpmnStudioClient.startProcessByKey(this.process.key);
   }
 
 }


### PR DESCRIPTION
## What did you change?

BPMN-Studio will:

- Return to list-view if process was started from list-view.
- Return to detail-view if process was started from detail-view.

Refactored some codestyle.

Fixes #318

## How can others test the changes?

Start the "Create Process"-Process.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
