### PR TITLE
:sparkles: Use Management Api for SolutionExplorer

### DIFF
--- a/aurelia_project/aurelia.json
+++ b/aurelia_project/aurelia.json
@@ -337,6 +337,11 @@
             "path": "../node_modules/@process-engine/solutionexplorer.repository.processengine/dist/amd"
           },
           {
+            "name": "@process-engine/solutionexplorer.repository.management_api",
+            "main": "index.js",
+            "path": "../node_modules/@process-engine/solutionexplorer.repository.management_api/dist/amd"
+          },
+          {
             "name": "@process-engine/solutionexplorer.service",
             "path": "../node_modules/@process-engine/solutionexplorer.service/dist/amd",
             "main": "index.js"

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@process-engine/solutionexplorer.repository.contracts": "1.0.0",
     "@process-engine/solutionexplorer.repository.filesystem": "1.0.0",
     "@process-engine/solutionexplorer.repository.processengine": "1.0.0",
+    "@process-engine/solutionexplorer.repository.management_api": "0.0.1",
     "@process-engine/solutionexplorer.service": "1.0.0",
     "@process-engine/solutionexplorer.service.contracts": "1.0.0",
     "@process-engine/management_api_contracts": "0.6.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,6 @@
 import {Aurelia} from 'aurelia-framework';
 
 import {IIdentity} from '@essential-projects/core_contracts';
-import {SolutionExplorerFileSystemRepository} from '@process-engine/solutionexplorer.repository.filesystem';
-import {SolutionExplorerProcessEngineRepository} from '@process-engine/solutionexplorer.repository.processengine';
-import {SolutionExplorerService} from '@process-engine/solutionexplorer.service';
 
 import {NotificationType} from './contracts/index';
 import environment from './environment';
@@ -32,15 +29,7 @@ export function configure(aurelia: Aurelia): void {
     if (!window.localStorage.getItem('processEngineRoute')) {
       localStorage.setItem('processEngineRoute', `http://${newHost}`);
     }
-    // Register SolutionExplorerFileSystemService
-    const fileSystemrepository: SolutionExplorerFileSystemRepository = new SolutionExplorerFileSystemRepository();
-    const filesystemSolutionexplorerService: SolutionExplorerService = new SolutionExplorerService(fileSystemrepository);
-    aurelia.container.registerInstance('SolutionExplorerServiceFileSystem', filesystemSolutionexplorerService);
   }
-
-  const processengineRepository: SolutionExplorerProcessEngineRepository = new SolutionExplorerProcessEngineRepository();
-  const solutionexplorerService: SolutionExplorerService = new SolutionExplorerService(processengineRepository);
-  aurelia.container.registerInstance('SolutionExplorerServiceProcessEngine', solutionexplorerService);
 
   if (window.localStorage.getItem('processEngineRoute')) {
     const processEngineRoute: string = window.localStorage.getItem('processEngineRoute');
@@ -54,17 +43,6 @@ export function configure(aurelia: Aurelia): void {
     environment.processengine.routes.importBPMN = `${processEngineRoute}/processengine/create_bpmn_from_xml`;
   }
 
-  /**
-   * Register Fake Identity for SolutionExplorer.
-   * TODO: Get real identity when IAM is finished.
-  */
-  const fakeIdentity: IIdentity = {
-    name: 'fakeIdentity',
-    id: 'fakeIdentity',
-    roles: [],
-  };
-  aurelia.container.registerInstance('Identity', fakeIdentity);
-
   aurelia.use
     .standardConfiguration()
     .feature('modules/fetch-http-client')
@@ -75,6 +53,7 @@ export function configure(aurelia: Aurelia): void {
     .feature('modules/diagram-validation-service')
     .feature('modules/bpmn-studio_client', tokenRepository)
     .feature('modules/management-api_client')
+    .feature('modules/solution-explorer-services')
     .feature('resources')
     .plugin('aurelia-bootstrap')
     .plugin('aurelia-validation')

--- a/src/modules/process-solution-panel/process-solution-panel.ts
+++ b/src/modules/process-solution-panel/process-solution-panel.ts
@@ -9,6 +9,7 @@ import {ISolutionExplorerService} from '@process-engine/solutionexplorer.service
 
 import {
   AuthenticationStateEvent,
+  IAuthenticationService,
   IDiagramValidationService,
   IFileInfo,
   IInputEvent,
@@ -20,14 +21,13 @@ import {NotificationService} from '../notification/notification.service';
 @inject(
   EventAggregator,
   Router,
-  'SolutionExplorerServiceProcessEngine',
+  'SolutionExplorerServiceManagementApi',
   'SolutionExplorerServiceFileSystem',
   'NotificationService',
   'DiagramValidationService',
-  'Identity')
+  'NewAuthenticationService')
 export class ProcessSolutionPanel {
   public processes: IPagination<IProcessDefEntity>;
-  public processengineSolutionString: string;
   public openedProcessEngineSolution: ISolution;
   public openedFileSystemSolutions: Array<ISolution> = [];
   public openedSingleDiagrams: Array<IDiagram> = [];
@@ -43,24 +43,27 @@ export class ProcessSolutionPanel {
   private _eventAggregator: EventAggregator;
   private _router: Router;
   private _notificationService: NotificationService;
-  private _identity: IIdentity;
-  private _solutionExplorerServiceProcessEngine: ISolutionExplorerService;
+  private _solutionExplorerServiceManagementApi: ISolutionExplorerService;
   private _solutionExplorerServiceFileSystem: ISolutionExplorerService;
   private _diagramValidationService: IDiagramValidationService;
+  private _authenticationService: IAuthenticationService;
 
   constructor(eventAggregator: EventAggregator,
               router: Router,
-              solutionExplorerServiceProcessEngine: ISolutionExplorerService,
+              solutionExplorerServiceManagementApi: ISolutionExplorerService,
               solutionExplorerServiceFileSystem: ISolutionExplorerService,
               notificationService: NotificationService,
-              diagramValidationService: IDiagramValidationService) {
+              diagramValidationService: IDiagramValidationService,
+              authenticationService: IAuthenticationService,
+            ) {
 
     this._eventAggregator = eventAggregator;
     this._router = router;
-    this._solutionExplorerServiceProcessEngine = solutionExplorerServiceProcessEngine;
+    this._solutionExplorerServiceManagementApi = solutionExplorerServiceManagementApi;
     this._solutionExplorerServiceFileSystem = solutionExplorerServiceFileSystem;
     this._notificationService = notificationService;
     this._diagramValidationService = diagramValidationService;
+    this._authenticationService = authenticationService;
   }
 
   public async attached(): Promise<void> {
@@ -252,15 +255,30 @@ export class ProcessSolutionPanel {
   }
 
   private async _refreshProcesslist(): Promise<void> {
-    this.processengineSolutionString = environment.bpmnStudioClient.baseRoute;
-    await this._solutionExplorerServiceProcessEngine.openSolution(this.processengineSolutionString, this._identity);
+    const processengineSolutionString: string = environment.bpmnStudioClient.baseRoute;
 
-    this.openedProcessEngineSolution = await this._solutionExplorerServiceProcessEngine.loadSolution();
+    const identity: IIdentity = await this._createIdentityForSolutionExplorer();
+
+    await this._solutionExplorerServiceManagementApi.openSolution(processengineSolutionString, identity);
+
+    this.openedProcessEngineSolution = await this._solutionExplorerServiceManagementApi.loadSolution();
   }
 
   private _updateSolution(solutionToUpdate: ISolution, solution: ISolution): void {
     const index: number = this.openedFileSystemSolutions.indexOf(solutionToUpdate);
     this.openedFileSystemSolutions.splice(index, 1, solution);
+  }
+
+  private async _createIdentityForSolutionExplorer(): Promise<IIdentity> {
+    const orginalIdentity: IIdentity = await this._authenticationService.getIdentity();
+
+    const solutionExplorerIdentity: any = {
+      accessToken: this._authenticationService.getAccessToken(),
+    };
+
+    Object.assign(solutionExplorerIdentity, orginalIdentity);
+
+    return solutionExplorerIdentity;
   }
 
   private _findURIObject<T extends {uri: string}>(objects: Array<T>, targetURI: string): T {

--- a/src/modules/solution-explorer-services/index.ts
+++ b/src/modules/solution-explorer-services/index.ts
@@ -1,0 +1,36 @@
+import {IHttpClient} from '@essential-projects/http_contracts';
+import {SolutionExplorerFileSystemRepository} from '@process-engine/solutionexplorer.repository.filesystem';
+import {SolutionExplorerManagementApiRepository} from '@process-engine/solutionexplorer.repository.management_api';
+import {SolutionExplorerProcessEngineRepository} from '@process-engine/solutionexplorer.repository.processengine';
+import {SolutionExplorerService} from '@process-engine/solutionexplorer.service';
+import {Container, FrameworkConfiguration} from 'aurelia-framework';
+
+export async function configure(config: FrameworkConfiguration): Promise<void> {
+  if ((<any> window).nodeRequire) {
+    // only available if a filesystem is present
+    registerFileSystem(config.container);
+  }
+
+  registerManagementApi(config.container);
+  registerProcessEngine(config.container);
+}
+
+function registerFileSystem(container: Container): void {
+  const fileSystemrepository: SolutionExplorerFileSystemRepository = new SolutionExplorerFileSystemRepository();
+  const filesystemSolutionexplorerService: SolutionExplorerService = new SolutionExplorerService(fileSystemrepository);
+  container.registerInstance('SolutionExplorerServiceFileSystem', filesystemSolutionexplorerService);
+}
+
+function registerProcessEngine(container: Container): void {
+  const processengineRepository: SolutionExplorerProcessEngineRepository = new SolutionExplorerProcessEngineRepository();
+  const solutionexplorerService: SolutionExplorerService = new SolutionExplorerService(processengineRepository);
+  container.registerInstance('SolutionExplorerServiceProcessEngine', solutionexplorerService);
+}
+
+function registerManagementApi(container: Container): void {
+  const httpClient: IHttpClient = container.get('HttpFetchClient');
+
+  const managementApiRepository: SolutionExplorerManagementApiRepository = new SolutionExplorerManagementApiRepository(httpClient);
+  const solutionexplorerService: SolutionExplorerService = new SolutionExplorerService(managementApiRepository);
+  container.registerInstance('SolutionExplorerServiceManagementApi', solutionexplorerService);
+}


### PR DESCRIPTION
~~⏰ Waiting on https://github.com/process-engine/solutionexplorer.repository.management_api/pull/1~~

## What did you change?

**Changes**:

- Extract solution explorer instantiation into own class.
- Use the management solution explorer in panel. 

## How can others test the changes?

Build and link https://github.com/process-engine/solutionexplorer.repository.management_api/tree/feature/intial_setup

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [ ] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [ ] I've tested **all** changes included in this PR.
- [ ] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [ ] I've merged the `develop` branch into my branch before finishing this PR.
- [ ] I've **not added any other changes** than the ones described above.
- [ ] I've mentioned all **PRs, which relate to this one**
