### PR TITLE
💄Hide FileSystem SolutionExplorer when in web

### DIFF
--- a/src/modules/process-solution-panel/process-solution-panel.html
+++ b/src/modules/process-solution-panel/process-solution-panel.html
@@ -3,7 +3,7 @@
   <div class="process-explorer__solution-explorer">
 
     <div class="solution-explorer-index-cards">
-      <div class="index-card" class.bind="fileSystemIndexCardIsActive ? 'index-card--active' : ''" click.delegate="openFileSystemIndexCard()">
+      <div class="index-card" class.bind="fileSystemIndexCardIsActive ? 'index-card--active' : ''" click.delegate="openFileSystemIndexCard()" if.bind="enableFileSystemSolutions">
         <i class="fa fa-folder"></i>
       </div>
       <div class="index-card" class.bind="processEngineIndexCardIsActive ? 'index-card--active' : ''" click.delegate="openProcessEngineIndexCard()">
@@ -11,7 +11,7 @@
       </div>
     </div>
 
-    <div class="solution-explorer__filesystem" show.bind="fileSystemIndexCardIsActive ">
+    <div class="solution-explorer__filesystem" show.bind="fileSystemIndexCardIsActive && enableFileSystemSolutions">
       <div class="process-explorer__heading">Solution Explorer
         <button class="open-solution-button" id="solutionInputButton"><i class="fas fa-plus"></i></button>
       </div>


### PR DESCRIPTION
## What did you change?

This branch readds the binds that hides the FileSystem SolutionExplorer Indexcard when in web and shows it when in electron.

## How can others test the changes?

Open BPMN-Studio in web. -> Check SolutionExplorer if there is a folder icon.
Open BPMN-Studio in electron. ->Check if there is a folder icon now.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
