### PR TITLE
✨ Prevent Solution Explorer from Adding Solutions/Diagrams Multiple Times

### DIFF
--- a/src/contracts/file-input-event/IFile.ts
+++ b/src/contracts/file-input-event/IFile.ts
@@ -1,0 +1,8 @@
+export interface IFile {
+  lastModified: number;
+  name: string;
+  path: string;
+  size: number;
+  type: string;
+  webkitRelativePath: string;
+}

--- a/src/contracts/file-input-event/IInputEvent.ts
+++ b/src/contracts/file-input-event/IInputEvent.ts
@@ -1,0 +1,5 @@
+import {IInputTarget} from './index';
+
+export interface IInputEvent {
+  target: IInputTarget;
+}

--- a/src/contracts/file-input-event/IInputTarget.ts
+++ b/src/contracts/file-input-event/IInputTarget.ts
@@ -1,0 +1,5 @@
+import {IFile} from './index';
+
+export interface IInputTarget {
+  files: Array<IFile>;
+}

--- a/src/contracts/file-input-event/index.ts
+++ b/src/contracts/file-input-event/index.ts
@@ -1,0 +1,3 @@
+export * from './IFile';
+export * from './IInputEvent';
+export * from './IInputTarget';

--- a/src/contracts/index.ts
+++ b/src/contracts/index.ts
@@ -10,3 +10,4 @@ export * from './colorpicker/index';
 export * from './print/index';
 export * from './export/index';
 export * from './diffview/index';
+export * from './file-input-event/index';

--- a/src/modules/process-solution-panel/process-solution-panel.ts
+++ b/src/modules/process-solution-panel/process-solution-panel.ts
@@ -7,7 +7,7 @@ import {IPagination, IProcessDefEntity} from '@process-engine/bpmn-studio_client
 import {IDiagram, ISolution} from '@process-engine/solutionexplorer.contracts';
 import {ISolutionExplorerService} from '@process-engine/solutionexplorer.service.contracts';
 
-import {AuthenticationStateEvent, IFileInfo, NotificationType} from '../../contracts/index';
+import {AuthenticationStateEvent, IFileInfo, IInputEvent, NotificationType} from '../../contracts/index';
 import environment from '../../environment';
 import {NotificationService} from '../notification/notification.service';
 
