### PR TITLE
🐛 Fix Stopping Polling

### DIFF
--- a/src/modules/waiting-room/waiting-room.ts
+++ b/src/modules/waiting-room/waiting-room.ts
@@ -60,7 +60,7 @@ export class WaitingRoom {
 
   private async _startPolling(): Promise<void> {
     this._pollingTimer = setTimeout(async() => {
-      const noUserTaskFound: boolean = await this._pollUserTasksForCorrelation();
+      const noUserTaskFound: boolean = !(await this._pollUserTasksForCorrelation());
       const correlationIsStillActive: boolean = await this._pollIsCorrelationStillActive();
 
       if (noUserTaskFound && correlationIsStillActive) {


### PR DESCRIPTION
## What did you change?

This PR fixes stopping the polling in case that setTimeout does not cancel the timeout.

## How can others test the changes?

- Open up the BPMN-Studio 
- Go to the Detail View of any diagram with user tasks
- Run the task and cancel the user task
- Repeat this multiple times
- Notice that the user task will never be rendered again after canceling it

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
