### PR TITLE
✨Leave waiting-room and navigate to process detail view

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -115,7 +115,7 @@ export class App {
         moduleId: 'modules/config-panel/config-panel',
       },
       {
-        route: 'waitingroom/:correlationId',
+        route: 'waitingroom/:correlationId/:processModelId',
         title: 'Waiting Room',
         name: 'waiting-room',
         moduleId: 'modules/waiting-room/waiting-room',

--- a/src/modules/processdef-detail/processdef-detail.ts
+++ b/src/modules/processdef-detail/processdef-detail.ts
@@ -271,6 +271,7 @@ export class ProcessDefDetail {
 
       this._router.navigateToRoute('waiting-room', {
         correlationId: correlationId,
+        processModelId: this.process.id,
       });
     } catch (error) {
       this.

--- a/src/modules/task-dynamic-ui/task-dynamic-ui.ts
+++ b/src/modules/task-dynamic-ui/task-dynamic-ui.ts
@@ -86,6 +86,7 @@ export class TaskDynamicUi {
   private _finishTask(action: string): void {
     this._router.navigateToRoute('waiting-room', {
       correlationId: this._userTask.correlationId,
+      processModelId: this._userTask.processModelId,
     });
   }
 

--- a/src/modules/waiting-room/waiting-room.html
+++ b/src/modules/waiting-room/waiting-room.html
@@ -8,7 +8,7 @@
       <img src="src/resources/images/gears.svg">
     </div>
     <div class="row waiting-room__button-row">
-      <button class="btn btn-danger waiting-room__cancel-button" click.delegate="navigateToTaskList()" title="Redirect to Tasklist">Leave Waiting Room</button>
+      <button class="btn btn-danger waiting-room__cancel-button" click.delegate="navigateToDetailView()" title="Navigate to process">Navigate to process</button>
     </div>
   </div>
 </template>

--- a/src/modules/waiting-room/waiting-room.html
+++ b/src/modules/waiting-room/waiting-room.html
@@ -8,7 +8,7 @@
       <img src="src/resources/images/gears.svg">
     </div>
     <div class="row waiting-room__button-row">
-      <button class="btn btn-danger waiting-room__cancel-button" click.delegate="navigateToDetailView()" title="Navigate to process">Navigate to process</button>
+      <button class="btn btn-default waiting-room__cancel-button" click.delegate="navigateToDetailView()" title="Navigate to process">Navigate to process</button>
     </div>
   </div>
 </template>

--- a/src/modules/waiting-room/waiting-room.ts
+++ b/src/modules/waiting-room/waiting-room.ts
@@ -13,6 +13,7 @@ import {NotificationService} from '../notification/notification.service';
 
 interface RouteParameters {
   correlationId: string;
+  processModelId: string;
 }
 
 @inject(Router, 'NotificationService', 'AuthenticationService', 'ManagementApiClientService')
@@ -24,6 +25,7 @@ export class WaitingRoom {
   private _authenticationService: IAuthenticationService;
   private _managementApiClient: IManagementApiService;
   private _pollingTimer: NodeJS.Timer;
+  private _processModelId: string;
 
   constructor(router: Router,
               notificationService: NotificationService,
@@ -38,6 +40,7 @@ export class WaitingRoom {
 
   public activate(routeParameters: RouteParameters): void {
     this._correlationId = routeParameters.correlationId;
+    this._processModelId = routeParameters.processModelId;
   }
 
   public attached(): void {
@@ -52,9 +55,9 @@ export class WaitingRoom {
     return activationStrategy.replace;
   }
 
-  public navigateToTaskList(): void {
-    this._router.navigateToRoute('task-list-correlation', {
-      correlationId: this._correlationId,
+  public navigateToDetailView(): void {
+    this._router.navigateToRoute('processdef-detail', {
+      processModelId: this._processModelId,
     });
   }
 


### PR DESCRIPTION
## What did you change?

This PR lets the user navigate to the process detail view from the waiting-room.

## How can others test the changes?

- checkout the branch
- npm run electron-start-dev
- start a process with an usertask
- if you are in the waiting-room, click on the `navigate to process` button
- goto the dashboard and click on the `UserTask` link of a correlation
- click on the continue button of a task
- click on the `navigate to process` button again

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
