### PR TITLE
✨Persist Hide States When Reloading

### DIFF
--- a/src/modules/bpmn-io/bpmn-io.ts
+++ b/src/modules/bpmn-io/bpmn-io.ts
@@ -152,6 +152,10 @@ export class BpmnIo {
                               parseInt(previousPropertyPanelWidth) :
                               environment.propertyPanel.defaultWidth;
 
+    const propertyPanelHideState: string = window.localStorage.getItem('propertyPanelHideState');
+    const wasPropertyPanelVisible: boolean = propertyPanelHideState === undefined || propertyPanelHideState === 'show';
+    this._toggled = wasPropertyPanelVisible;
+    this.togglePanel();
   }
 
   public detached(): void {
@@ -215,11 +219,13 @@ export class BpmnIo {
       this.toggleButtonPropertyPanel.classList.add('tool--active');
       this.propertyPanelDisplay = 'inline';
       this._toggled = false;
+      window.localStorage.setItem('propertyPanelHideState', 'show');
     } else {
 
       this.toggleButtonPropertyPanel.classList.remove('tool--active');
       this.propertyPanelDisplay = 'none';
       this._toggled = true;
+      window.localStorage.setItem('propertyPanelHideState', 'hide');
     }
   }
 

--- a/src/modules/bpmn-io/bpmn-io.ts
+++ b/src/modules/bpmn-io/bpmn-io.ts
@@ -146,7 +146,7 @@ export class BpmnIo {
 
     /*
      * Update the property panel width;
-     * if no previoud width was found, take the configured one.
+     * if no previous width was found, take the configured one.
      */
     this.propertyPanelWidth = (previousPropertyPanelWidth !== undefined) ?
                               parseInt(previousPropertyPanelWidth) :
@@ -251,8 +251,9 @@ export class BpmnIo {
 
     /*
      * This is needed to stop the width from increasing too far
-     * The property panel would not be displayed with that width,
-     * but when increasing the browser width, the property panel then may also increase
+     * the property panel would not be displayed with that width,
+     * but when increasing the browser width, the property panel
+     * then may also increase.
      */
     const newPropertyPanelWidth: number = Math.min(resizedWidth, propertyPanelMaxWidth);
 

--- a/src/modules/bpmn-io/bpmn-io.ts
+++ b/src/modules/bpmn-io/bpmn-io.ts
@@ -210,7 +210,7 @@ export class BpmnIo {
   }
 
   public togglePanel(): void {
-    if (this._propertyPanelShouldOpen === true) {
+    if (this._propertyPanelShouldOpen) {
       if (this._propertyPanelHasNoSpace) {
         this._notificationService.showNotification(NotificationType.ERROR, 'There is not enough space for the property panel!');
         return;
@@ -262,8 +262,9 @@ export class BpmnIo {
 
   private _hidePropertyPanelForSpaceReasons(): void {
     this._propertyPanelHasNoSpace = true;
+    const propertyPanelIsOpen: boolean = !this._propertyPanelShouldOpen;
 
-    if (this._propertyPanelShouldOpen === false) {
+    if (propertyPanelIsOpen) {
       this._propertyPanelHiddenForSpaceReasons = true;
       this.togglePanel();
     }

--- a/src/modules/bpmn-io/bpmn-io.ts
+++ b/src/modules/bpmn-io/bpmn-io.ts
@@ -153,7 +153,7 @@ export class BpmnIo {
                               environment.propertyPanel.defaultWidth;
 
     const propertyPanelHideState: string = window.localStorage.getItem('propertyPanelHideState');
-    const wasPropertyPanelVisible: boolean = propertyPanelHideState === undefined || propertyPanelHideState === 'show';
+    const wasPropertyPanelVisible: boolean = propertyPanelHideState === null || propertyPanelHideState === 'show';
     this._toggled = wasPropertyPanelVisible;
     this.togglePanel();
   }

--- a/src/modules/bpmn-io/bpmn-io.ts
+++ b/src/modules/bpmn-io/bpmn-io.ts
@@ -31,7 +31,7 @@ export class BpmnIo {
   public minCanvasWidth: number = 100;
   public minPropertyPanelWidth: number = 200;
 
-  private _toggled: boolean = false;
+  private _propertyPanelShouldOpen: boolean = false;
   private _propertyPanelHiddenForSpaceReasons: boolean = false;
   private _propertyPanelHasNoSpace: boolean = false;
 
@@ -154,7 +154,7 @@ export class BpmnIo {
 
     const propertyPanelHideState: string = window.localStorage.getItem('propertyPanelHideState');
     const wasPropertyPanelVisible: boolean = propertyPanelHideState === null || propertyPanelHideState === 'show';
-    this._toggled = wasPropertyPanelVisible;
+    this._propertyPanelShouldOpen = wasPropertyPanelVisible;
     this.togglePanel();
   }
 
@@ -210,7 +210,7 @@ export class BpmnIo {
   }
 
   public togglePanel(): void {
-    if (this._toggled === true) {
+    if (this._propertyPanelShouldOpen === true) {
       if (this._propertyPanelHasNoSpace) {
         this._notificationService.showNotification(NotificationType.ERROR, 'There is not enough space for the property panel!');
         return;
@@ -218,13 +218,13 @@ export class BpmnIo {
 
       this.toggleButtonPropertyPanel.classList.add('tool--active');
       this.propertyPanelDisplay = 'inline';
-      this._toggled = false;
+      this._propertyPanelShouldOpen = false;
       window.localStorage.setItem('propertyPanelHideState', 'show');
     } else {
 
       this.toggleButtonPropertyPanel.classList.remove('tool--active');
       this.propertyPanelDisplay = 'none';
-      this._toggled = true;
+      this._propertyPanelShouldOpen = true;
       window.localStorage.setItem('propertyPanelHideState', 'hide');
     }
   }
@@ -263,7 +263,7 @@ export class BpmnIo {
   private _hidePropertyPanelForSpaceReasons(): void {
     this._propertyPanelHasNoSpace = true;
 
-    if (this._toggled === false) {
+    if (this._propertyPanelShouldOpen === false) {
       this._propertyPanelHiddenForSpaceReasons = true;
       this.togglePanel();
     }
@@ -273,7 +273,7 @@ export class BpmnIo {
     this._propertyPanelHasNoSpace = false;
     this._propertyPanelHiddenForSpaceReasons = false;
 
-    this._toggled = true;
+    this._propertyPanelShouldOpen = true;
     this.togglePanel();
   }
 

--- a/src/modules/navbar/navbar.ts
+++ b/src/modules/navbar/navbar.ts
@@ -28,6 +28,10 @@ export class NavBar {
 
     document.addEventListener('click', this.dropdownClickListener);
 
+    const processSolutionExplorerHideState: string = window.localStorage.getItem('processSolutionExplorerHideState');
+    const wasprocessSolutionExplorerVisible: boolean = processSolutionExplorerHideState === 'show';
+    this.showSolutionExplorer = wasprocessSolutionExplorerVisible;
+
     this._eventAggregator.subscribe('router:navigation:complete', () => {
       this._dertermineActiveRoute();
     });

--- a/src/modules/navbar/navbar.ts
+++ b/src/modules/navbar/navbar.ts
@@ -29,8 +29,8 @@ export class NavBar {
     document.addEventListener('click', this.dropdownClickListener);
 
     const processSolutionExplorerHideState: string = window.localStorage.getItem('processSolutionExplorerHideState');
-    const wasprocessSolutionExplorerVisible: boolean = processSolutionExplorerHideState === 'show';
-    this.showSolutionExplorer = wasprocessSolutionExplorerVisible;
+    const wasProcessSolutionExplorerVisible: boolean = processSolutionExplorerHideState === 'show';
+    this.showSolutionExplorer = wasProcessSolutionExplorerVisible;
 
     this._eventAggregator.subscribe('router:navigation:complete', () => {
       this._dertermineActiveRoute();

--- a/src/modules/process-solution-panel/process-solution-panel.ts
+++ b/src/modules/process-solution-panel/process-solution-panel.ts
@@ -27,6 +27,8 @@ export class ProcessSolutionPanel {
     this._refreshProcesslist();
     this._eventAggregator.publish(environment.events.processSolutionPanel.toggleProcessSolutionExplorer);
 
+    window.localStorage.setItem('processSolutionExplorerHideState', 'show');
+
     this._subscriptions = [
       this._eventAggregator.subscribe(AuthenticationStateEvent.LOGIN, () => {
         this._refreshProcesslist();
@@ -45,6 +47,8 @@ export class ProcessSolutionPanel {
       subscription.dispose();
     }
     this._eventAggregator.publish(environment.events.processSolutionPanel.toggleProcessSolutionExplorer);
+
+    window.localStorage.setItem('processSolutionExplorerHideState', 'hide');
   }
 
   private async _refreshProcesslist(): Promise<void> {


### PR DESCRIPTION
## What did you change?

When reloading the diagram/view or changing the diagram via the plan view, the hide state of the property panel is restored.

When reloading the BPMN-Studio, the hide state of the process solution explorer is restored.

## How can others test the changes?

- Open up the BPMN-Studio

- Go to any diagram
- Toggle the property panel
- Change the diagram via the plan view or reload the page
- Notice that the property panel is still hidden/shown

- Toggle the process solution explorer
- Reload the page
- Notice that the process solution explorer is still hidden/shown

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [ ] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
