### PR TITLE
🐛 Fix saving of an invalid diagram via cmd + s

### DIFF
--- a/src/modules/bpmn-io/bpmn-io.ts
+++ b/src/modules/bpmn-io/bpmn-io.ts
@@ -353,15 +353,17 @@ export class BpmnIo {
     * @see environment.events.processDefDetail.saveDiagram
     */
     const sKeyIsPressed: boolean = event.key === 's';
-    const userWantsToSave: boolean = metaKeyIsPressed && sKeyIsPressed;
+    const userDoesNotWantsToSave: boolean = !(metaKeyIsPressed && sKeyIsPressed);
 
-    if (userWantsToSave) {
-      // Prevent the browser from handling the default action for CTRL + s.
-      event.preventDefault();
+    if (userDoesNotWantsToSave) {
+      return;
+    }
 
-      if (this._diagramIsValid) {
-        this._eventAggregator.publish(environment.events.processDefDetail.saveDiagram);
-      }
+    // Prevent the browser from handling the default action for CTRL + s.
+    event.preventDefault();
+
+    if (this._diagramIsValid) {
+      this._eventAggregator.publish(environment.events.processDefDetail.saveDiagram);
     }
   }
 

--- a/src/modules/bpmn-io/bpmn-io.ts
+++ b/src/modules/bpmn-io/bpmn-io.ts
@@ -353,9 +353,9 @@ export class BpmnIo {
     * @see environment.events.processDefDetail.saveDiagram
     */
     const sKeyIsPressed: boolean = event.key === 's';
-    const userDoesNotWantsToSave: boolean = !(metaKeyIsPressed && sKeyIsPressed);
+    const userDoesNotWantToSave: boolean = !(metaKeyIsPressed && sKeyIsPressed);
 
-    if (userDoesNotWantsToSave) {
+    if (userDoesNotWantToSave) {
       return;
     }
 

--- a/src/modules/bpmn-io/bpmn-io.ts
+++ b/src/modules/bpmn-io/bpmn-io.ts
@@ -42,6 +42,7 @@ export class BpmnIo {
   private _notificationService: NotificationService;
   private _eventAggregator: EventAggregator;
   private _subscriptions: Array<Subscription>;
+  private _diagramIsValid: boolean = true;
 
   /**
    * We are using the direct reference of a container element to place the tools of bpmn-js
@@ -152,6 +153,12 @@ export class BpmnIo {
         setTimeout(() => { // This makes the function gets called after the XMLView is toggled
           this._hideOrShowPpForSpaceReasons();
         }, 0);
+      }),
+      this._eventAggregator.subscribe(environment.events.navBar.enableSaveButton, () => {
+        this._diagramIsValid = true;
+      }),
+      this._eventAggregator.subscribe(environment.events.navBar.disableSaveButton, () => {
+        this._diagramIsValid = false;
       }),
     ];
 
@@ -347,8 +354,9 @@ export class BpmnIo {
      */
     const sKeyIsPressed: boolean = event.key === 's';
     const userWantsToSave: boolean = metaKeyIsPressed && sKeyIsPressed;
+    const diagramCanBeSaved: boolean = userWantsToSave && this._diagramIsValid;
 
-    if (userWantsToSave) {
+    if (diagramCanBeSaved) {
       // Prevent the browser from handling the default action for CTRL + s.
       event.preventDefault();
       this._eventAggregator.publish(environment.events.processDefDetail.saveDiagram);

--- a/src/modules/bpmn-io/bpmn-io.ts
+++ b/src/modules/bpmn-io/bpmn-io.ts
@@ -347,19 +347,21 @@ export class BpmnIo {
     const metaKeyIsPressed: boolean = currentPlattformIsMac ? event.metaKey : event.ctrlKey;
 
     /*
-     * If both keys (meta and s) are pressed, save the diagram.
-     * A diagram is saved, by throwing a saveDiagram event.
-     *
-     * @see environment.events.processDefDetail.saveDiagram
-     */
+    * If both keys (meta and s) are pressed, save the diagram.
+    * A diagram is saved, by throwing a saveDiagram event.
+    *
+    * @see environment.events.processDefDetail.saveDiagram
+    */
     const sKeyIsPressed: boolean = event.key === 's';
     const userWantsToSave: boolean = metaKeyIsPressed && sKeyIsPressed;
-    const diagramCanBeSaved: boolean = userWantsToSave && this._diagramIsValid;
 
-    if (diagramCanBeSaved) {
+    if (userWantsToSave) {
       // Prevent the browser from handling the default action for CTRL + s.
       event.preventDefault();
-      this._eventAggregator.publish(environment.events.processDefDetail.saveDiagram);
+
+      if (this._diagramIsValid) {
+        this._eventAggregator.publish(environment.events.processDefDetail.saveDiagram);
+      }
     }
   }
 


### PR DESCRIPTION
## What did you change?
This PR Fixes the bug, where you can save an invalid diagram while pressing `cmd + s` while the property pane was active. 

Fixes: #501 

## How can others test the changes?
* Create a diagram
* Create two elements with the same id
* See, that the saving is no longer possible

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
