### PR TITLE
🐛 Fix Incomparable Check

### DIFF
--- a/src/modules/bpmn-diff-view/bpmn-diff-view.ts
+++ b/src/modules/bpmn-diff-view/bpmn-diff-view.ts
@@ -172,6 +172,11 @@ export class BpmnDiffView {
   }
 
   private _setNoChangesReason(): void {
+
+    /*
+    * This Regex removes all newlines and spaces to make sure that both xml
+    * are not formatted.
+    */
     const unformattedXml: string = this.xml.replace(/\r?\n|\r|\s/g, '');
     const unformattedSaveXml: string = this.savedxml.replace(/\r?\n|\r|\s/g, '');
 

--- a/src/modules/bpmn-diff-view/bpmn-diff-view.ts
+++ b/src/modules/bpmn-diff-view/bpmn-diff-view.ts
@@ -172,9 +172,12 @@ export class BpmnDiffView {
   }
 
   private _setNoChangesReason(): void {
-      const diagramIsUnchanged: boolean = this.savedxml === this.xml;
+    const unformattedXml: string = this.xml.replace(/\r?\n|\r|\s/g, '');
+    const unformattedSaveXml: string = this.savedxml.replace(/\r?\n|\r|\s/g, '');
 
-      if (diagramIsUnchanged) {
+    const diagramIsUnchanged: boolean = unformattedSaveXml === unformattedXml;
+
+    if (diagramIsUnchanged) {
         this.noChangesReason = 'The two diagrams are identical.';
       } else {
         this.noChangesReason = 'The two diagrams are incomparable.';

--- a/src/modules/bpmn-diff-view/bpmn-diff-view.ts
+++ b/src/modules/bpmn-diff-view/bpmn-diff-view.ts
@@ -177,8 +177,10 @@ export class BpmnDiffView {
     * This Regex removes all newlines and spaces to make sure that both xml
     * are not formatted.
     */
-    const unformattedXml: string = this.xml.replace(/\r?\n|\r|\s/g, '');
-    const unformattedSaveXml: string = this.savedxml.replace(/\r?\n|\r|\s/g, '');
+    const whitespaceAndNewLineRegex: RegExp = /\r?\n|\r|\s/g;
+
+    const unformattedXml: string = this.xml.replace(whitespaceAndNewLineRegex, '');
+    const unformattedSaveXml: string = this.savedxml.replace(whitespaceAndNewLineRegex, '');
 
     const diagramIsUnchanged: boolean = unformattedSaveXml === unformattedXml;
 


### PR DESCRIPTION
## What did you change?

When there are no changes the diff view checks if the diagrams are the same or incomparable.

When only one of the two xml string was formatted, but the other one was not, the diff view thought that the diagrams are incomparable, even if they were the same.

This has been fixed.

## How can others test the changes?

- Import [this](https://github.com/process-engine/bpmn-studio/files/2191579/Email.Senden.Bug.bpmn.zip) diagram (or any other diagram that has never been saved in the BPMN-Studio)
- Have a look at the diff view
- Notice that there change list now says "The two diagrams are identical." instead of "The two diagrams are incomparable."

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
