### PR TITLE
🐛 Fix Adding Existing Diagram Via File Association

### DIFF
--- a/src/modules/process-solution-panel/process-solution-panel.ts
+++ b/src/modules/process-solution-panel/process-solution-panel.ts
@@ -62,7 +62,12 @@ export class ProcessSolutionPanel {
       // Register handler for double-click event fired from "elecrin.js".
       ipcRenderer.on('double-click-on-file', async(event: Event, pathToFile: string) => {
         const diagram: IDiagram = await this._solutionExplorerServiceFileSystem.openSingleDiagram(pathToFile, this._identity);
-        this.openedSingleDiagrams.push(diagram);
+
+        const diagramIsNotAlreadyOpen: boolean = this._findURIObject(this.openedSingleDiagrams, diagram.uri) === undefined;
+        if (diagramIsNotAlreadyOpen) {
+          this.openedSingleDiagrams.push(diagram);
+        }
+
         this.navigateToDiagramDetail(diagram);
         this.openFileSystemIndexCard();
       });

--- a/src/modules/process-solution-panel/process-solution-panel.ts
+++ b/src/modules/process-solution-panel/process-solution-panel.ts
@@ -63,12 +63,16 @@ export class ProcessSolutionPanel {
       ipcRenderer.on('double-click-on-file', async(event: Event, pathToFile: string) => {
         const diagram: IDiagram = await this._solutionExplorerServiceFileSystem.openSingleDiagram(pathToFile, this._identity);
 
-        const diagramIsNotAlreadyOpen: boolean = this._findURIObject(this.openedSingleDiagrams, diagram.uri) === undefined;
+        const openedDiagram: IDiagram = this._findURIObject(this.openedSingleDiagrams, diagram.uri);
+
+        const diagramIsNotAlreadyOpen: boolean = openedDiagram === undefined;
         if (diagramIsNotAlreadyOpen) {
           this.openedSingleDiagrams.push(diagram);
+          this.navigateToDiagramDetail(diagram);
+        } else {
+          this.navigateToDiagramDetail(openedDiagram);
         }
 
-        this.navigateToDiagramDetail(diagram);
         this.openFileSystemIndexCard();
       });
 

--- a/src/modules/process-solution-panel/process-solution-panel.ts
+++ b/src/modules/process-solution-panel/process-solution-panel.ts
@@ -59,7 +59,7 @@ export class ProcessSolutionPanel {
       const ipcRenderer: any = (<any> window).nodeRequire('electron').ipcRenderer;
       const path: string = (<any> window).nodeRequire('path');
 
-      // Register handler for double-click event fired from "elecrin.js".
+      // Register handler for double-click event fired from "elecron.js".
       ipcRenderer.on('double-click-on-file', async(event: Event, pathToFile: string) => {
         const diagram: IDiagram = await this._solutionExplorerServiceFileSystem.openSingleDiagram(pathToFile, this._identity);
 


### PR DESCRIPTION
## What did you change?

This PR adds functionality to prevent the BPMN-Studio from adding existing diagramsto the Solution Explorer via file association.

- Fix adding existing diagram via file association

## How can others test the changes?

- Open up the BPMN-Studio
- Add diagram via file association
- (Change View)
- Add same diagram via file association
- Notice that it will no longer be added twice, but the detail view will still be shown after adding the same diagram a second time

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
