### PR TITLE
Cleanup leftovers from the `AuthenticationService` duplicates.

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,15 +1,15 @@
 import {inject} from 'aurelia-framework';
 import {OpenIdConnect} from 'aurelia-open-id-connect';
 import {Router, RouterConfiguration} from 'aurelia-router';
-import {NewAuthenticationService} from './modules/authentication/new_authentication.service';
+import {AuthenticationService} from './modules/authentication/authentication.service';
 
-@inject(OpenIdConnect, 'NewAuthenticationService')
+@inject(OpenIdConnect, 'AuthenticationService')
 export class App {
   private _openIdConnect: OpenIdConnect;
-  private _authenticationService: NewAuthenticationService;
+  private _authenticationService: AuthenticationService;
   private _router: Router;
 
-  constructor(openIdConnect: OpenIdConnect, authenticationService: NewAuthenticationService) {
+  constructor(openIdConnect: OpenIdConnect, authenticationService: AuthenticationService) {
     this._openIdConnect = openIdConnect;
     this._authenticationService = authenticationService;
   }

--- a/src/contracts/authentication/IAuthenticationService.ts
+++ b/src/contracts/authentication/IAuthenticationService.ts
@@ -1,10 +1,9 @@
 import {IIdentity} from './IIdentity';
 
 export interface IAuthenticationService {
-  // TODO: remove old implementations that still use username and password
-  login(username?: string, password?: string): Promise<void>;
+  readonly isLoggedIn: boolean;
+  login(): Promise<void>;
   logout(): Promise<void>;
   getAccessToken(): string;
-  hasToken(): boolean;
   getIdentity(): Promise<IIdentity>;
 }

--- a/src/contracts/authentication/IAuthenticationService.ts
+++ b/src/contracts/authentication/IAuthenticationService.ts
@@ -1,9 +1,9 @@
 import {IIdentity} from './IIdentity';
 
 export interface IAuthenticationService {
-  readonly isLoggedIn: boolean;
   login(): Promise<void>;
   logout(): Promise<void>;
+  isLoggedIn(): boolean;
   getAccessToken(): string;
   getIdentity(): Promise<IIdentity>;
 }

--- a/src/modules/authentication/authentication.service.ts
+++ b/src/modules/authentication/authentication.service.ts
@@ -12,11 +12,15 @@ const UNAUTHORIZED_STATUS_CODE: number = 401;
 const LOGOUT_SUCCESS_STATUS_CODE: number = 200;
 
 @inject(EventAggregator, OpenIdConnect)
-export class NewAuthenticationService implements IAuthenticationService {
+export class AuthenticationService implements IAuthenticationService {
 
   private _eventAggregator: EventAggregator;
   private _openIdConnect: OpenIdConnect;
   private _user: User;
+
+  public get isLoggedIn(): boolean {
+    return !!this._user;
+  }
 
   constructor(eventAggregator: EventAggregator, openIdConnect: OpenIdConnect) {
     this._eventAggregator = eventAggregator;
@@ -86,15 +90,6 @@ export class NewAuthenticationService implements IAuthenticationService {
       return null;
     }
     return this._user.access_token;
-  }
-
-  public hasToken(): boolean {
-    const hasToken: boolean =
-      this._user !== undefined
-      && this._user !== null
-      && !!this._user.id_token;
-
-    return hasToken;
   }
 
   public async getIdentity(): Promise<IIdentity> {

--- a/src/modules/authentication/authentication.service.ts
+++ b/src/modules/authentication/authentication.service.ts
@@ -18,10 +18,6 @@ export class AuthenticationService implements IAuthenticationService {
   private _openIdConnect: OpenIdConnect;
   private _user: User;
 
-  public get isLoggedIn(): boolean {
-    return !!this._user;
-  }
-
   constructor(eventAggregator: EventAggregator, openIdConnect: OpenIdConnect) {
     this._eventAggregator = eventAggregator;
     this._openIdConnect = openIdConnect;
@@ -30,6 +26,10 @@ export class AuthenticationService implements IAuthenticationService {
 
   private async _initialize(): Promise<void> {
     this._user = await this._openIdConnect.getUser();
+  }
+
+  public isLoggedIn(): boolean {
+    return !!this._user;
   }
 
   public async login(): Promise<void> {

--- a/src/modules/authentication/index.ts
+++ b/src/modules/authentication/index.ts
@@ -1,6 +1,6 @@
 import {FrameworkConfiguration} from 'aurelia-framework';
-import {NewAuthenticationService} from './new_authentication.service';
+import {AuthenticationService} from './authentication.service';
 
 export async function configure(config: FrameworkConfiguration): Promise<void> {
-  config.container.registerSingleton('NewAuthenticationService', NewAuthenticationService);
+  config.container.registerSingleton('AuthenticationService', AuthenticationService);
 }

--- a/src/modules/config-panel/config-panel.ts
+++ b/src/modules/config-panel/config-panel.ts
@@ -8,7 +8,7 @@ import environment from '../../environment';
 import {oidcConfig} from '../../open-id-connect-configuration';
 import {NotificationService} from '../notification/notification.service';
 
-@inject(Router, 'NotificationService', EventAggregator, 'NewAuthenticationService', OpenIdConnect, 'InternalProcessEngineBaseRoute')
+@inject(Router, 'NotificationService', EventAggregator, 'AuthenticationService', OpenIdConnect, 'InternalProcessEngineBaseRoute')
 export class ConfigPanel {
 
   private _router: Router;
@@ -49,14 +49,14 @@ export class ConfigPanel {
       this.baseRoute = baseRouteConfiguredInLocalStorage;
     }
 
-    this.isLoggedInToProcessEngine = this._authenticationService.hasToken();
+    this.isLoggedInToProcessEngine = this._authenticationService.isLoggedIn();
 
     this._subscriptions = [
       this._eventAggregator.subscribe(AuthenticationStateEvent.LOGOUT, () => {
-        this.isLoggedInToProcessEngine = this._authenticationService.hasToken();
+        this.isLoggedInToProcessEngine = this._authenticationService.isLoggedIn();
       }),
       this._eventAggregator.subscribe(AuthenticationStateEvent.LOGIN, () => {
-        this.isLoggedInToProcessEngine = this._authenticationService.hasToken();
+        this.isLoggedInToProcessEngine = this._authenticationService.isLoggedIn();
       }),
     ];
   }

--- a/src/modules/dashboard/dashboard.ts
+++ b/src/modules/dashboard/dashboard.ts
@@ -7,7 +7,7 @@ import {
 } from '../../contracts/index';
 import {NotificationService} from '../notification/notification.service';
 
-@inject('ManagementApiClientService', 'NotificationService', 'NewAuthenticationService')
+@inject('ManagementApiClientService', 'NotificationService', 'AuthenticationService')
 export class Dashboard {
 
   public showTaskList: boolean = false;

--- a/src/modules/diagram-detail/diagram-detail.ts
+++ b/src/modules/diagram-detail/diagram-detail.ts
@@ -16,7 +16,7 @@ interface RouteParameters {
   diagramUri: string;
 }
 
-@inject('SolutionExplorerServiceFileSystem', 'ManagementApiClientService', 'NewAuthenticationService', 'NotificationService', EventAggregator, Router)
+@inject('SolutionExplorerServiceFileSystem', 'ManagementApiClientService', 'AuthenticationService', 'NotificationService', EventAggregator, Router)
 export class DiagramDetail {
 
   public diagram: IDiagram;

--- a/src/modules/process-list/process-list.ts
+++ b/src/modules/process-list/process-list.ts
@@ -14,7 +14,7 @@ interface IProcessListRouteParameters {
   processModelId?: string;
 }
 
-@inject('ManagementApiClientService', EventAggregator, Router, 'NotificationService', 'NewAuthenticationService')
+@inject('ManagementApiClientService', EventAggregator, Router, 'NotificationService', 'AuthenticationService')
 export class ProcessList {
 
   @observable public currentPage: number = 0;

--- a/src/modules/process-solution-panel/process-solution-panel.ts
+++ b/src/modules/process-solution-panel/process-solution-panel.ts
@@ -25,7 +25,7 @@ import {NotificationService} from '../notification/notification.service';
   'SolutionExplorerServiceFileSystem',
   'NotificationService',
   'DiagramValidationService',
-  'NewAuthenticationService')
+  'AuthenticationService')
 export class ProcessSolutionPanel {
   public openedProcessEngineSolution: ISolution;
   public openedFileSystemSolutions: Array<ISolution> = [];

--- a/src/modules/processdef-detail/processdef-detail.ts
+++ b/src/modules/processdef-detail/processdef-detail.ts
@@ -33,7 +33,7 @@ interface RouteParameters {
   Router,
   ValidationController,
   'NotificationService',
-  'NewAuthenticationService',
+  'AuthenticationService',
   'ManagementApiClientService')
 export class ProcessDefDetail {
 

--- a/src/modules/processdef-list/processdef-list.ts
+++ b/src/modules/processdef-list/processdef-list.ts
@@ -12,7 +12,7 @@ import {AuthenticationStateEvent, IAuthenticationService, NotificationType} from
 import environment from '../../environment';
 import {NotificationService} from '../notification/notification.service';
 
-@inject(EventAggregator, Router,  'NewAuthenticationService', 'ManagementApiClientService', 'NotificationService')
+@inject(EventAggregator, Router,  'AuthenticationService', 'ManagementApiClientService', 'NotificationService')
 export class ProcessDefList {
 
   @observable public currentPage: number = 1;

--- a/src/modules/task-list/task-list.ts
+++ b/src/modules/task-list/task-list.ts
@@ -28,7 +28,7 @@ interface IUserTaskWithProcessModel {
   processModel: ProcessModelExecution.ProcessModel;
 }
 
-@inject(EventAggregator, 'ManagementApiClientService', Router, 'NotificationService', 'NewAuthenticationService')
+@inject(EventAggregator, 'ManagementApiClientService', Router, 'NotificationService', 'AuthenticationService')
 export class TaskList {
 
   public currentPage: number = 0;

--- a/src/modules/user-login/user-login.ts
+++ b/src/modules/user-login/user-login.ts
@@ -4,7 +4,7 @@ import {bindable, bindingMode, computedFrom, inject} from 'aurelia-framework';
 import {AuthenticationStateEvent, IAuthenticationService, IIdentity, NotificationType} from '../../contracts/index';
 import {NotificationService} from './../notification/notification.service';
 
-@inject('NewAuthenticationService', EventAggregator, 'NotificationService')
+@inject('AuthenticationService', EventAggregator, 'NotificationService')
 export class UserLogin {
 
   private _authenticationService: IAuthenticationService;


### PR DESCRIPTION
## What did you change?

This PR cleans up all the leftovers from the `AuthenticationService` duplicates.

* renamed `NewAuthenticationService` to `AuthenticationService`
* renamed `hasToken()` to `isLoggedIn()`

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
