### PR TITLE
🎨 Make the diagram close button black when hovering

### DIFF
--- a/src/modules/process-solution-panel/process-solution-panel.scss
+++ b/src/modules/process-solution-panel/process-solution-panel.scss
@@ -147,6 +147,7 @@
 }
 
 .single-diagram-group__close:hover {
+  color: black;
   cursor: pointer;
   text-decoration: underline;
 }


### PR DESCRIPTION
## What did you change?

This PR makes the close button for single diagrams opened with the solution explorer filesystem black when hovering.

## How can others test the changes?

- checkout the branch
- `npm run electron-start-dev`
- open a single diagram with the solutiojn explorer
- move the mouse to the `x` button on the right of the process name
- see that it gets blacked

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
