### PR TITLE
✨ Prevent Drag and Drop from Redirecting

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -22,6 +22,12 @@ export class App {
       return false;
     };
 
+    /*
+    * These EventListeners are used to prevent the BPMN-Studio from redirecting after
+    * trying to drop a file to the BPMN-Studio
+    *
+    * TODO: Import the dropped filed when it is a valid BPMN File
+    */
     document.addEventListener('dragover', this._preventDefaultFunction);
     document.addEventListener('drop', this._preventDefaultFunction);
   }

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,24 +1,29 @@
 import {inject} from 'aurelia-framework';
 import {OpenIdConnect} from 'aurelia-open-id-connect';
 import {Router, RouterConfiguration} from 'aurelia-router';
+import {NotificationType} from './contracts/index';
 import {AuthenticationService} from './modules/authentication/authentication.service';
+import {NotificationService} from './modules/notification/notification.service';
 
-@inject(OpenIdConnect, 'AuthenticationService')
+@inject(OpenIdConnect, 'AuthenticationService', 'NotificationService')
 export class App {
   private _openIdConnect: OpenIdConnect;
   private _authenticationService: AuthenticationService;
   private _router: Router;
+  private _notificationService: NotificationService;
 
   private _preventDefaultBehaviour: EventListener;
 
-  constructor(openIdConnect: OpenIdConnect, authenticationService: AuthenticationService) {
+  constructor(openIdConnect: OpenIdConnect, authenticationService: AuthenticationService, notificationService: NotificationService) {
     this._openIdConnect = openIdConnect;
     this._authenticationService = authenticationService;
+    this._notificationService = notificationService;
   }
 
   public activate(): void {
     this._preventDefaultBehaviour = (event: Event): boolean => {
       event.preventDefault();
+      this._notificationService.showNotification(NotificationType.INFO, 'Drag and drop is currently not supported.');
       return false;
     };
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -24,7 +24,7 @@ export class App {
 
     /*
     * These EventListeners are used to prevent the BPMN-Studio from redirecting after
-    * trying to drop a file to the BPMN-Studio
+    * trying to drop a file to the BPMN-Studio.
     *
     * TODO: Import the dropped filed when it is a valid BPMN File
     */

--- a/src/app.ts
+++ b/src/app.ts
@@ -14,6 +14,16 @@ export class App {
     this._authenticationService = authenticationService;
   }
 
+  public activate(): void {
+    const preventDefaultFunction: EventListener =  (event: Event): boolean => {
+      event.preventDefault();
+      return false;
+    };
+
+    document.addEventListener('dragover', preventDefaultFunction);
+    document.addEventListener('drop', preventDefaultFunction);
+  }
+
   private _parseDeepLinkingUrl(url: string): string {
     const customProtocolPrefix: string = 'bpmn-studio://';
     const urlFragment: string = url.substring(customProtocolPrefix.length);

--- a/src/app.ts
+++ b/src/app.ts
@@ -9,7 +9,7 @@ export class App {
   private _authenticationService: AuthenticationService;
   private _router: Router;
 
-  private _preventDefaultFunction: EventListener;
+  private _preventDefaultBehaviour: EventListener;
 
   constructor(openIdConnect: OpenIdConnect, authenticationService: AuthenticationService) {
     this._openIdConnect = openIdConnect;
@@ -17,7 +17,7 @@ export class App {
   }
 
   public activate(): void {
-    this._preventDefaultFunction = (event: Event): boolean => {
+    this._preventDefaultBehaviour = (event: Event): boolean => {
       event.preventDefault();
       return false;
     };
@@ -28,13 +28,13 @@ export class App {
     *
     * TODO: Import the dropped filed when it is a valid BPMN File
     */
-    document.addEventListener('dragover', this._preventDefaultFunction);
-    document.addEventListener('drop', this._preventDefaultFunction);
+    document.addEventListener('dragover', this._preventDefaultBehaviour);
+    document.addEventListener('drop', this._preventDefaultBehaviour);
   }
 
   public deactivate(): void {
-    document.removeEventListener('dragover', this._preventDefaultFunction);
-    document.removeEventListener('drop', this._preventDefaultFunction);
+    document.removeEventListener('dragover', this._preventDefaultBehaviour);
+    document.removeEventListener('drop', this._preventDefaultBehaviour);
   }
 
   private _parseDeepLinkingUrl(url: string): string {

--- a/src/app.ts
+++ b/src/app.ts
@@ -9,19 +9,26 @@ export class App {
   private _authenticationService: AuthenticationService;
   private _router: Router;
 
+  private _preventDefaultFunction: EventListener;
+
   constructor(openIdConnect: OpenIdConnect, authenticationService: AuthenticationService) {
     this._openIdConnect = openIdConnect;
     this._authenticationService = authenticationService;
   }
 
   public activate(): void {
-    const preventDefaultFunction: EventListener =  (event: Event): boolean => {
+    this._preventDefaultFunction = (event: Event): boolean => {
       event.preventDefault();
       return false;
     };
 
-    document.addEventListener('dragover', preventDefaultFunction);
-    document.addEventListener('drop', preventDefaultFunction);
+    document.addEventListener('dragover', this._preventDefaultFunction);
+    document.addEventListener('drop', this._preventDefaultFunction);
+  }
+
+  public deactivate(): void {
+    document.removeEventListener('dragover', this._preventDefaultFunction);
+    document.removeEventListener('drop', this._preventDefaultFunction);
   }
 
   private _parseDeepLinkingUrl(url: string): string {

--- a/src/app.ts
+++ b/src/app.ts
@@ -26,7 +26,7 @@ export class App {
     * These EventListeners are used to prevent the BPMN-Studio from redirecting after
     * trying to drop a file to the BPMN-Studio.
     *
-    * TODO: Import the dropped filed when it is a valid BPMN File
+    * TODO: Import the dropped file when it is a valid BPMN file
     */
     document.addEventListener('dragover', this._preventDefaultBehaviour);
     document.addEventListener('drop', this._preventDefaultBehaviour);


### PR DESCRIPTION
## What did you change?

Currently drag and drop is not supported.
For that reason, dragging a file to the BPMN-Studio would cause electron/the browser to open the file.
This PR simply prevents the BPMN-Studio from opening the file.

Fixes #724

## How can others test the changes?

- Open up the BPMN-Studio 
- Drag and Drop a File to the BPMN-Studio
- Notice that nothing happens

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
