### PR TITLE
🐛Check for Same Diagram Name

### DIFF
--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -620,6 +620,11 @@ export class SolutionExplorerSolution {
       return false;
     }
 
+    const filenameWasNotChanged: boolean = this._currentlyRenamingDiagram.name === this._diagramRenamingState.currentDiagramInputValue;
+    if (filenameWasNotChanged) {
+      return true;
+    }
+
     try {
       await this.solutionService.renameDiagram(this._currentlyRenamingDiagram, this._diagramRenamingState.currentDiagramInputValue);
     } catch (error) {

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -115,7 +115,7 @@ export class SolutionExplorerSolution {
         const diagramWithIdDoesNotExists: boolean = this.
           _findURIObject(this._openedSolution.diagrams, diagramUri) === undefined;
 
-        const newDiagramNameIsValid: boolean = diagramWithIdDoesNotExists || diagramNameIsTheSame;
+        const newDiagramNameIsValid: boolean = diagramWithIdDoesNotExists || diagramNameIsUnchanged;
 
         return newDiagramNameIsValid;
       })

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -118,9 +118,7 @@ export class SolutionExplorerSolution {
         const diagramWithUriDoesNotExist: boolean = this.
           _findURIObject(this._openedSolution.diagrams, diagramUri) === undefined;
 
-        const newDiagramNameIsValid: boolean = diagramWithUriDoesNotExist;
-
-        return newDiagramNameIsValid;
+        return diagramWithUriDoesNotExist;
       })
       .withMessage('A diagram with that name already exists.');
 

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -109,11 +109,15 @@ export class SolutionExplorerSolution {
         // The solution may have changed on the file system.
         await this.updateSolution();
 
+        const diagramNameIsTheSame: boolean = this._currentlyRenamingDiagram.name === input;
+
         const diagramUri: string = `${this._openedSolution.uri}/${input}.bpmn`;
         const diagramWithIdDoesNotExists: boolean = this.
           _findURIObject(this._openedSolution.diagrams, diagramUri) === undefined;
 
-        return diagramWithIdDoesNotExists;
+        const newDiagramNameIsValid: boolean = diagramWithIdDoesNotExists || diagramNameIsTheSame;
+
+        return newDiagramNameIsValid;
       })
       .withMessage('A diagram with that name already exists.');
 

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -106,16 +106,19 @@ export class SolutionExplorerSolution {
       .withMessage('The diagram name can not end with a whitespace character.')
       .then()
       .satisfies(async(input: string) => {
+        const diagramNameIsUnchanged: boolean = this._currentlyRenamingDiagram.name === input;
+        if (diagramNameIsUnchanged) {
+          return true;
+        }
+
         // The solution may have changed on the file system.
         await this.updateSolution();
-
-        const diagramNameIsUnchanged: boolean = this._currentlyRenamingDiagram.name === input;
 
         const diagramUri: string = `${this._openedSolution.uri}/${input}.bpmn`;
         const diagramWithIdDoesNotExists: boolean = this.
           _findURIObject(this._openedSolution.diagrams, diagramUri) === undefined;
 
-        const newDiagramNameIsValid: boolean = diagramWithIdDoesNotExists || diagramNameIsUnchanged;
+        const newDiagramNameIsValid: boolean = diagramWithIdDoesNotExists;
 
         return newDiagramNameIsValid;
       })

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -115,10 +115,10 @@ export class SolutionExplorerSolution {
         await this.updateSolution();
 
         const diagramUri: string = `${this._openedSolution.uri}/${input}.bpmn`;
-        const diagramWithIdDoesNotExists: boolean = this.
+        const diagramWithUriDoesNotExist: boolean = this.
           _findURIObject(this._openedSolution.diagrams, diagramUri) === undefined;
 
-        const newDiagramNameIsValid: boolean = diagramWithIdDoesNotExists;
+        const newDiagramNameIsValid: boolean = diagramWithUriDoesNotExist;
 
         return newDiagramNameIsValid;
       })

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -109,7 +109,7 @@ export class SolutionExplorerSolution {
         // The solution may have changed on the file system.
         await this.updateSolution();
 
-        const diagramNameIsTheSame: boolean = this._currentlyRenamingDiagram.name === input;
+        const diagramNameIsUnchanged: boolean = this._currentlyRenamingDiagram.name === input;
 
         const diagramUri: string = `${this._openedSolution.uri}/${input}.bpmn`;
         const diagramWithIdDoesNotExists: boolean = this.


### PR DESCRIPTION
**Changes:**

1. Adds a check to validate if the diagram name hasn't changed yet when renaming.
This won't show the error message "Diagram with same name already exists" when the user didn't type anything yet.

**Issues:**

Closes #1062 

PR: #1063

---

See the [examples](#example) for inspiration.

## How can others test the changes?

> Describe how others can test your changes (you can remove this section for typo fixes etc.)

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).

## Example

<details>
<summary>
:warning: Before merging please click here to expand and follow the guide.
</summary>
<br>

Please use `:twisted_rightwards_arrows:` at the beginning of your merge commit title.

Example 1:

<pre>
<code>
:twisted_rightwards_arrows: :bug: Fix Wrong Text Decoration at ...
</code>
</pre>

To get your commit message, just copy the first part of this pull request.

Example 2:
<pre>
<code>
**Changes:**

- Fixes Wrong Text Decoration at ...
- Fixes some typos
- ...

**Issues:**

Closes #NumberOfFixedIssue

PR: #NumberOfThisPR
</code>
</pre>
</details>

## Emojis

<details>
<summary>
Expand for a list of most used Emojis.
</summary>
<br>

Please prefix your commit messages with an Emoji.

Ref: https://gitmoji.carloscuesta.me/

| Description              | Glyphe               | Emoji  |
|--------------------------|----------------------|--------|
| Bugfix                   | `:bug:`              | 🐛     |
| Configuration releated   | `:wrench:`           | 🔧     |
| Cosmetic                 | `:lipstick:`         | 💄     |
| Dependencies Downgrade   | `:arrow_down:`       | ⬇️     |
| Dependencies Upgrade     | `:arrow_up:`         | ⬆️     |
| Formatting               | `:art:`              | 🎨     |
| Improving Performance    | `:zap:`              | ⚡️     |
| Initial commit           | `:tada:`             | 🎉     |
| Linter                   | `:rotating_light:`   | 🚨     |
| Miscellaneous            | `:package:`          | 📦     |
| New Feature              | `:sparkles:`         | ✨     |
| Refactoring Code         | `:recycle:`          | ♻️     |
| Releasing / Version tags | `:bookmark:`         | 🔖     |
| Removing Stuff           | `:fire:`             | 🔥     |
| Tests                    | `:white_check_mark:` | ✅     |
| Work In Progress (WIP)   | `:construction:`     | 🚧     |

</details>
