### PR TITLE
🔓Add dummy token fallback to authentication service

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@process-engine/consumer_api_contracts": "^0.14.2",
     "@process-engine/management_api_client": "^0.6.0",
     "@process-engine/management_api_contracts": "0.7.0",
-    "@process-engine/skeleton-electron": "6.0.6",
+    "@process-engine/skeleton-electron": "6.0.7",
     "@process-engine/solutionexplorer.contracts": "1.0.0",
     "@process-engine/solutionexplorer.repository.contracts": "1.0.0",
     "@process-engine/solutionexplorer.repository.filesystem": "1.0.0",

--- a/src/modules/authentication/authentication.service.ts
+++ b/src/modules/authentication/authentication.service.ts
@@ -121,9 +121,15 @@ export class AuthenticationService implements IAuthenticationService {
 
   public getAccessToken(): string | null {
     if (!this._user) {
-      return null;
+      return this._getDummyAccessToken();
     }
     return this._user.access_token;
+  }
+
+  private _getDummyAccessToken(): string {
+    const dummyAccessTokenString: string = 'dummy_token';
+    const base64EncodedString: string = btoa(dummyAccessTokenString);
+    return base64EncodedString;
   }
 
   public async getIdentity(): Promise<IIdentity | null> {

--- a/src/modules/authentication/authentication.service.ts
+++ b/src/modules/authentication/authentication.service.ts
@@ -126,6 +126,10 @@ export class AuthenticationService implements IAuthenticationService {
     return this._user.access_token;
   }
 
+  // TODO: The dummy token needs to be removed in the future!!
+  // This dummy token serves as a temporary workaround to bypass login. This
+  // enables us to work without depending on a full environment with
+  // IdentityServer.
   private _getDummyAccessToken(): string {
     const dummyAccessTokenString: string = 'dummy_token';
     const base64EncodedString: string = btoa(dummyAccessTokenString);

--- a/src/modules/process-solution-panel/process-solution-panel.ts
+++ b/src/modules/process-solution-panel/process-solution-panel.ts
@@ -286,13 +286,13 @@ export class ProcessSolutionPanel {
   }
 
   private async _createIdentityForSolutionExplorer(): Promise<IIdentity> {
-    const solutionExplorerIdentity: IIdentity = await this._authenticationService.getIdentity();
+    const solutionExplorerIdentity: IIdentity = await this._authenticationService.getIdentity() || {};
 
     const solutionExplorerAccesstoken: {accessToken: string} = {
       accessToken: this._authenticationService.getAccessToken(),
     };
 
-    Object.assign(solutionExplorerIdentity || {}, solutionExplorerAccesstoken);
+    Object.assign(solutionExplorerIdentity, solutionExplorerAccesstoken);
 
     return solutionExplorerIdentity;
   }

--- a/src/modules/process-solution-panel/process-solution-panel.ts
+++ b/src/modules/process-solution-panel/process-solution-panel.ts
@@ -289,11 +289,11 @@ export class ProcessSolutionPanel {
   private async _createIdentityForSolutionExplorer(): Promise<IIdentity> {
     const solutionExplorerIdentity: IIdentity = await this._authenticationService.getIdentity() || {};
 
-    const solutionExplorerAccesstoken: {accessToken: string} = {
+    const solutionExplorerAccessToken: {accessToken: string} = {
       accessToken: this._authenticationService.getAccessToken(),
     };
 
-    Object.assign(solutionExplorerIdentity, solutionExplorerAccesstoken);
+    Object.assign(solutionExplorerIdentity, solutionExplorerAccessToken);
 
     return solutionExplorerIdentity;
   }

--- a/src/modules/process-solution-panel/process-solution-panel.ts
+++ b/src/modules/process-solution-panel/process-solution-panel.ts
@@ -287,7 +287,7 @@ export class ProcessSolutionPanel {
   }
 
   private async _createIdentityForSolutionExplorer(): Promise<IIdentity> {
-    const solutionExplorerIdentity: IIdentity = await this._authenticationService.getIdentity() || {};
+    const solutionExplorerIdentity: IIdentity = await this._authenticationService.getIdentity() || {} as IIdentity;
 
     const solutionExplorerAccessToken: {accessToken: string} = {
       accessToken: this._authenticationService.getAccessToken(),

--- a/src/modules/process-solution-panel/process-solution-panel.ts
+++ b/src/modules/process-solution-panel/process-solution-panel.ts
@@ -47,6 +47,7 @@ export class ProcessSolutionPanel {
   private _diagramValidationService: IDiagramValidationService;
   private _authenticationService: IAuthenticationService;
   private _identity: IIdentity;
+  private _solutionExplorerIdentity: IIdentity;
 
   constructor(eventAggregator: EventAggregator,
               router: Router,
@@ -112,6 +113,8 @@ export class ProcessSolutionPanel {
         this.openFileSystemIndexCard();
       }
     }
+
+    this._solutionExplorerIdentity = await this._createIdentityForSolutionExplorer();
 
     this._refreshProcesslist();
     this._eventAggregator.publish(environment.events.processSolutionPanel.toggleProcessSolutionExplorer);
@@ -263,10 +266,8 @@ export class ProcessSolutionPanel {
   private async _refreshProcesslist(): Promise<void> {
     const processengineSolutionString: string = window.localStorage.getItem('processEngineRoute');
 
-    const identity: IIdentity = await this._createIdentityForSolutionExplorer();
-
     try {
-      await this._solutionExplorerServiceManagementApi.openSolution(processengineSolutionString, identity);
+      await this._solutionExplorerServiceManagementApi.openSolution(processengineSolutionString, this._solutionExplorerIdentity);
       this.openedProcessEngineSolution = await this._solutionExplorerServiceManagementApi.loadSolution();
 
     } catch (error) {


### PR DESCRIPTION
Depends on:
* https://github.com/process-engine/iam/pull/8

## What did you change?

* if not logged in, `getAccessToken()` will provide a dummy token that can be used to bypass authorization in the backend

## How can others test the changes?

* run the `process-engine-server` from https://github.com/process-engine/skeleton/pull/70
* run the BPMN-Studio and make sure it uses the previously started server
* if you can view deployed processes, deploy processes, etc. without being logged in, everything should work fine

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
