### PR TITLE
🐛 Fix Auto Update on Windows

### DIFF
--- a/electron_app/electron.js
+++ b/electron_app/electron.js
@@ -103,18 +103,7 @@ Main._initializeApplication = function () {
   });
 
   initializeDeepLinking();
-
-  const platformIsNotWindows = process.platform !== 'win32';
-  // The AutoUpdater gets not initialized on windows, because it is broken currently
-  // See https://github.com/process-engine/bpmn-studio/issues/715
-  if (platformIsNotWindows) {
-    initializeAutoUpdater();
-  } else {
-    electron.ipcMain.on('add_autoupdater_listener', (event) => {
-      event.sender.send('autoupdater_windows_notification');
-    });
-  }
-
+  initializeAutoUpdater();
   initializeFileOpenFeature();
 
   function initializeDeepLinking() {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     ],
     "nsis": {
       "perMachine": true,
-      "oneClick": false
+      "oneClick": false,
+      "allowToChangeInstallationDirectory": true
     },
     "win": {
       "target": "nsis",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "nsis": {
       "perMachine": true,
       "oneClick": false,
-      "allowToChangeInstallationDirectory": true
+      "allowToChangeInstallationDirectory": true,
+      "runAfterFinish": false
     },
     "win": {
       "target": "nsis",

--- a/src/main.ts
+++ b/src/main.ts
@@ -107,17 +107,6 @@ export function configure(aurelia: Aurelia): void {
 
         notificationService.showNonDisappearingNotification(NotificationType.ERROR, errorMessage);
       });
-
-      ipcRenderer.on('autoupdater_windows_notification', () => {
-        // tslint:disable-next-line: max-line-length
-        const targetHref: string = `<a href="javascript:nodeRequire('open')('https://github.com/process-engine/bpmn-studio/issues/715')">click here</a>`;
-
-        const infoMessage: string = `The autoupdater is currently unavailable for the Windows platform.
-         There is more information about this here: ${targetHref}.`;
-        const notificationService: NotificationService = aurelia.container.get('NotificationService');
-
-        notificationService.showNonDisappearingNotification(NotificationType.INFO, infoMessage);
-      });
     }
   });
 }


### PR DESCRIPTION
Currently the 'Run BPMN-Studio'-Checkbox is disabled, because there is a bug when running the BPMN-Studio that way.

**Changes:**

1. Enable Auto Updater on Windows
2. Make Installation Directory Customisable
3. Disable 'Run BPMN-Studio'-Checkbox

**Issues:**

Closes #715
Closes #739

PR: #1018

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).

## Example

<details>
<summary>
:warning: Before merging please click here to expand and follow the guide.
</summary>
<br>

Please use `:twisted_rightwards_arrows:` at the beginning of your merge commit title.

Example 1:

<pre>
<code>
:twisted_rightwards_arrows: :bug: Fix Wrong Text Decoration at ...
</code>
</pre>

To get your commit message, just copy the first part of this pull request.

Example 2:
<pre>
<code>
**Changes:**

- Fixes Wrong Text Decoration at ...
- Fixes some typos
- ...

**Issues:**

Closes #NumberOfFixedIssue

PR: #NumberOfThisPR
</code>
</pre>
</details>

## Emojis

<details>
<summary>
Expand for a list of most used Emojis.
</summary>
<br>

Please prefix your commit messages with an Emoji.

Ref: https://gitmoji.carloscuesta.me/

| Description              | Glyphe               | Emoji  |
|--------------------------|----------------------|--------|
| Bugfix                   | `:bug:`              | 🐛     |
| Configuration releated   | `:wrench:`           | 🔧     |
| Cosmetic                 | `:lipstick:`         | 💄     |
| Dependencies Downgrade   | `:arrow_down:`       | ⬇️     |
| Dependencies Upgrade     | `:arrow_up:`         | ⬆️     |
| Formatting               | `:art:`              | 🎨     |
| Improving Performance    | `:zap:`              | ⚡️     |
| Initial commit           | `:tada:`             | 🎉     |
| Linter                   | `:rotating_light:`   | 🚨     |
| Miscellaneous            | `:package:`          | 📦     |
| New Feature              | `:sparkles:`         | ✨     |
| Refactoring Code         | `:recycle:`          | ♻️     |
| Releasing / Version tags | `:bookmark:`         | 🔖     |
| Removing Stuff           | `:fire:`             | 🔥     |
| Tests                    | `:white_check_mark:` | ✅     |
| Work In Progress (WIP)   | `:construction:`     | 🚧     |

</details>
