### PR TITLE
✨ Persist and Load Last Property Panel Width in Local Storage

### DIFF
--- a/aurelia_project/environments/dev.ts
+++ b/aurelia_project/environments/dev.ts
@@ -52,8 +52,6 @@ export default {
     baseRoute: processEngineRoute,
   },
   propertyPanel: {
-    minWidth: 190,
-    maxWidth: 300,
     defaultWidth: 250,
   },
   colorPickerSettings: {

--- a/aurelia_project/environments/dev.ts
+++ b/aurelia_project/environments/dev.ts
@@ -54,6 +54,7 @@ export default {
   propertyPanel: {
     minWidth: 190,
     maxWidth: 300,
+    defaultWidth: 250,
   },
   colorPickerSettings: {
     clickoutFiresChange: true,

--- a/aurelia_project/environments/prod.ts
+++ b/aurelia_project/environments/prod.ts
@@ -53,8 +53,6 @@ export default {
     baseRoute: processEngineRoute,
   },
   propertyPanel: {
-    minWidth: 190,
-    maxWidth: 300,
     defaultWidth: 250,
   },
   colorPickerSettings: {

--- a/aurelia_project/environments/prod.ts
+++ b/aurelia_project/environments/prod.ts
@@ -55,6 +55,7 @@ export default {
   propertyPanel: {
     minWidth: 190,
     maxWidth: 300,
+    defaultWidth: 250,
   },
   colorPickerSettings: {
     clickoutFiresChange: true,

--- a/aurelia_project/environments/stage.ts
+++ b/aurelia_project/environments/stage.ts
@@ -53,8 +53,6 @@ export default {
     baseRoute: processEngineRoute,
   },
   propertyPanel: {
-    minWidth: 190,
-    maxWidth: 300,
     defaultWidth: 250,
   },
   colorPickerSettings: {

--- a/aurelia_project/environments/stage.ts
+++ b/aurelia_project/environments/stage.ts
@@ -55,6 +55,7 @@ export default {
   propertyPanel: {
     minWidth: 190,
     maxWidth: 300,
+    defaultWidth: 250,
   },
   colorPickerSettings: {
     clickoutFiresChange: true,

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -52,8 +52,6 @@ export default {
     baseRoute: processEngineRoute,
   },
   propertyPanel: {
-    minWidth: 190,
-    maxWidth: 300,
     defaultWidth: 250,
   },
   colorPickerSettings: {

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -54,6 +54,7 @@ export default {
   propertyPanel: {
     minWidth: 190,
     maxWidth: 300,
+    defaultWidth: 250,
   },
   colorPickerSettings: {
     clickoutFiresChange: true,

--- a/src/modules/bpmn-io/bpmn-io.ts
+++ b/src/modules/bpmn-io/bpmn-io.ts
@@ -156,11 +156,15 @@ export class BpmnIo {
     ];
 
     const previousPropertyPanelWidth: string = window.localStorage.getItem('propertyPanelWidth');
-    if (previousPropertyPanelWidth !== undefined) {
-      this.propertyPanelWidth = parseInt(previousPropertyPanelWidth);
-    } else {
-      this.propertyPanelWidth = environment.propertyPanel.defaultWidth;
-    }
+    
+    /*
+     * Update the property panel width;
+     * if no previoud width was found, take the configured one.
+     */
+    this.propertyPanelWidth = (previousPropertyPanelWidth !== undefined) ? 
+                              parseInt(previousPropertyPanelWidth) :
+                              environment.propertyPanel.defaultWidth;
+
   }
 
   public detached(): void {
@@ -256,7 +260,7 @@ export class BpmnIo {
      * This is needed to stop the width from increasing too far
      * The property panel would not be displayed with that width,
      * but when increasing the browser width, the property panel then may also increase
-    */
+     */
     const newPropertyPanelWidth: number = Math.min(resizedWidth, propertyPanelMaxWidth);
 
     this.propertyPanelWidth = newPropertyPanelWidth;

--- a/src/modules/bpmn-io/bpmn-io.ts
+++ b/src/modules/bpmn-io/bpmn-io.ts
@@ -161,6 +161,11 @@ export class BpmnIo {
         }, 0);
       }),
     ];
+
+    const previousPropertyPanelWidth: string = window.localStorage.getItem('propertyPanelWidth');
+    if (previousPropertyPanelWidth !== undefined) {
+      this.propertyPanelWidth = parseInt(previousPropertyPanelWidth);
+    }
   }
 
   public detached(): void {
@@ -173,6 +178,8 @@ export class BpmnIo {
     for (const subscription of this._subscriptions) {
       subscription.dispose();
     }
+
+    window.localStorage.setItem('propertyPanelWidth', '' + this.propertyPanelWidth);
   }
 
   public xmlChanged(newValue: string, oldValue: string): void {

--- a/src/modules/bpmn-io/bpmn-io.ts
+++ b/src/modules/bpmn-io/bpmn-io.ts
@@ -3,16 +3,9 @@ import {EventAggregator, Subscription} from 'aurelia-event-aggregator';
 import {bindable, inject, observable} from 'aurelia-framework';
 import * as $ from 'jquery';
 
-import {ElementDistributeOptions,
-        IBpmnFunction,
-        IBpmnModeler,
-        IDefinition,
+import {IBpmnModeler,
         IEditorActions,
         IKeyboard,
-        IModdleElement,
-        IModeling,
-        IProcessDefEntity,
-        IShape,
         NotificationType,
       } from '../../contracts/index';
 import environment from '../../environment';

--- a/src/modules/bpmn-io/bpmn-io.ts
+++ b/src/modules/bpmn-io/bpmn-io.ts
@@ -34,7 +34,7 @@ export class BpmnIo {
   public initialLoadingFinished: boolean = false;
   public showXMLView: boolean = false;
   public colorPickerLoaded: boolean = false;
-  public propertyPanelWidth: number = 250;
+  @observable public propertyPanelWidth: number;
   public minCanvasWidth: number = 100;
   public minPropertyPanelWidth: number = 200;
 
@@ -165,6 +165,8 @@ export class BpmnIo {
     const previousPropertyPanelWidth: string = window.localStorage.getItem('propertyPanelWidth');
     if (previousPropertyPanelWidth !== undefined) {
       this.propertyPanelWidth = parseInt(previousPropertyPanelWidth);
+    } else {
+      this.propertyPanelWidth = environment.propertyPanel.defaultWidth;
     }
   }
 

--- a/src/modules/bpmn-io/bpmn-io.ts
+++ b/src/modules/bpmn-io/bpmn-io.ts
@@ -180,16 +180,20 @@ export class BpmnIo {
     for (const subscription of this._subscriptions) {
       subscription.dispose();
     }
-
-    window.localStorage.setItem('propertyPanelWidth', '' + this.propertyPanelWidth);
   }
 
-  public xmlChanged(newValue: string, oldValue: string): void {
+  public xmlChanged(newValue: string): void {
     if (this.modeler !== undefined && this.modeler !== null) {
       this.modeler.importXML(newValue, (err: Error) => {
         return 0;
       });
       this.xml = newValue;
+    }
+  }
+
+  public propertyPanelWidthChanged(newValue: number): void {
+    if (newValue !== undefined) {
+      window.localStorage.setItem('propertyPanelWidth', '' + this.propertyPanelWidth);
     }
   }
 


### PR DESCRIPTION
## What did you change?

When returning to the view/diagram, the width of the property panel is restored.

## How can others test the changes?

- Open the BPMN-Studio
- Go to the "Detail View"
- Resize the property panel
- Go to the "Plan View"
- Go back to the "Detail View"
- Notice that the property panel still has the resized size

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
