### PR TITLE
🐛 Fix UserTask FormField type defaults to CustomType

### DIFF
--- a/src/modules/property-panel/indextabs/forms/sections/basics/basics.ts
+++ b/src/modules/property-panel/indextabs/forms/sections/basics/basics.ts
@@ -191,13 +191,6 @@ export class BasicsSection implements ISection {
     this.isFormSelected = true;
 
     const selectedFormHasType: boolean = this.selectedForm.type !== undefined;
-
-    /*
-     * If the Form type is not defined, we can set it to null. If it is defined,
-     * assign the correct form type.
-     *
-     * TODO: Find out if this is the proper way to handle such case.
-     */
     this.selectedType = selectedFormHasType
                     ? this._getTypeAndHandleCustomType(this.selectedForm.type)
                     : null;

--- a/src/modules/property-panel/indextabs/forms/sections/basics/basics.ts
+++ b/src/modules/property-panel/indextabs/forms/sections/basics/basics.ts
@@ -189,7 +189,21 @@ export class BasicsSection implements ISection {
     this.validationController.validate();
 
     this.isFormSelected = true;
-    this.selectedType = this._getTypeAndHandleCustomType(this.selectedForm.type);
+
+    const selectedFormHasType: boolean = this.selectedForm.type !== undefined;
+
+    /*
+     * If the Form type is not defined, we can set it to null. If it is defined,
+     * assign the correct form type.
+     *
+     * TODO: Find out if this is the proper way to handle such case.
+     */
+    if (selectedFormHasType) {
+      this.selectedType = this._getTypeAndHandleCustomType(this.selectedForm.type);
+    } else {
+      this.selectedType = null;
+    }
+
     this._selectedIndex = this._getSelectedIndex();
 
     this._setValidationRules();
@@ -321,6 +335,7 @@ export class BasicsSection implements ISection {
                                     || this._formElement.fields === undefined
                                     || this._formElement.fields === null
                                     || this._formElement.fields.length === 0;
+
     if (noFormFieldsExist) {
       return;
     }

--- a/src/modules/property-panel/indextabs/forms/sections/basics/basics.ts
+++ b/src/modules/property-panel/indextabs/forms/sections/basics/basics.ts
@@ -212,8 +212,8 @@ export class BasicsSection implements ISection {
         this.selectedType !== FormfieldTypes.custom_type;
 
       if (selectedTypeIsNotCustomType) {
-          return this.selectedType;
-        }
+        return this.selectedType;
+      }
 
       const customTypeIsDefined: boolean = this.customType !== undefined;
       return customTypeIsDefined

--- a/src/modules/property-panel/indextabs/forms/sections/basics/basics.ts
+++ b/src/modules/property-panel/indextabs/forms/sections/basics/basics.ts
@@ -198,11 +198,9 @@ export class BasicsSection implements ISection {
      *
      * TODO: Find out if this is the proper way to handle such case.
      */
-    if (selectedFormHasType) {
-      this.selectedType = this._getTypeAndHandleCustomType(this.selectedForm.type);
-    } else {
-      this.selectedType = null;
-    }
+    this.selectedType = selectedFormHasType
+                    ? this._getTypeAndHandleCustomType(this.selectedForm.type)
+                    : null;
 
     this._selectedIndex = this._getSelectedIndex();
 

--- a/src/modules/property-panel/indextabs/forms/sections/basics/basics.ts
+++ b/src/modules/property-panel/indextabs/forms/sections/basics/basics.ts
@@ -202,17 +202,24 @@ export class BasicsSection implements ISection {
   }
 
   public updateType(): void {
-    let type: string;
+    /*
+     * Evaluates the type of the form field.
+     *
+     * If the user selected a custom type, find out what type the user provided.
+     */
+    const type: string = ((): string => {
+      const selectedTypeIsNotCustomType: boolean =
+        this.selectedType !== FormfieldTypes.custom_type;
 
-    if (this.selectedType === FormfieldTypes.custom_type) {
+      if (selectedTypeIsNotCustomType) {
+          return this.selectedType;
+        }
+
       const customTypeIsDefined: boolean = this.customType !== undefined;
-      type = customTypeIsDefined
-                ? this.customType
-                : '';
-
-    } else {
-      type = this.selectedType;
-    }
+      return customTypeIsDefined
+                  ? this.customType
+                  : '';
+    })();
 
     this._formElement.fields[this._selectedIndex].type = type;
     this._reloadEnumValues();

--- a/src/modules/property-panel/indextabs/forms/sections/basics/basics.ts
+++ b/src/modules/property-panel/indextabs/forms/sections/basics/basics.ts
@@ -205,7 +205,11 @@ export class BasicsSection implements ISection {
     let type: string;
 
     if (this.selectedType === FormfieldTypes.custom_type) {
-      type = this.customType;
+      const customTypeIsDefined: boolean = this.customType !== undefined;
+      type = customTypeIsDefined
+                ? this.customType
+                : '';
+
     } else {
       type = this.selectedType;
     }


### PR DESCRIPTION
## What did you change?

Fixes #731 

This is more a _quickfix_. 
IMO we should discuss, if it should be possible for the user to save the diagram, if it contains a UserTask with a FormField, that has no associated type. 

## How can others test the changes?
* Create a UserTask
* Add a FormField
* Dont specify a form type
* Save the diagram
* Leave the Detail view
* Open the Diagram again
* The FormType of your added FormField should not be _custom type_. 

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [ ] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [ ] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
