### PR TITLE
🐛 Fix Diff And Xml View (Firefox)

### DIFF
--- a/src/modules/bpmn-io/bpmn-io.ts
+++ b/src/modules/bpmn-io/bpmn-io.ts
@@ -32,7 +32,7 @@ export class BpmnIo {
   public canvasModel: HTMLDivElement;
   public propertyPanel: HTMLElement;
 
-  @bindable({changeHandler: 'xmlChanged'}) public xml: string;
+  @bindable() public xml: string;
   @bindable({changeHandler: 'nameChanged'}) public name: string;
 
   public savedXml: string;
@@ -232,17 +232,6 @@ export class BpmnIo {
 
     for (const subscription of this._subscriptions) {
       subscription.dispose();
-    }
-  }
-
-  public xmlChanged(newValue: string): void {
-    const xmlIsEmpty: boolean = this.modeler !== undefined && this.modeler !== null;
-    if (xmlIsEmpty) {
-      this.modeler.importXML(newValue, (err: Error) => {
-        return;
-      });
-
-      this.xml = newValue;
     }
   }
 

--- a/src/modules/bpmn-io/bpmn-io.ts
+++ b/src/modules/bpmn-io/bpmn-io.ts
@@ -267,7 +267,7 @@ export class BpmnIo {
     }
   }
 
-  public async toggleDiffView(): void {
+  public async toggleDiffView(): Promise<void> {
     if (!this.showDiffView) {
       await this._updateXmlChanges();
       this.showDiffView = true;

--- a/src/modules/bpmn-io/bpmn-io.ts
+++ b/src/modules/bpmn-io/bpmn-io.ts
@@ -283,11 +283,11 @@ export class BpmnIo {
   }
 
   public async toggleXMLView(): Promise<void> {
-    this.showXMLView = !this.showXMLView;
-
     if (this.showXMLView) {
       this.xml = await this.getXML();
     }
+
+    this.showXMLView = !this.showXMLView;
   }
 
   public async getXML(): Promise<string> {

--- a/src/modules/bpmn-io/bpmn-io.ts
+++ b/src/modules/bpmn-io/bpmn-io.ts
@@ -267,9 +267,9 @@ export class BpmnIo {
     }
   }
 
-  public toggleDiffView(): void {
+  public async toggleDiffView(): void {
     if (!this.showDiffView) {
-      this._updateXmlChanges();
+      await this._updateXmlChanges();
       this.showDiffView = true;
     } else {
       this.showDiffView = false;

--- a/src/modules/property-panel/property-panel.ts
+++ b/src/modules/property-panel/property-panel.ts
@@ -113,13 +113,6 @@ export class PropertyPanel {
     return processHasLanes;
   }
 
-  private xmlChanged(newValue: string, oldValue: string): void {
-    if (oldValue) {
-      this.setFirstElement();
-      this.updateIndextab(this.generalIndextab);
-    }
-  }
-
   private updateIndexTabsSuitability(): void {
     for (const indextab of this.indextabs) {
       indextab.canHandleElement = indextab.isSuitableForElement(this.elementInPanel);


### PR DESCRIPTION
## What did you change?

This PR fixes the XML and diff view for firefox.
The change handler was needed for the process solution explorer, but since changing the process via process  solution explorer reloads the detail view, this is no longer needed.

Fixes #568

## How can others test the changes?

- Open up the BPMN-Studio (FIREFOX)
- Go to the Detail View of any diagram
- Go to the xml view and the diff view
- Go back to the diagram view
- Notice that the diagram is still there and editable

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
