### PR TITLE
🐛 Fix Windows Builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,9 +70,9 @@ pipeline {
       }
     }
     stage('build electron') {
-      when {
-        expression { branch_is_master || branch_is_develop }
-      }
+      // when {
+      //   expression { branch_is_master || branch_is_develop }
+      // }
       parallel {
         stage('Build on Linux') {
           agent {
@@ -126,41 +126,41 @@ pipeline {
           }
         }
         // The Windows build-step is currently diabled due to various build errors.
-        // stage('Build on Windows') {
-        //   agent {
-        //     label "windows"
-        //   }
-        //   steps {
-        //     unstash('post_build')
-        //     bat('node --version')
+        stage('Build on Windows') {
+          agent {
+            label "windows"
+          }
+          steps {
+            unstash('post_build')
+            bat('node --version')
 
-        //     script {
-        //       try {
-        //         timeout(time: 5, unit: 'MINUTES') {
-        //           powershell('npm install --global windows-build-tools');
-        //         }
-        //       } catch (error) {
-        //         echo('Unable to install windows-build-tools, trying to continue with jobs execution.')
-        //       }
-        //     }
+            // script {
+            //   try {
+            //     timeout(time: 5, unit: 'MINUTES') {
+            //       powershell('npm install --global windows-build-tools');
+            //     }
+            //   } catch (error) {
+            //     echo('Unable to install windows-build-tools, trying to continue with jobs execution.')
+            //   }
+            // }
 
-        //     // we copy the node_modules folder from the main slave
-        //     // which runs linux. Some dependencies may not be installed
-        //     // if they have a os restriction in their package.json
-        //     bat('npm install --prefer-offline')
+            // we copy the node_modules folder from the main slave
+            // which runs linux. Some dependencies may not be installed
+            // if they have a os restriction in their package.json
+            bat('npm install --prefer-offline')
 
-        //     bat('npm run jenkins-electron-install-app-deps')
-        //     bat('npm run jenkins-electron-rebuild-native')
-        //     bat('npm run jenkins-electron-build-windows')
+           // bat('npm run jenkins-electron-install-app-deps')
+            bat('npm run jenkins-electron-rebuild-native')
+            bat('npm run jenkins-electron-build-windows')
 
-        //     stash(includes: 'dist/*.*', excludes: 'electron-builder-effective-config.yaml', name: 'windows_results')
-        //   }
-        //   post {
-        //     always {
-        //       cleanup_workspace()
-        //     }
-        //   }
-        // }
+            stash(includes: 'dist/*.*', excludes: 'electron-builder-effective-config.yaml', name: 'windows_results')
+          }
+          post {
+            always {
+              cleanup_workspace()
+            }
+          }
+        }
       }
     }
     stage('test') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -125,7 +125,6 @@ pipeline {
             }
           }
         }
-        // The Windows build-step is currently diabled due to various build errors.
         stage('Build on Windows') {
           agent {
             label "windows"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -223,7 +223,7 @@ pipeline {
       steps {
         unstash('linux_results')
         unstash('macos_results')
-        // unstash('windows_results')
+        unstash('windows_results')
         nodejs(configId: env.NPM_RC_FILE, nodeJSInstallationName: env.NODE_JS_VERSION) {
           dir('.ci-tools') {
             sh('npm install --prefer-offline')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,9 +70,9 @@ pipeline {
       }
     }
     stage('build electron') {
-      // when {
-      //   expression { branch_is_master || branch_is_develop }
-      // }
+      when {
+        expression { branch_is_master || branch_is_develop }
+      }
       parallel {
         stage('Build on Linux') {
           agent {
@@ -134,22 +134,11 @@ pipeline {
             unstash('post_build')
             bat('node --version')
 
-            // script {
-            //   try {
-            //     timeout(time: 5, unit: 'MINUTES') {
-            //       powershell('npm install --global windows-build-tools');
-            //     }
-            //   } catch (error) {
-            //     echo('Unable to install windows-build-tools, trying to continue with jobs execution.')
-            //   }
-            // }
-
             // we copy the node_modules folder from the main slave
             // which runs linux. Some dependencies may not be installed
             // if they have a os restriction in their package.json
             bat('npm install --prefer-offline')
 
-           // bat('npm run jenkins-electron-install-app-deps')
             bat('npm run jenkins-electron-rebuild-native')
             bat('npm run jenkins-electron-build-windows')
 


### PR DESCRIPTION
## What did you change?

This PR should fixes the jenkins windows build.
The npm package `windows-build-tools` is now globally installed on the slave and the python path is configured correctly.

## How can others test the changes?

- check this https://ci.process-engine.io/job/process-engine_node-lts/job/bpmn-studio/job/feature%252Ftest_windows_build/2/display/redirect

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
