### PR TITLE
🐛📌 Pins electron-builder to 20.14.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "debug": "^3.1.0",
     "downloadjs": "1.4.4",
     "electron": "^1.7.9",
-    "electron-builder": "^20.14.7",
+    "electron-builder": "20.14.7",
     "electron-rebuild": "^1.7.3",
     "event-stream": "^3.3.3",
     "eventemitter2": "^4.1.2",


### PR DESCRIPTION
## What did you change?

This temporarily fixes the bug which occurs when you start the bpmn-studio as electron app.
Triggered by the latest electron-builder release.

![bildschirmfoto 2018-06-25 um 15 24 16](https://user-images.githubusercontent.com/17065920/41853755-ca1efc10-788e-11e8-84d1-d7171baa13c8.png)


## How can others test the changes?

- checkout the branch
- clear you node modules
- `npm i`
- `npm run electron-build-macos`
- start the generated app and see that it works

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
