### PR TITLE
💄 Hide Scrollbar Of Property Panel

### DIFF
--- a/src/modules/bpmn-io/bpmn-io.scss
+++ b/src/modules/bpmn-io/bpmn-io.scss
@@ -20,6 +20,10 @@
   overflow-y: auto;
 }
 
+.properties::-webkit-scrollbar {
+  display: none;
+}
+
 .modeler .label {
   color: black;
 }

--- a/src/modules/bpmn-io/bpmn-io.scss
+++ b/src/modules/bpmn-io/bpmn-io.scss
@@ -18,6 +18,7 @@
   height: 100%;
   background: rgb(220, 219, 219);
   overflow-y: auto;
+  -ms-overflow-style: none;
 }
 
 .properties::-webkit-scrollbar {
@@ -81,6 +82,7 @@
   overflow-y: auto;
   overflow-x: hidden;
   border-right: 2px solid #dcdbdb;
+  -ms-overflow-style: none;
 }
 
 .bpmn-io-layout__tools-left::-webkit-scrollbar {


### PR DESCRIPTION
## What did you change?

This PR hides the scrollbar of the property panel, because it breaks the layout.

Fixes #744

## How can others test the changes?

- Open up the BPMN-Studio 
- Go to the Detail View of any diagram 
- Open the Property Panel
- Add some Properties until the property panel is scrollable or open up the color selection
- Notice that there will no longer be a scrollbar that breaks the layout

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
