### PR TITLE
👷⚡️ :construction_worker: Add Prefer Offline Flag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,9 +65,9 @@ pipeline {
       }
     }
     stage('build electron') {
-      when {
-        expression { branch_is_master || branch_is_develop }
-      }
+      // when {
+      //   expression { branch_is_master || branch_is_develop }
+      // }
       parallel {
         stage('Build on Linux') {
           agent {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,9 +65,9 @@ pipeline {
       }
     }
     stage('build electron') {
-      // when {
-      //   expression { branch_is_master || branch_is_develop }
-      // }
+      when {
+        expression { branch_is_master || branch_is_develop }
+      }
       parallel {
         stage('Build on Linux') {
           agent {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@ pipeline {
         }
         nodejs(configId: env.NPM_RC_FILE, nodeJSInstallationName: env.NODE_JS_VERSION) {
           sh('node --version')
-          sh('npm install')
+          sh('npm install --prefer-offline')
           sh('npm rebuild node-sass')
         }
       }
@@ -97,7 +97,7 @@ pipeline {
             // we copy the node_modules folder from the main slave
             // which runs linux. Some dependencies may not be installed
             // if they have a os restriction in their package.json
-            sh('npm install')
+            sh('npm install --prefer-offline')
             sh('npm run jenkins-electron-install-app-deps')
             sh('npm run jenkins-electron-rebuild-native')
 
@@ -197,7 +197,7 @@ pipeline {
         unstash('windows_results')
         nodejs(configId: env.NPM_RC_FILE, nodeJSInstallationName: env.NODE_JS_VERSION) {
           dir('.ci-tools') {
-            sh('npm install')
+            sh('npm install --prefer-offline')
           }
           withCredentials([
             string(credentialsId: 'process-engine-ci_token', variable: 'RELEASE_GH_TOKEN')


### PR DESCRIPTION
## What did you change?

This PR adds the `--prefer-offline` flag that forces npm to use the cache. 

## How can others test the changes?

Maybe see the improved build speed here: https://ci.process-engine.io/blue/organizations/jenkins/process-engine_node-lts%2Fbpmn-studio/activity/?branch=feature%2Fadd_prefer_offline_flag

**Builds 1-3:** without electron

**Builds 4-6:** with electron (you can compare their speed with master or develop)


## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
