### PR TITLE
Add documentation for the scripts defined in the package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,16 +202,16 @@ Die Tests starten:
 npm run integration-test
 ```
 
-## Shortcut scripts
+## Shortcut Skripte
 
-Es sind bereits einige Script in der `package.json` - Datei vordefiniert, welche
+Es sind bereits einige Skripte in der `package.json` - Datei vordefiniert, welche
 sich einfach durch `npm run <name>` ausführen lassen.
 
 Die folgenden vordefinierten Skripte könnten hilfreich sein:
 * `build`: Baut das Aurelia Bundle
-* `start`: Startet die BPMN - Studio Webanwendung
-* `start_dev`: Startet die BPMN - Studio Webanwendung und trackt die Quelldatein (geänderte Quelltextdatein werden neu transpiliert und die Webanwendung wird neu geladen)
-* `electron-start-dev`: Baut das Aurelia bundle und startet die Electron Anwendung
+* `start`: Startet die BPMN-Studio Webanwendung
+* `start_dev`: Startet die BPMN-Studio Webanwendung und trackt die Quelldatein (geänderte Quelltextdatein werden neu transpiliert und die Webanwendung wird neu geladen)
+* `electron-start-dev`: Baut das Aurelia Bundle und startet die Electron Anwendung
 * `reset`: Entfernt alle node_modules, die `package-lock.json` Datei und bereinigt den NPM - Cache
 * `lint`: Startet `tslint` für das gesamte Projekt
 * `electron-build-macos`: Baut die Electron - Anwendung für MacOS

--- a/README.md
+++ b/README.md
@@ -202,6 +202,22 @@ Die Tests starten:
 npm run integration-test
 ```
 
+## Shortcut scripts
+
+Es sind bereits einige Script in der `package.json` - Datei vordefiniert, welche
+sich einfach durch `npm run <name>` ausführen lassen.
+
+Die folgenden vordefinierten Skripte könnten hilfreich sein:
+* `build`: Baut das Aurelia Bundle
+* `start`: Startet die BPMN - Studio Webanwendung
+* `start_dev`: Startet die BPMN - Studio Webanwendung und trackt die Quelldatein (geänderte Quelltextdatein werden neu transpiliert und die Webanwendung wird neu geladen)
+* `electron-start-dev`: Baut das Aurelia bundle und startet die Electron Anwendung
+* `reset`: Entfernt alle node_modules, die `package-lock.json` Datei und bereinigt den NPM - Cache
+* `lint`: Startet `tslint` für das gesamte Projekt
+* `electron-build-macos`: Baut die Electron - Anwendung für MacOS
+* `electron-build-linux`: Baut die Electron - Anwendung für Linux
+* `electron-build-windows`: Baut die Electron - Anwendung für Windows
+
 ## Was muss ich sonst noch wissen?
 
 Die Konfiguration liegt unter `aurelia_project/environments/dev|stage|prod.ts`.

--- a/README.md
+++ b/README.md
@@ -35,13 +35,16 @@ Engine verbunden werden, um diese Diagramme auszuführen.
 **Notizen:**
 
 1. Für `npm run electron-build-<OS>` gilt:
-  Für den Platzhalter `<OS>` können folgende Werte eingesetzt werden:
-  - `linux` für Linux
-  - `macos` für MacOS
-  - `windows` für Windows
 
-  Beispiel:
-  `npm run electron-build-macos`
+   Für den Platzhalter `<OS>` können folgende Werte eingesetzt werden:
+
+   - `linux` für Linux
+   - `macos` für MacOS
+   - `windows` für Windows
+
+   Beispiel:
+
+   `npm run electron-build-macos`
 
 **TL;DR Tests**
 
@@ -204,19 +207,48 @@ npm run integration-test
 
 ## Shortcut Skripte
 
-Es sind bereits einige Skripte in der `package.json` - Datei vordefiniert, welche
-sich einfach durch `npm run <name>` ausführen lassen.
+Es sind Skripte in der `package.json` vordefiniert, welche
+sich durch `npm run <script name>` ausführen lassen.
 
-Die folgenden vordefinierten Skripte könnten hilfreich sein:
-* `build`: Baut das Aurelia Bundle
-* `start`: Startet die BPMN-Studio Webanwendung
-* `start_dev`: Startet die BPMN-Studio Webanwendung und trackt die Quelldatein (geänderte Quelltextdatein werden neu transpiliert und die Webanwendung wird neu geladen)
-* `electron-start-dev`: Baut das Aurelia Bundle und startet die Electron Anwendung
-* `reset`: Entfernt alle node_modules, die `package-lock.json` Datei und bereinigt den NPM - Cache
-* `lint`: Startet `tslint` für das gesamte Projekt
-* `electron-build-macos`: Baut die Electron - Anwendung für MacOS
-* `electron-build-linux`: Baut die Electron - Anwendung für Linux
-* `electron-build-windows`: Baut die Electron - Anwendung für Windows
+Die folgenden Skripte, werden in unserem Tooling verwendet:
+
+* `build`
+
+   Baut das Aurelia Bundle.
+
+* `start`
+
+   Startet die BPMN-Studio Webanwendung
+
+* `start_dev`
+
+   Startet die BPMN-Studio Webanwendung und trackt die Quelldatein
+   (geänderte Quelltextdatein werden neu transpiliert und die
+   Webanwendung wird neu geladen).
+
+* `electron-start-dev`
+
+   Baut das Aurelia Bundle und startet die Electron Anwendung.
+
+* `reset`
+
+   Entfernt alle node_modules, die `package-lock.json` Datei und bereinigt den NPM-Cache.
+
+* `lint`
+
+   Startet `tslint` für das gesamte Projekt.
+
+* `electron-build-macos`
+
+   Baut die Electron-Anwendung für macOS.
+
+* `electron-build-linux`
+
+   Baut die Electron-Anwendung für Linux.
+
+* `electron-build-windows`
+
+   Baut die Electron-Anwendung für Windows.
 
 ## Was muss ich sonst noch wissen?
 


### PR DESCRIPTION
## What did you change?

This PR adds a documentation for the predefined scripts in the _package.json_ file which are callable via `npm run script`. 
The idea was to give a kind of overview of maybe helpful scripts. 

## How can others test the changes?

* Look at the readme

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [ ] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [ ] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [ ] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
