### PR TITLE
✨Readd double click feature while BPMN-Studio is open

### DIFF
--- a/electron_app/electron.js
+++ b/electron_app/electron.js
@@ -115,7 +115,7 @@ Main._initializeApplication = function () {
         // we need to navigate to the start page to activate the Aurelia
         // application again. Due to the bug referenced above, the login page of
         // the IdentityServer is opened in the same window, so that the Aurelia
-        // application closes down. 
+        // application closes down.
 
         Main._window.loadURL(`file://${__dirname}/../index.html`);
 
@@ -192,7 +192,6 @@ Main._initializeApplication = function () {
   }
 
   function initializeFileOpenFeature() {
-
     app.on('window-all-closed', () => {
       app.quit();
       filePath = undefined;
@@ -208,6 +207,21 @@ Main._initializeApplication = function () {
       app.on('open-file', (event, path) => {
         filePath = path;
       });
+    });
+
+    /**
+     * Wait for the "waiting"-event signalling the app has started and the
+     * component is ready to handle events.
+     *
+     * Register an "open-file"-listener to get the path to file which has been
+     * clicked on.
+     *
+     * "open-file" gets fired when someone double clicks a .bpmn file.
+     */
+    electron.ipcMain.on('waiting-for-double-file-click', (mainEvent) => {
+      app.on('open-file', (event, path) => {
+        mainEvent.sender.send('double-click-on-file', path);
+      })
     });
 
     electron.ipcMain.on('get_opened_file', (event) => {

--- a/src/app.html
+++ b/src/app.html
@@ -11,7 +11,7 @@
     <nav-bar show-solution-explorer.two-way="showSolutionExplorer"></nav-bar>
 
     <div class="bpmn-studio-layout__content">
-      <process-solution-panel if.bind="showSolutionExplorer"></process-solution-panel>
+      <process-solution-panel show.bind="showSolutionExplorer"></process-solution-panel>
       <div class="router-view">
         <router-view></router-view>
       </div>


### PR DESCRIPTION
## What did you change?

This branch readds the lost feature of double clicking while BPMN-Studio is open.

Fixes #736

## How can others test the changes?

Open BPMN-Studio and double click a .bpmn-file.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
