### PR TITLE
:bug: Only Show Diagram Upload Button on Diagram Detail View

### DIFF
--- a/aurelia_project/environments/dev.ts
+++ b/aurelia_project/environments/dev.ts
@@ -46,6 +46,8 @@ export default {
       updateProcess: 'navbar:process:update',
       disableSaveButton: 'navbar:saveButton:disable',
       enableSaveButton: 'navbar:saveButton:enable',
+      showDiagramUploadButton: 'navbar:diagramUploadButton:show',
+      hideDiagramUploadButton: 'navbar:diagramUploadButton:hide',
     },
     processDefDetail: {
       printDiagram: 'processdefdetail:diagram:print',

--- a/aurelia_project/environments/prod.ts
+++ b/aurelia_project/environments/prod.ts
@@ -46,6 +46,8 @@ export default {
       updateProcess: 'navbar:process:update',
       disableSaveButton: 'navbar:saveButton:disable',
       enableSaveButton: 'navbar:saveButton:enable',
+      showDiagramUploadButton: 'navbar:diagramUploadButton:show',
+      hideDiagramUploadButton: 'navbar:diagramUploadButton:hide',
     },
     processDefDetail: {
       printDiagram: 'processdefdetail:diagram:print',

--- a/aurelia_project/environments/stage.ts
+++ b/aurelia_project/environments/stage.ts
@@ -42,6 +42,8 @@ export default {
       updateProcess: 'navbar:process:update',
       disableSaveButton: 'navbar:saveButton:disable',
       enableSaveButton: 'navbar:saveButton:enable',
+      showDiagramUploadButton: 'navbar:diagramUploadButton:show',
+      hideDiagramUploadButton: 'navbar:diagramUploadButton:hide',
     },
     processDefDetail: {
       printDiagram: 'processdefdetail:diagram:print',

--- a/src/modules/diagram-detail/diagram-detail.ts
+++ b/src/modules/diagram-detail/diagram-detail.ts
@@ -60,6 +60,8 @@ export class DiagramDetail {
 
   public attached(): void {
     this._eventAggregator.publish(environment.events.navBar.showTools, this.diagram);
+    this._eventAggregator.publish(environment.events.navBar.showDiagramUploadButton);
+
     this._eventAggregator.publish(environment.events.statusBar.showDiagramViewButtons);
 
     this._subscriptions = [
@@ -121,6 +123,8 @@ export class DiagramDetail {
     }
 
     this._eventAggregator.publish(environment.events.navBar.hideTools);
+    this._eventAggregator.publish(environment.events.navBar.hideDiagramUploadButton);
+
     this._eventAggregator.publish(environment.events.statusBar.hideDiagramViewButtons);
   }
 

--- a/src/modules/navbar/navbar.html
+++ b/src/modules/navbar/navbar.html
@@ -59,7 +59,7 @@
           <i class="fas fa-play"></i>
         </button>
       </template>
-      <template if.bind="showTools">
+      <template if.bind="showDiagramUploadButton">
         <button class="menu-bar__menu-center--action-button" click.delegate="uploadProcess()" disabled.bind="validationError" title="Upload to ProcessEngine">
           <i class="fas fa-dolly-flatbed"></i>
         </button>

--- a/src/modules/navbar/navbar.ts
+++ b/src/modules/navbar/navbar.ts
@@ -16,6 +16,7 @@ export class NavBar {
   public showTools: boolean = false;
   public showStartButton: boolean = false;
   public disableSaveButton: boolean = false;
+  public showDiagramUploadButton: boolean = false;
 
   private _router: Router;
   private _eventAggregator: EventAggregator;
@@ -65,6 +66,14 @@ export class NavBar {
 
     this._eventAggregator.subscribe(environment.events.navBar.hideStartButton, () => {
       this.showStartButton = false;
+    });
+
+    this._eventAggregator.subscribe(environment.events.navBar.showDiagramUploadButton, () => {
+      this.showDiagramUploadButton = true;
+    });
+
+    this._eventAggregator.subscribe(environment.events.navBar.hideDiagramUploadButton, () => {
+      this.showDiagramUploadButton = false;
     });
   }
 


### PR DESCRIPTION
## What did you change?

**Changes**:

- Add events to hide and show digram upload button in navbar.
- Fire new events when opening or closing diagram detail view.
- Listen in navbar for events and hide or show button accordingly.

PR: #670 

## How can others test the changes?

- Checkout + build electron
- Goto detail view of a process on the file system
- Click upload button (should be shown)
- Goto the uploaded process on the processengine
- Upload button is hidden, only start button is shown.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
