### PR TITLE
♻️Refactor the Plattform check

### DIFF
--- a/src/modules/bpmn-io/bpmn-io.ts
+++ b/src/modules/bpmn-io/bpmn-io.ts
@@ -422,9 +422,9 @@ export class BpmnIo {
   }
 
   /**
-   * Checks, if the current platform is a mac.
+   * Checks, if the current platform is a macOS.
    *
-   * @returns true, if the current plattform is a mac
+   * @returns true, if the current platform is macOS
    */
   private _checkIfCurrentPlatformIsMac = (): boolean => {
     const macRegex: RegExp = /.*mac*./i;

--- a/src/modules/bpmn-io/bpmn-io.ts
+++ b/src/modules/bpmn-io/bpmn-io.ts
@@ -428,9 +428,9 @@ export class BpmnIo {
    */
   private _checkIfCurrentPlatformIsMac = (): boolean => {
     const macRegex: RegExp = /.*mac*./i;
-    const currentPlattform: string = navigator.platform;
-    const currentPlattformIsMac: boolean = macRegex.test(currentPlattform);
+    const currentPlatform: string = navigator.platform;
+    const currentPlatformIsMac: boolean = macRegex.test(currentPlatform);
 
-    return currentPlattformIsMac;
+    return currentPlatformIsMac;
   }
 }

--- a/src/modules/bpmn-io/bpmn-io.ts
+++ b/src/modules/bpmn-io/bpmn-io.ts
@@ -338,13 +338,10 @@ export class BpmnIo {
    * @return void
    */
   private _saveHotkeyEventHandler = (event: KeyboardEvent): void  => {
-
-    // On macOS the 'common control key' is the meta instead of the control key. So we need to find
-    // out if on a mac, the meta key instead of the control key is pressed.
-    const macRegex: RegExp = /.*mac*./i;
-    const currentPlattform: string = navigator.platform;
-    const currentPlattformIsMac: boolean = macRegex.test(currentPlattform);
-    const metaKeyIsPressed: boolean = currentPlattformIsMac ? event.metaKey : event.ctrlKey;
+    // On macOS the 'common control key' is the meta instead of the control key. So on a mac we need to find
+    // out, if the meta key instead of the control key is pressed.
+    const currentPlatformIsMac: boolean = this._currentPlattformIsMac();
+    const metaKeyIsPressed: boolean = currentPlatformIsMac ? event.metaKey : event.ctrlKey;
 
     /*
     * If both keys (meta and s) are pressed, save the diagram.
@@ -368,11 +365,9 @@ export class BpmnIo {
   }
 
   private _addKeyboardListener(): void {
-    const macRegex: RegExp = /.*mac*./i;
-    const currentPlattform: string = navigator.platform;
-    const currentPlattformIsNotMac: boolean = !macRegex.test(currentPlattform);
+    const currentPlatformIsNotMac: boolean = !this._currentPlattformIsMac();
 
-    if (currentPlattformIsNotMac) {
+    if (currentPlatformIsNotMac) {
       return;
     }
 
@@ -402,10 +397,8 @@ export class BpmnIo {
   private _printHotkeyEventHandler = (event: KeyboardEvent): void  => {
     // On macOS the 'common control key' is the meta instead of the control key. So on a mac we need to find
     // out, if the meta key instead of the control key is pressed.
-    const macRegex: RegExp = /.*mac*./i;
-    const currentPlattform: string = navigator.platform;
-    const currentPlattformIsMac: boolean = macRegex.test(currentPlattform);
-    const metaKeyIsPressed: boolean = currentPlattformIsMac ? event.metaKey : event.ctrlKey;
+    const currentPlatformIsMac: boolean = this._currentPlattformIsMac();
+    const metaKeyIsPressed: boolean = currentPlatformIsMac ? event.metaKey : event.ctrlKey;
 
     /*
      * If both keys (meta and p) are pressed, print the diagram.
@@ -421,5 +414,18 @@ export class BpmnIo {
       event.preventDefault();
       this._eventAggregator.publish(environment.events.processDefDetail.printDiagram);
     }
+  }
+
+  /**
+   * Checks, if the current platform is a mac.
+   *
+   * @returns true, if the current plattform is a mac
+   */
+  private _currentPlattformIsMac = (): boolean => {
+    const macRegex: RegExp = /.*mac*./i;
+    const currentPlattform: string = navigator.platform;
+    const currentPlattformIsMac: boolean = macRegex.test(currentPlattform);
+
+    return currentPlattformIsMac;
   }
 }

--- a/src/modules/bpmn-io/bpmn-io.ts
+++ b/src/modules/bpmn-io/bpmn-io.ts
@@ -340,7 +340,7 @@ export class BpmnIo {
   private _saveHotkeyEventHandler = (event: KeyboardEvent): void  => {
     // On macOS the 'common control key' is the meta instead of the control key. So on a mac we need to find
     // out, if the meta key instead of the control key is pressed.
-    const currentPlatformIsMac: boolean = this._currentPlattformIsMac();
+    const currentPlatformIsMac: boolean = this._checkIfCurrentPlatformIsMac();
     const metaKeyIsPressed: boolean = currentPlatformIsMac ? event.metaKey : event.ctrlKey;
 
     /*
@@ -370,7 +370,7 @@ export class BpmnIo {
    * element to the backspace key, if the current platform is macOS.
    */
   private _addRemoveWithBackspaceKeyboardListener(): void {
-    const currentPlatformIsNotMac: boolean = !this._currentPlattformIsMac();
+    const currentPlatformIsNotMac: boolean = !this._checkIfCurrentPlatformIsMac();
 
     if (currentPlatformIsNotMac) {
       return;
@@ -402,7 +402,7 @@ export class BpmnIo {
   private _printHotkeyEventHandler = (event: KeyboardEvent): void  => {
     // On macOS the 'common control key' is the meta instead of the control key. So on a mac we need to find
     // out, if the meta key instead of the control key is pressed.
-    const currentPlatformIsMac: boolean = this._currentPlattformIsMac();
+    const currentPlatformIsMac: boolean = this._checkIfCurrentPlatformIsMac();
     const metaKeyIsPressed: boolean = currentPlatformIsMac ? event.metaKey : event.ctrlKey;
 
     /*
@@ -426,7 +426,7 @@ export class BpmnIo {
    *
    * @returns true, if the current plattform is a mac
    */
-  private _currentPlattformIsMac = (): boolean => {
+  private _checkIfCurrentPlatformIsMac = (): boolean => {
     const macRegex: RegExp = /.*mac*./i;
     const currentPlattform: string = navigator.platform;
     const currentPlattformIsMac: boolean = macRegex.test(currentPlattform);

--- a/src/modules/bpmn-io/bpmn-io.ts
+++ b/src/modules/bpmn-io/bpmn-io.ts
@@ -72,7 +72,7 @@ export class BpmnIo {
       },
     });
 
-    this._addKeyboardListener();
+    this._addRemoveWithBackspaceKeyboardListener();
 
     if (this.xml !== undefined && this.xml !== null) {
       this.modeler.importXML(this.xml, (err: Error) => {
@@ -364,7 +364,12 @@ export class BpmnIo {
     }
   }
 
-  private _addKeyboardListener(): void {
+  /**
+   * On macOS it is typically to remove elements with the backspace instead
+   * of the delete key. This Method binds the removal of a selected
+   * element to the backspace key, if the current platform is macOS.
+   */
+  private _addRemoveWithBackspaceKeyboardListener(): void {
     const currentPlatformIsNotMac: boolean = !this._currentPlattformIsMac();
 
     if (currentPlatformIsNotMac) {


### PR DESCRIPTION
## What did you change?
This PR moves the check, if the current Plattform is a mac, to a dedicated method. 

Since three methods use the same method to ask for the current platform, I thought that its a good idea to move the duplicated lines of code to a dedicated method.

This may also become handy, if we want to implement more features, that uses the meta key since we don't have to copy the same regex for the platform check over and over. 

Also, this PR fixes a few typos in the word _platform_ and change the name of the `_addKeyboardListener()` Method, since the only purpose of this method was to bind an event to the backspace key, if the current platform is a mac.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
