### PR TITLE
🐛 Fix Creating Unneeded ExtensionElements

### DIFF
--- a/src/modules/property-panel/indextabs/extensions/sections/basics/basics.ts
+++ b/src/modules/property-panel/indextabs/extensions/sections/basics/basics.ts
@@ -100,7 +100,7 @@ export class BasicsSection implements ISection {
                                                        || this._businessObjInPanel.extensionElements === null;
 
     if (businessObjectHasNoExtensionElements) {
-      this._createExtensionElement();
+      return;
     }
 
     this._propertyElement = this._getPropertyElement();


### PR DESCRIPTION
## What did you change?

The BPMN-Studio no longer adds extensionElements to the Start Event when its extensionElements is undefined.

Fixes: #546 

## How can others test the changes?

- Import [this](https://github.com/process-engine/bpmn-studio/files/2191579/Email.Senden.Bug.bpmn.zip) diagram (or any other diagram that has never been saved in the BPMN-Studio)
- Have a look at the diff view
- Notice that there are no changes

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
