### PR TITLE
🐛 Fix Setting Default Base Route for Non Electron

### DIFF
--- a/aurelia_project/environments/dev.ts
+++ b/aurelia_project/environments/dev.ts
@@ -68,9 +68,7 @@ export default {
       toggleProcessSolutionExplorer: 'processSolutionPanel:processsolutionexplorer:toggle',
     },
   },
-  bpmnStudioClient: {
-    baseRoute: processEngineRoute,
-  },
+  baseRoute: processEngineRoute,
   propertyPanel: {
     defaultWidth: 250,
   },

--- a/aurelia_project/environments/prod.ts
+++ b/aurelia_project/environments/prod.ts
@@ -68,9 +68,7 @@ export default {
       toggleProcessSolutionExplorer: 'processSolutionPanel:processsolutionexplorer:toggle',
     },
   },
-  bpmnStudioClient: {
-    baseRoute: processEngineRoute,
-  },
+  baseRoute: processEngineRoute,
   propertyPanel: {
     defaultWidth: 250,
   },

--- a/aurelia_project/environments/stage.ts
+++ b/aurelia_project/environments/stage.ts
@@ -64,9 +64,7 @@ export default {
       toggleProcessSolutionExplorer: 'processSolutionPanel:processsolutionexplorer:toggle',
     },
   },
-  bpmnStudioClient: {
-    baseRoute: processEngineRoute,
-  },
+  baseRoute: processEngineRoute,
   propertyPanel: {
     defaultWidth: 250,
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,7 +27,7 @@ export function configure(aurelia: Aurelia): void {
 
     aurelia.container.registerInstance('InternalProcessEngineBaseRoute', processEngineBaseRouteWithProtocol);
   } else {
-    localStorage.setItem('InternalProcessEngineRoute', environment.bpmnStudioClient.baseRoute);
+    localStorage.setItem('InternalProcessEngineRoute', environment.baseRoute);
     aurelia.container.registerInstance('InternalProcessEngineBaseRoute', null);
   }
 
@@ -41,7 +41,7 @@ export function configure(aurelia: Aurelia): void {
 
   const processEngineRouteExists: boolean = processEngineRoute !== null && processEngineRoute !== '';
   if (processEngineRouteExists) {
-    environment.bpmnStudioClient.baseRoute = processEngineRoute;
+    environment.baseRoute = processEngineRoute;
     environment.processengine.routes.processes = `${processEngineRoute}/datastore/ProcessDef`;
     environment.processengine.routes.iam = `${processEngineRoute}/iam`;
     environment.processengine.routes.startProcess = `${processEngineRoute}/processengine/start`;

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ export function configure(aurelia: Aurelia): void {
 
     aurelia.container.registerInstance('InternalProcessEngineBaseRoute', processEngineBaseRouteWithProtocol);
   } else {
+    localStorage.setItem('InternalProcessEngineRoute', environment.bpmnStudioClient.baseRoute);
     aurelia.container.registerInstance('InternalProcessEngineBaseRoute', null);
   }
 

--- a/src/modules/config-panel/config-panel.ts
+++ b/src/modules/config-panel/config-panel.ts
@@ -41,7 +41,7 @@ export class ConfigPanel {
   }
 
   public attached(): void {
-    this.baseRoute = this.config.bpmnStudioClient.baseRoute;
+    this.baseRoute = this.config.baseRoute;
 
     // If there is a route set in the localstorage, we prefer this setting.
     const customProcessEngineRoute: string = window.localStorage.getItem('processEngineRoute');


### PR DESCRIPTION
## What did you change?

This PR fixes setting the base route for the non electron version.
This bug only occurs when the localStorage is cleared.

## How can others test the changes?

- Open up the BPMN-Studio 
- Have a look at the base route in the status bar (lower left corner). This should no longer say "null"

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
