### PR TITLE
:sparkles: Display Info if the Internal ProcessEngine is Unused

### DIFF
--- a/electron_app/electron.js
+++ b/electron_app/electron.js
@@ -31,10 +31,9 @@ Main.execute = function () {
   } else {
 
     // If this is the first instance then start the application
-    Main._startInternalProcessEngine()
-      .then(() => {
-        Main._initializeApplication();
-      });
+    Main._startInternalProcessEngine();
+
+    Main._initializeApplication();
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,10 @@ export function configure(aurelia: Aurelia): void {
     if (!window.localStorage.getItem('processEngineRoute')) {
       localStorage.setItem('processEngineRoute', `http://${newHost}`);
     }
+
+    aurelia.container.registerInstance('InternalProcessEngineBaseRoute', newHost);
+  } else {
+    aurelia.container.registerInstance('InternalProcessEngineBaseRoute', null);
   }
 
   if (window.localStorage.getItem('processEngineRoute')) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,15 +16,18 @@ export function configure(aurelia: Aurelia): void {
   if ((<any> window).nodeRequire) {
     const ipcRenderer: any = (<any> window).nodeRequire('electron').ipcRenderer;
     const newHost: string = ipcRenderer.sendSync('get_host');
+
     /**
      * Currently the internal PE is always connected via http.
      * This will be subject to change.
      */
+    const processEngineBaseRouteWithProtocol: string = `http://${newHost}`;
+
     if (!window.localStorage.getItem('processEngineRoute')) {
-      localStorage.setItem('processEngineRoute', `http://${newHost}`);
+      localStorage.setItem('processEngineRoute', processEngineBaseRouteWithProtocol);
     }
 
-    aurelia.container.registerInstance('InternalProcessEngineBaseRoute', newHost);
+    aurelia.container.registerInstance('InternalProcessEngineBaseRoute', processEngineBaseRouteWithProtocol);
   } else {
     aurelia.container.registerInstance('InternalProcessEngineBaseRoute', null);
   }

--- a/src/modules/config-panel/config-panel.html
+++ b/src/modules/config-panel/config-panel.html
@@ -10,7 +10,15 @@
     <div class="config-panel__panel panel panel-default">
       <label for="processEngineRoute">Base Route</label>
       <input value.bind="baseRoute" type="text" class="form-control" id="processEngineRoute">
-      <p if.bind="isLoggedInToProcessEngine">The login session is bound to the current ProcessEngine. Changing the backend route will log you out.</p>
+      <p class="help-block" if.bind="isLoggedInToProcessEngine">The login session is bound to the current ProcessEngine. Changing the backend route will log you out.</p>
+      <div class="config-panel__panel__alert alert alert-info" if.bind="hasInternalProcessEngineBaseRouteSet() && isBaseRouteNotSetToInternalProcessEngine" role="alert">
+        <span>
+          <i class="fa fa-info-circle" aria-hidden="true"></i>
+          An internal ProcessEngine is currently running. Click 
+          <a class="use-internal-processengine" click.delegate="setBaseRouteToInternalProcessEngine()">here</a>
+          to use the internal ProcessEngine, this will change the Base Route to <code>${internalProcessEngineBaseRoute}</code>.
+        </span>
+      </div>
     </div>
     <div class="config-panel__subtitle">
       <h3>OpenID Connect</h3>

--- a/src/modules/config-panel/config-panel.scss
+++ b/src/modules/config-panel/config-panel.scss
@@ -13,3 +13,13 @@
 .config-panel__panel {
   padding: 20px 20px 20px 20px;
 }
+
+.use-internal-processengine {
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.config-panel__panel__alert {
+  margin-top: 10px;
+  margin-bottom: 0px;
+}

--- a/src/modules/config-panel/config-panel.scss
+++ b/src/modules/config-panel/config-panel.scss
@@ -21,5 +21,5 @@
 
 .config-panel__panel__alert {
   margin-top: 10px;
-  margin-bottom: 0px;
+  margin-bottom: 0;
 }

--- a/src/modules/config-panel/config-panel.ts
+++ b/src/modules/config-panel/config-panel.ts
@@ -1,5 +1,6 @@
 import {EventAggregator, Subscription} from 'aurelia-event-aggregator';
 import {bindable, inject} from 'aurelia-framework';
+import {computedFrom} from 'aurelia-framework';
 import {OpenIdConnect} from 'aurelia-open-id-connect';
 import {Router} from 'aurelia-router';
 import {IAuthenticationService} from '../../contracts/authentication/IAuthenticationService';
@@ -8,7 +9,7 @@ import environment from '../../environment';
 import {oidcConfig} from '../../open-id-connect-configuration';
 import {NotificationService} from '../notification/notification.service';
 
-@inject(Router, 'NotificationService', EventAggregator, 'NewAuthenticationService', OpenIdConnect)
+@inject(Router, 'NotificationService', EventAggregator, 'NewAuthenticationService', OpenIdConnect, 'InternalProcessEngineBaseRoute')
 export class ConfigPanel {
 
   private _router: Router;
@@ -22,18 +23,22 @@ export class ConfigPanel {
   public config: typeof environment = environment;
   public isLoggedInToProcessEngine: boolean;
   @bindable() public baseRoute: string;
+  public internalProcessEngineBaseRoute: string | null;
 
   constructor(router: Router,
               notificationService: NotificationService,
               eventAggregator: EventAggregator,
               authenticationService: IAuthenticationService,
-              openIdConnect: OpenIdConnect) {
+              openIdConnect: OpenIdConnect,
+              internalProcessEngineBaseRoute: string | null,
+            ) {
 
     this._router = router;
     this._notificationService = notificationService;
     this._eventAggregator = eventAggregator;
     this._authenticationService = authenticationService;
     this._openIdConnect = openIdConnect;
+    this.internalProcessEngineBaseRoute = internalProcessEngineBaseRoute;
   }
 
   public attached(): void {
@@ -78,6 +83,19 @@ export class ConfigPanel {
   public cancelUpdate(): void {
     this._notificationService.showNotification(NotificationType.WARNING, 'Settings dismissed!');
     this._router.navigateBack();
+  }
+
+  @computedFrom('baseRoute')
+  public get isBaseRouteNotSetToInternalProcessEngine(): boolean {
+    return this.internalProcessEngineBaseRoute !== this.baseRoute;
+  }
+
+  public hasInternalProcessEngineBaseRouteSet(): boolean {
+    return this.internalProcessEngineBaseRoute !== null;
+  }
+
+  public async setBaseRouteToInternalProcessEngine(): Promise<void> {
+    this.baseRoute = this.internalProcessEngineBaseRoute;
   }
 
 }

--- a/src/modules/config-panel/config-panel.ts
+++ b/src/modules/config-panel/config-panel.ts
@@ -1,6 +1,5 @@
 import {EventAggregator, Subscription} from 'aurelia-event-aggregator';
-import {bindable, inject} from 'aurelia-framework';
-import {computedFrom} from 'aurelia-framework';
+import {bindable, computedFrom, inject} from 'aurelia-framework';
 import {OpenIdConnect} from 'aurelia-open-id-connect';
 import {Router} from 'aurelia-router';
 import {IAuthenticationService} from '../../contracts/authentication/IAuthenticationService';
@@ -94,7 +93,7 @@ export class ConfigPanel {
     return this.internalProcessEngineBaseRoute !== null;
   }
 
-  public async setBaseRouteToInternalProcessEngine(): Promise<void> {
+  public setBaseRouteToInternalProcessEngine(): void {
     this.baseRoute = this.internalProcessEngineBaseRoute;
   }
 


### PR DESCRIPTION
## What did you change?

**Changes**:

- Display a info if the internal processengine is unused.
- Fix creating of main window.

PR: #664 

<img width="1210" alt="grafik" src="https://user-images.githubusercontent.com/4148404/43393603-09b638c8-93f8-11e8-9722-7cfc51a198df.png">


## How can others test the changes?

> Describe how others can test your changes (you can remove this section for typo fixes etc.)

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
