### PR TITLE
🐛 Fix Width Style Issues

### DIFF
--- a/src/modules/navbar/navbar.scss
+++ b/src/modules/navbar/navbar.scss
@@ -143,7 +143,11 @@ button {
 }
 
 .process-details-title {
+  float: left;
+  max-width: 220px;
   margin-left: 5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .menu-bar__user-login {

--- a/src/modules/processdef-list/processdef-list.html
+++ b/src/modules/processdef-list/processdef-list.html
@@ -85,13 +85,10 @@
         <table class="table table-striped table-bordered">
           <tr>
             <th>Process Definition Name</th>
-            <!-- TODO: Drop the Id; it does not seem usefull -->
-            <th>Process Definition Id</th>
             <th></th>
           </tr>
           <tr repeat.for="process of processes" id="processDef">
             <td>${process.name}</td>
-            <td>${process.id}</td>
             <td>
               <button click.delegate="startProcess(process.id)" class="btn btn-success">Start</button>
               <button click.delegate="showDetails(process.id)" class="btn btn-primary" id="processDefDetailsButton">Details</button>

--- a/src/modules/processdef-list/processdef-list.html
+++ b/src/modules/processdef-list/processdef-list.html
@@ -85,7 +85,7 @@
         <table class="table table-striped table-bordered process-def-list-table">
           <tr>
             <th>Process Definition Name</th>
-            <th></th>
+            <th class="process-buttons-table-entry"></th>
           </tr>
           <tr repeat.for="process of processes" id="processDef">
             <td>${process.name}</td>

--- a/src/modules/processdef-list/processdef-list.html
+++ b/src/modules/processdef-list/processdef-list.html
@@ -82,7 +82,7 @@
           <i class="fas fa-download"></i> Import BPMN
         </a>
         <input type="file" ref="fileInput" accept=".xml,.bpmn" files.bind="selectedFiles" class="hidden">
-        <table class="table table-striped table-bordered">
+        <table class="table table-striped table-bordered process-def-list-table">
           <tr>
             <th>Process Definition Name</th>
             <th></th>

--- a/src/modules/processdef-list/processdef-list.html
+++ b/src/modules/processdef-list/processdef-list.html
@@ -88,7 +88,7 @@
             <th class="process-buttons-table-entry"></th>
           </tr>
           <tr repeat.for="process of processes" id="processDef">
-            <td class="process-name-table-entry">${process.name}</td>
+            <td class="process-name-table-entry" title="${process.name}">${process.name}</td>
             <td class="process-buttons-table-entry">
               <button click.delegate="startProcess(process.id)" class="btn btn-success">Start</button>
               <button click.delegate="showDetails(process.id)" class="btn btn-primary" id="processDefDetailsButton">Details</button>

--- a/src/modules/processdef-list/processdef-list.html
+++ b/src/modules/processdef-list/processdef-list.html
@@ -88,8 +88,8 @@
             <th class="process-buttons-table-entry"></th>
           </tr>
           <tr repeat.for="process of processes" id="processDef">
-            <td>${process.name}</td>
-            <td>
+            <td class="process-name-table-entry">${process.name}</td>
+            <td class="process-buttons-table-entry">
               <button click.delegate="startProcess(process.id)" class="btn btn-success">Start</button>
               <button click.delegate="showDetails(process.id)" class="btn btn-primary" id="processDefDetailsButton">Details</button>
             </td>

--- a/src/modules/processdef-list/processdef-list.scss
+++ b/src/modules/processdef-list/processdef-list.scss
@@ -58,6 +58,12 @@
   margin-bottom: 4px;
 }
 
+.process-name-table-entry {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .process-buttons-table-entry {
   width: 150px;
 }

--- a/src/modules/processdef-list/processdef-list.scss
+++ b/src/modules/processdef-list/processdef-list.scss
@@ -7,6 +7,10 @@
   height: 100%;
 }
 
+.process-def-list-table {
+  table-layout: fixed;
+}
+
 .processdef-list__btn-table-cell {
   text-align: center;
 }

--- a/src/modules/processdef-list/processdef-list.scss
+++ b/src/modules/processdef-list/processdef-list.scss
@@ -57,3 +57,7 @@
   margin-top: 4px;
   margin-bottom: 4px;
 }
+
+.process-buttons-table-entry {
+  width: 150px;
+}

--- a/src/modules/processdef-start/processdef-start.html
+++ b/src/modules/processdef-start/processdef-start.html
@@ -2,7 +2,7 @@
   <require from="./processdef-start.css"></require>
   <require from="../dynamic-ui-wrapper/dynamic-ui-wrapper"></require>
   <div class="start-process">
-    <div class="container start-process-container">
+    <div class="container-fluid start-process-container">
       <template if.bind="process">
         <h3>Start process: ${process.name}</h3>
 

--- a/src/modules/processdef-start/processdef-start.scss
+++ b/src/modules/processdef-start/processdef-start.scss
@@ -5,5 +5,6 @@
 }
 
 .start-process-container {
+  width: 100%;
   padding-top: 60px;
 }

--- a/src/modules/processdef-start/processdef-start.scss
+++ b/src/modules/processdef-start/processdef-start.scss
@@ -5,6 +5,7 @@
 }
 
 .start-process-container {
-  width: 100%;
+  width: 80%;
+  max-width: 800px;
   padding-top: 60px;
 }


### PR DESCRIPTION
## What did you change?

This PR fixes 3 issues:

1. Adds a maximum width for the diagram title in the navbar (#561)
1. Fixes the maximum width of the start-process-container (#562)
1. Fixes the style of the process-def-list for long diagram names (#566)

This also removes the process id from the process-def-list, since it was not really helpful.

Fixes: #561 
Fixes: #562 
Fixes: #566 

## How can others test the changes?

- Open up the BPMN-Studio

1. Issue

- Go to the detail view of any diagram with a really long name
- Notice that the navbar can no longer become too long

2. Issue

- Click on the 'Create Process Definition'-button
- Resize the browser/electron window
- Notice that the text boxes will no longer become too long

3. Issue

- Add a process diagram with a really long name
- Go to the process-def-list
- Notice that the layout of the table will still look like before

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
