### PR TITLE
Improve the resolution when printing or exporting a diagram as an image

### DIFF
--- a/src/modules/processdef-detail/processdef-detail.ts
+++ b/src/modules/processdef-detail/processdef-detail.ts
@@ -453,15 +453,15 @@ export class ProcessDefDetail {
     const targetDPI: number = 300;
 
     /*
-     * TODO: Figure out, how to optain the format of the print before printing.
+     * TODO: Figure out, how to obtain the format of the print before printing.
      * In the current implementation, I assume that we print to a DIN A4 Paper,
      * which has a diagonal size of 14,33 inch.
      *
      * There may be some problems if we try to print to a larger paper format
      * such as DIN A3 or even DIN A0.
     */
-    const dinA4DiagonalSize: number = 14.33;
-    const pixelRatio: number = this._getPixelRatioForDPI(svgWidth, svgHeight, targetDPI, dinA4DiagonalSize);
+    const dinA4DiagonalSizeInch: number = 14.17;
+    const pixelRatio: number = this._calculatePixelRatioForDPI(svgWidth, svgHeight, targetDPI, dinA4DiagonalSizeInch);
 
     canvas.width = svgWidth * pixelRatio;
     canvas.height = svgHeight * pixelRatio;
@@ -486,13 +486,16 @@ export class ProcessDefDetail {
 
   /**
    * Calculate the pixel ratio for the given DPI.
+   * The Pixel Ratio is the factor which is needed, to extend the
+   * the width and height of a canvas to match a rendered resolution
+   * with the targeting DPI.
    *
-   * @param svgWidth With of the diagrams canvas element
-   * @param svgHeight Height of the diagrams canvas element
-   * @param outputDPI DPI of the output
-   * @param diagonalSize Diagonal Size of the printed document
+   * @param svgWidth With of the diagrams canvas element.
+   * @param svgHeight Height of the diagrams canvas element.
+   * @param targetDPI DPI of the output.
+   * @param diagonalSize Diagonal Size of the printed document.
    */
-  private _getPixelRatioForDPI(svgWidth: number, svgHeight: number, outputDPI: number, diagonalSize: number): number {
+  private _calculatePixelRatioForDPI(svgWidth: number, svgHeight: number, targetDPI: number, diagonalSize: number): number {
 
     // tslint:disable:no-magic-numbers
     const svgWidthSquared: number = Math.pow(svgWidth, 2);
@@ -501,7 +504,7 @@ export class ProcessDefDetail {
     const diagonalResolution: number = Math.sqrt(svgWidthSquared + svgHeightSquared);
 
     const originalDPI: number = diagonalResolution / diagonalSize;
-    const pixelRatio: number = outputDPI / originalDPI;
+    const pixelRatio: number = targetDPI / originalDPI;
 
     return pixelRatio;
   }

--- a/src/modules/processdef-detail/processdef-detail.ts
+++ b/src/modules/processdef-detail/processdef-detail.ts
@@ -436,30 +436,7 @@ export class ProcessDefDetail {
     const svg: string = await this.bpmnio.getSVG();
     const png: string = this._generateImageFromSVG('png', svg);
 
-    const svgContentRegex: RegExp = /<svg.*?>(.*)<\/svg>/i;
-    const viewBoxRegex: RegExp = /<svg .*? (viewBox\=\"(.*?)\")/i;
-
-    const svgContentMatch: RegExpMatchArray = svg.match(svgContentRegex);
-    const viewBoxContentMatch: RegExpMatchArray = svg.match(viewBoxRegex);
-
-    /*
-     * TODO: Improve the regex.
-     *
-     * It should be possible to use only one regex with different groupings.
-     */
-    // tslint:disable-next-line:no-magic-numbers
-    const svgContent: string = svgContentMatch[1];
-
-    // tslint:disable-next-line:no-magic-numbers
-    const viewBoxContent: string = viewBoxContentMatch[2];
-
-    const svgElement: string = `<svg width="100%" height="100%" viewBox="${viewBoxContent}" preserveAspectRatio="xMinYMin">${svgContent}</svg>`;
-
-    const printWindow: Window = window.open();
-    printWindow.document.body.innerHTML = svgElement;
-
-    printWindow.print();
-    printWindow.close();
+    print.default({printable: png, type: 'image'});
   }
 
   private _generateImageFromSVG(desiredImageType: string, svg: any): string {
@@ -470,7 +447,19 @@ export class ProcessDefDetail {
     const svgWidth: number = parseInt(svg.match(/<svg[^>]*width\s*=\s*\"?(\d+)\"?[^>]*>/)[1]);
     const svgHeight: number = parseInt(svg.match(/<svg[^>]*height\s*=\s*\"?(\d+)\"?[^>]*>/)[1]);
 
-    const pixelRatio: number = 4;
+    // For a print, we use 300 dpi
+    const targetDPI: number = 300;
+
+    /*
+     * TODO: Figure out, how to optain the format of the print before printing.
+     * In the current implementation, I assume that we print to a DIN A4 Paper,
+     * which has a diagonal size of 14,33 inch.
+     *
+     * There may be some problems if we try to print to a larger paper format
+     * such as DIN A3 or even DIN A0.
+    */
+    const dinA4DiagonalSize: number = 14.33;
+    const pixelRatio: number = this._getPixelRatioForDPI(svgWidth, svgHeight, targetDPI, dinA4DiagonalSize);
 
     canvas.width = svgWidth * pixelRatio;
     canvas.height = svgHeight * pixelRatio;

--- a/src/modules/processdef-detail/processdef-detail.ts
+++ b/src/modules/processdef-detail/processdef-detail.ts
@@ -24,6 +24,8 @@ import environment from '../../environment';
 import {BpmnIo} from '../bpmn-io/bpmn-io';
 import {NotificationService} from './../notification/notification.service';
 
+import * as print from 'print-js';
+
 interface RouteParameters {
   processDefId: string;
 }

--- a/src/modules/processdef-detail/processdef-detail.ts
+++ b/src/modules/processdef-detail/processdef-detail.ts
@@ -24,8 +24,6 @@ import environment from '../../environment';
 import {BpmnIo} from '../bpmn-io/bpmn-io';
 import {NotificationService} from './../notification/notification.service';
 
-import * as print from 'print-js';
-
 interface RouteParameters {
   processDefId: string;
 }

--- a/src/modules/processdef-detail/processdef-detail.ts
+++ b/src/modules/processdef-detail/processdef-detail.ts
@@ -447,7 +447,19 @@ export class ProcessDefDetail {
     const svgWidth: number = parseInt(svg.match(/<svg[^>]*width\s*=\s*\"?(\d+)\"?[^>]*>/)[1]);
     const svgHeight: number = parseInt(svg.match(/<svg[^>]*height\s*=\s*\"?(\d+)\"?[^>]*>/)[1]);
 
-    const pixelRatio: number = window.devicePixelRatio || 1;
+    // For a print, we use 300 dpi
+    const targetDPI: number = 300;
+
+    /*
+     * TODO: Figure out, how to optain the format of the print before printing.
+     * In the current implementation, I assume that we print to a DIN A4 Paper,
+     * which has a diagonal size of 14,33 inch.
+     *
+     * There may be some problems if we try to print to a larger paper format
+     * such as DIN A3 or even DIN A0.
+    */
+    const dinA4DiagonalSize: number = 14.33;
+    const pixelRatio: number = this._getPixelRatioForDPI(svgWidth, svgHeight, targetDPI, dinA4DiagonalSize);
 
     canvas.width = svgWidth * pixelRatio;
     canvas.height = svgHeight * pixelRatio;
@@ -468,6 +480,28 @@ export class ProcessDefDetail {
     // get image as base64 datastring
     const image: string = canvas.toDataURL(encoding);
     return image;
+  }
+
+  /**
+   * Calculate the pixel ratio for the given DPI.
+   *
+   * @param svgWidth With of the diagrams canvas element
+   * @param svgHeight Height of the diagrams canvas element
+   * @param outputDPI DPI of the output
+   * @param diagonalSize Diagonal Size of the printed document
+   */
+  private _getPixelRatioForDPI(svgWidth: number, svgHeight: number, outputDPI: number, diagonalSize: number): number {
+
+    // tslint:disable:no-magic-numbers
+    const svgWidthSquared: number = Math.pow(svgWidth, 2);
+    const svgHeightSquared: number = Math.pow(svgHeight, 2);
+
+    const diagonalResolution: number = Math.sqrt(svgWidthSquared + svgHeightSquared);
+
+    const originalDPI: number = diagonalResolution / diagonalSize;
+    const pixelRatio: number = outputDPI / originalDPI;
+
+    return pixelRatio;
   }
   //  }}} Exporting Functions - Probably an ExportService is a better idea //
 


### PR DESCRIPTION
## What did you change?
Fixes #510 

In the old implementation, the quality when export a png file depends on the resolution of the used monitor. 
Also the pixel density was way to low to produce a quality print of a diagram. 

This PR adds printing of the native SVG vector graphic, so that that browser can handle the rasterisation itself. 

## Known issues
We are still locked to a DIN A4 format. The problem is that we cant really obtain the correct paper format before the user gets prompted with the printing dialogue. 

## How can others test the changes?
* Print a diagram
* Look at the printed diagram

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
