### PR TITLE
Make the reset script usable with windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "postinstall": "npm rebuild node-sass && electron-builder install-app-deps",
     "start_dev": "au run --watch",
     "build": "au build --prod",
-    "reset": "dev_tooling/scripts/build_clean_setup.bash",
+    "reset": "bash dev_tooling/scripts/build_clean_setup.bash",
     "deploy": "npm run build && npm publish",
     "integration-test-init": "webdriver-manager update && webdriver-manager start",
     "integration-test": "au e2e",


### PR DESCRIPTION
## What did you change?

This PR lets the reset bash script execute directly with `bash` when using `npm run reset`. 

This is necessary to use this command under Windows using Gitbash. 

*Keep in mind that you **have to use gitbash** when you run `npm run reset`* 

### TODO
We maybe should think about a native Windows Batch/Powershell alternative for this. 

## How can others test the changes?
* Run `npm run reset` with gitbash

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