@@ -121,7 +121,7 @@ export class ProcessSolutionPanel {
    * @param event A event that holds the files that were "uploaded" by the user.
    * Currently there is no type for this kind of event.
    */
-  public async onSolutionInputChange(event: any): Promise<void> {
+  public async onSolutionInputChange(event: IInputEvent): Promise<void> {
     await this._solutionExplorerServiceFileSystem.openSolution(event.target.files[0].path, this._identity);
     const newSolution: ISolution = await this._solutionExplorerServiceFileSystem.loadSolution();
 
@@ -143,7 +143,7 @@ export class ProcessSolutionPanel {
    * @param event A event that holds the files that were "uploaded" by the user.
    * Currently there is no type for this kind of event.
    */
-  public async onSingleDiagramInputChange(event: any): Promise<void> {
+  public async onSingleDiagramInputChange(event: IInputEvent): Promise<void> {
     const pathToDiagram: string = event.target.files[0].path;
     const newDiagram: IDiagram = await this._solutionExplorerServiceFileSystem.openSingleDiagram(pathToDiagram, this._identity);
 

--- a/src/modules/process-solution-panel/process-solution-panel.ts
+++ b/src/modules/process-solution-panel/process-solution-panel.ts
@@ -128,6 +128,7 @@ export class ProcessSolutionPanel {
 
     if (solutionIsAlreadyOpen) {
       this._notificationService.showNotification(NotificationType.INFO, 'Solution is already open');
+
       return;
     }
 
@@ -151,6 +152,7 @@ export class ProcessSolutionPanel {
 
     if (diagramIsAlreadyOpen) {
       this._notificationService.showNotification(NotificationType.INFO, 'Diagram is already open');
+
       return;
     }
 

--- a/src/modules/process-solution-panel/process-solution-panel.ts
+++ b/src/modules/process-solution-panel/process-solution-panel.ts
@@ -116,6 +116,12 @@ export class ProcessSolutionPanel {
   public async onSolutionInputChange(event: any): Promise<void> {
     await this._solutionExplorerServiceFileSystem.openSolution(event.target.files[0].path, this._identity);
     const solution: ISolution = await this._solutionExplorerServiceFileSystem.loadSolution();
+
+    const solutionIsAlreadyOpen: boolean = this.openedFileSystemSolutions.includes(solution);
+    if (solutionIsAlreadyOpen) {
+      return;
+    }
+
     this.openedFileSystemSolutions.push(solution);
     this.solutionInput.value = '';
   }
@@ -128,7 +134,14 @@ export class ProcessSolutionPanel {
   public async onSingleDiagramInputChange(event: any): Promise<void> {
     const pathToDiagram: string = event.target.files[0].path;
     const diagram: IDiagram = await this._solutionExplorerServiceFileSystem.openSingleDiagram(pathToDiagram, this._identity);
+
+    const diagramIsAlreadyOpen: boolean = this.openedSingleDiagrams.includes(diagram);
+    if (diagramIsAlreadyOpen) {
+      return;
+    }
+
     this.openedSingleDiagrams.push(diagram);
+    this.singleDiagramInput.value = '';
   }
 
   public closeFileSystemSolution(solutionToClose: ISolution): void {

--- a/src/modules/process-solution-panel/process-solution-panel.ts
+++ b/src/modules/process-solution-panel/process-solution-panel.ts
@@ -11,6 +11,10 @@ import {AuthenticationStateEvent, IFileInfo, NotificationType} from '../../contr
 import environment from '../../environment';
 import {NotificationService} from '../notification/notification.service';
 
+interface IURIObject {
+  uri: string;
+}
+
 @inject(EventAggregator, Router, 'SolutionExplorerServiceProcessEngine', 'SolutionExplorerServiceFileSystem', 'NotificationService', 'Identity')
 export class ProcessSolutionPanel {
   public processes: IPagination<IProcessDefEntity>;
@@ -123,14 +127,7 @@ export class ProcessSolutionPanel {
 
     this.solutionInput.value = '';
 
-    const getSolutionFromArray: ((solution: ISolution) => ISolution) =
-    (solution: ISolution): ISolution =>
-      this.openedFileSystemSolutions
-        .find((solutionFromArray: ISolution) => {
-          return solutionFromArray.uri === solution.uri;
-        });
-
-    const solutionIsAlreadyOpen: boolean = getSolutionFromArray(newSolution) !== undefined;
+    const solutionIsAlreadyOpen: boolean = this._findURIObject(this.openedFileSystemSolutions, newSolution.uri) !== undefined;
 
     if (solutionIsAlreadyOpen) {
       this._notificationService.showNotification(NotificationType.INFO, 'Solution is already open');
@@ -152,14 +149,7 @@ export class ProcessSolutionPanel {
 
     this.singleDiagramInput.value = '';
 
-    const getDiagramFromArray: ((diagram: IDiagram) => IDiagram) =
-    (diagram: IDiagram): IDiagram =>
-      this.openedSingleDiagrams
-        .find((diagramFromArray: IDiagram) => {
-          return diagramFromArray.uri === diagram.uri;
-        });
-
-    const diagramIsAlreadyOpen: boolean = getDiagramFromArray(newDiagram) !== undefined;
+    const diagramIsAlreadyOpen: boolean = this._findURIObject(this.openedSingleDiagrams, newDiagram.uri) !== undefined;
 
     if (diagramIsAlreadyOpen) {
       this._notificationService.showNotification(NotificationType.INFO, 'Diagram is already open');
@@ -222,5 +212,13 @@ export class ProcessSolutionPanel {
   private _updateSolution(solutionToUpdate: ISolution, solution: ISolution): void {
     const index: number = this.openedFileSystemSolutions.indexOf(solutionToUpdate);
     this.openedFileSystemSolutions.splice(index, 1, solution);
+  }
+
+  private _findURIObject<T extends IURIObject>(objects: Array<T>, targetURI: string): T {
+    const foundObject: T = objects.find((object: T): boolean => {
+      return object.uri === targetURI;
+    });
+
+    return foundObject;
   }
 }

--- a/src/modules/process-solution-panel/process-solution-panel.ts
+++ b/src/modules/process-solution-panel/process-solution-panel.ts
@@ -121,12 +121,10 @@ export class ProcessSolutionPanel {
     await this._solutionExplorerServiceFileSystem.openSolution(event.target.files[0].path, this._identity);
     const newSolution: ISolution = await this._solutionExplorerServiceFileSystem.loadSolution();
 
-    let solutionIsAlreadyOpen: boolean = false;
-    this.openedFileSystemSolutions.forEach((solution: ISolution) => {
-      if (solution.uri === newSolution.uri) {
-        solutionIsAlreadyOpen = true;
-      }
-    });
+    const solutionIsAlreadyOpen: ISolution = this.openedFileSystemSolutions
+      .find((solution: ISolution) => {
+        return solution.uri === newSolution.uri;
+      });
 
     if (solutionIsAlreadyOpen) {
       this._notificationService.showNotification(NotificationType.INFO, 'Solution is already open');
@@ -146,12 +144,10 @@ export class ProcessSolutionPanel {
     const pathToDiagram: string = event.target.files[0].path;
     const newDiagram: IDiagram = await this._solutionExplorerServiceFileSystem.openSingleDiagram(pathToDiagram, this._identity);
 
-    let diagramIsAlreadyOpen: boolean = false;
-    this.openedSingleDiagrams.forEach((diagram: IDiagram) => {
-      if (diagram.uri === newDiagram.uri) {
-        diagramIsAlreadyOpen = true;
-      }
-    });
+    const diagramIsAlreadyOpen: IDiagram = this.openedSingleDiagrams
+      .find((diagram: IDiagram) => {
+        return diagram.uri === newDiagram.uri;
+      });
 
     if (diagramIsAlreadyOpen) {
       this._notificationService.showNotification(NotificationType.INFO, 'Diagram is already open');

--- a/src/modules/process-solution-panel/process-solution-panel.ts
+++ b/src/modules/process-solution-panel/process-solution-panel.ts
@@ -126,6 +126,8 @@ export class ProcessSolutionPanel {
         return solution.uri === newSolution.uri;
       });
 
+    this.solutionInput.value = '';
+
     if (solutionIsAlreadyOpen) {
       this._notificationService.showNotification(NotificationType.INFO, 'Solution is already open');
 
@@ -133,7 +135,6 @@ export class ProcessSolutionPanel {
     }
 
     this.openedFileSystemSolutions.push(newSolution);
-    this.solutionInput.value = '';
   }
 
   /**
@@ -144,6 +145,8 @@ export class ProcessSolutionPanel {
   public async onSingleDiagramInputChange(event: any): Promise<void> {
     const pathToDiagram: string = event.target.files[0].path;
     const newDiagram: IDiagram = await this._solutionExplorerServiceFileSystem.openSingleDiagram(pathToDiagram, this._identity);
+
+    this.singleDiagramInput.value = '';
 
     const diagramIsAlreadyOpen: IDiagram = this.openedSingleDiagrams
       .find((diagram: IDiagram) => {
@@ -157,7 +160,6 @@ export class ProcessSolutionPanel {
     }
 
     this.openedSingleDiagrams.push(newDiagram);
-    this.singleDiagramInput.value = '';
   }
 
   public closeFileSystemSolution(solutionToClose: ISolution): void {

--- a/src/modules/process-solution-panel/process-solution-panel.ts
+++ b/src/modules/process-solution-panel/process-solution-panel.ts
@@ -121,12 +121,16 @@ export class ProcessSolutionPanel {
     await this._solutionExplorerServiceFileSystem.openSolution(event.target.files[0].path, this._identity);
     const newSolution: ISolution = await this._solutionExplorerServiceFileSystem.loadSolution();
 
-    const solutionIsAlreadyOpen: ISolution = this.openedFileSystemSolutions
-      .find((solution: ISolution) => {
-        return solution.uri === newSolution.uri;
-      });
-
     this.solutionInput.value = '';
+
+    const getSolutionFromArray: ((solution: ISolution) => ISolution) =
+    (solution: ISolution): ISolution =>
+      this.openedFileSystemSolutions
+        .find((solutionFromArray: ISolution) => {
+          return solutionFromArray.uri === solution.uri;
+        });
+
+    const solutionIsAlreadyOpen: boolean = getSolutionFromArray(newSolution) !== undefined;
 
     if (solutionIsAlreadyOpen) {
       this._notificationService.showNotification(NotificationType.INFO, 'Solution is already open');
@@ -148,10 +152,14 @@ export class ProcessSolutionPanel {
 
     this.singleDiagramInput.value = '';
 
-    const diagramIsAlreadyOpen: IDiagram = this.openedSingleDiagrams
-      .find((diagram: IDiagram) => {
-        return diagram.uri === newDiagram.uri;
-      });
+    const getDiagramFromArray: ((diagram: IDiagram) => IDiagram) =
+    (diagram: IDiagram): IDiagram =>
+      this.openedSingleDiagrams
+        .find((diagramFromArray: IDiagram) => {
+          return diagramFromArray.uri === diagram.uri;
+        });
+
+    const diagramIsAlreadyOpen: boolean = getDiagramFromArray(newDiagram) !== undefined;
 
     if (diagramIsAlreadyOpen) {
       this._notificationService.showNotification(NotificationType.INFO, 'Diagram is already open');

--- a/src/modules/process-solution-panel/process-solution-panel.ts
+++ b/src/modules/process-solution-panel/process-solution-panel.ts
@@ -11,10 +11,6 @@ import {AuthenticationStateEvent, IFileInfo, IInputEvent, NotificationType} from
 import environment from '../../environment';
 import {NotificationService} from '../notification/notification.service';
 
-interface IURIObject {
-  uri: string;
-}
-
 @inject(EventAggregator, Router, 'SolutionExplorerServiceProcessEngine', 'SolutionExplorerServiceFileSystem', 'NotificationService', 'Identity')
 export class ProcessSolutionPanel {
   public processes: IPagination<IProcessDefEntity>;
@@ -214,7 +210,7 @@ export class ProcessSolutionPanel {
     this.openedFileSystemSolutions.splice(index, 1, solution);
   }
 
-  private _findURIObject<T extends IURIObject>(objects: Array<T>, targetURI: string): T {
+  private _findURIObject<T extends {uri: string}>(objects: Array<T>, targetURI: string): T {
     const foundObject: T = objects.find((object: T): boolean => {
       return object.uri === targetURI;
     });

--- a/src/modules/processdef-list/processdef-list.ts
+++ b/src/modules/processdef-list/processdef-list.ts
@@ -63,7 +63,7 @@ export class ProcessDefList {
 
     this._refreshProcesslist();
 
-    this._fileReader.onload = async(fileInformations: any): Promise<void> => {
+    this._fileReader.onload = async(fileInformations: FileReaderProgressEvent): Promise<void> => {
 
       const xml: string = fileInformations.target.result;
       const filename: string = this.selectedFiles[0].name;


### PR DESCRIPTION
## What did you change?

This branch:

- Adds a check for double solutions and diagrams.
- Shows a notification when the solution or diagram is already open.

Closes #545

## How can others test the changes?

Try to open the same diagram or solution twice with the SolutionExplorer.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
