### PR TITLE
✨ Add Functionality to Set The Viewbox

### DIFF
--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -7,6 +7,7 @@ import * as bundle from '@process-engine/bpmn-js-custom-bundle';
 import {
   IBpmnModeler,
   IBpmnXmlSaveOptions,
+  ICanvas,
   IDiagramExportService,
   IDiagramPrintService,
   IEditorActions,
@@ -292,8 +293,12 @@ export class BpmnIo {
   }
 
   public xmlChanged(newValue: string): void {
-    if (this.modeler !== undefined && this.modeler !== null) {
+    const modelerIsSet: boolean = this.modeler !== undefined && this.modeler !== null;
+
+    if (modelerIsSet) {
       this.modeler.importXML(newValue, (err: Error) => {
+        this._fitDiagramToViewport();
+
         return 0;
       });
 
@@ -355,6 +360,12 @@ export class BpmnIo {
       });
     });
     return returnPromise;
+  }
+
+  private _fitDiagramToViewport(): void {
+    const canvas: ICanvas = this.modeler.get('canvas');
+
+    canvas.zoom('fit-viewport');
   }
 
   private _renameFormFields(event: IInternalEvent): IInternalEvent {

--- a/src/modules/design/diagram-tools-right/diagram-tools-right.html
+++ b/src/modules/design/diagram-tools-right/diagram-tools-right.html
@@ -33,6 +33,9 @@
     <a class="button tool" title="Fit diagram to viewport" click.delegate="fitDiagramToViewport()">
       <i class="fas fa-expand"></i>
     </a>
+    <a class="button tool" title="Move viewport to zero point" click.delegate="moveViewportToZeroPoint()">
+      <i class="fas fa-compress"></i>
+    </a>
     <!-- Why are these here?-->
     <div class="tool">
 

--- a/src/modules/design/diagram-tools-right/diagram-tools-right.html
+++ b/src/modules/design/diagram-tools-right/diagram-tools-right.html
@@ -30,6 +30,9 @@
     <a class="button tool" class.bind="distributeElementsEnabled ? '' : 'button--disabled tool--disabled'" title.bind="distributeElementsEnabled ? 'Distribute Elements Horizontally' : 'Select at least three elements to distribute them horizontally'" click.delegate="distributeElementsHorizontally()" disabled.bind="!distributeElementsEnabled">
       <i class="fas fa-arrows-alt-h"></i>
     </a>
+    <a class="button tool" title="Fit diagram to viewport" click.delegate="fitDiagramToViewport()">
+      <i class="fas fa-expand"></i>
+    </a>
     <!-- Why are these here?-->
     <div class="tool">
 

--- a/src/modules/design/diagram-tools-right/diagram-tools-right.html
+++ b/src/modules/design/diagram-tools-right/diagram-tools-right.html
@@ -30,7 +30,7 @@
     <a class="button tool" class.bind="distributeElementsEnabled ? '' : 'button--disabled tool--disabled'" title.bind="distributeElementsEnabled ? 'Distribute Elements Horizontally' : 'Select at least three elements to distribute them horizontally'" click.delegate="distributeElementsHorizontally()" disabled.bind="!distributeElementsEnabled">
       <i class="fas fa-arrows-alt-h"></i>
     </a>
-    <a class="button tool" title="Fit diagram to viewport" click.delegate="fitDiagramToViewport()">
+    <a class="button tool" title="Fit diagram to window." click.delegate="fitDiagramToViewport()">
       <i class="fas fa-expand"></i>
     </a>
     <!-- Why are these here?-->

--- a/src/modules/design/diagram-tools-right/diagram-tools-right.html
+++ b/src/modules/design/diagram-tools-right/diagram-tools-right.html
@@ -33,7 +33,7 @@
     <a class="button tool" title="Fit diagram to viewport" click.delegate="fitDiagramToViewport()">
       <i class="fas fa-expand"></i>
     </a>
-    <a class="button tool" title="Move viewport to zero point" click.delegate="moveViewportToZeroPoint()">
+    <a class="button tool" title="Move viewport to origin" click.delegate="moveViewportToZeroPoint()">
       <i>0</i>
     </a>
     <!-- Why are these here?-->

--- a/src/modules/design/diagram-tools-right/diagram-tools-right.html
+++ b/src/modules/design/diagram-tools-right/diagram-tools-right.html
@@ -33,9 +33,6 @@
     <a class="button tool" title="Fit diagram to viewport" click.delegate="fitDiagramToViewport()">
       <i class="fas fa-expand"></i>
     </a>
-    <a class="button tool" title="Move viewport to origin" click.delegate="moveViewportToZeroPoint()">
-      <i>0</i>
-    </a>
     <!-- Why are these here?-->
     <div class="tool">
 

--- a/src/modules/design/diagram-tools-right/diagram-tools-right.html
+++ b/src/modules/design/diagram-tools-right/diagram-tools-right.html
@@ -34,7 +34,7 @@
       <i class="fas fa-expand"></i>
     </a>
     <a class="button tool" title="Move viewport to zero point" click.delegate="moveViewportToZeroPoint()">
-      <i class="fas fa-compress"></i>
+      <i>0</i>
     </a>
     <!-- Why are these here?-->
     <div class="tool">

--- a/src/modules/design/diagram-tools-right/diagram-tools-right.ts
+++ b/src/modules/design/diagram-tools-right/diagram-tools-right.ts
@@ -12,7 +12,9 @@ import {defaultBpmnColors,
         IEvent,
         IEventFunction,
         IModdleElement,
-        IModeling, IShape, NotificationType} from '../../../contracts/index';
+        IModeling,
+        IShape,
+        NotificationType} from '../../../contracts/index';
 import environment from '../../../environment';
 import {NotificationService} from '../../notification/notification.service';
 

--- a/src/modules/design/diagram-tools-right/diagram-tools-right.ts
+++ b/src/modules/design/diagram-tools-right/diagram-tools-right.ts
@@ -148,16 +148,6 @@ export class DiagramToolsRight {
     canvas.zoom('fit-viewport');
   }
 
-  public moveViewportToZeroPoint(): void {
-    const canvas: ICanvas = this.modeler.get('canvas');
-
-    const previousViewbox: IViewbox = canvas.viewbox();
-    previousViewbox.x = 0;
-    previousViewbox.y = 0;
-
-    canvas.viewbox(previousViewbox);
-  }
-
   private _setColor(color: IColorPickerColor): void {
     const modeling: IModeling = this.modeler.get('modeling');
 

--- a/src/modules/design/diagram-tools-right/diagram-tools-right.ts
+++ b/src/modules/design/diagram-tools-right/diagram-tools-right.ts
@@ -82,7 +82,6 @@ export class DiagramToolsRight {
     this.modeler.on('commandStack.elements.move.postExecute', (event: IEvent) => {
       this.colorPickerEnabled = true;
     });
-
   }
 
   public detached(): void {

--- a/src/modules/design/diagram-tools-right/diagram-tools-right.ts
+++ b/src/modules/design/diagram-tools-right/diagram-tools-right.ts
@@ -7,6 +7,7 @@ import {defaultBpmnColors,
         ElementDistributeOptions,
         IBpmnFunction,
         IBpmnModeler,
+        ICanvas,
         IColorPickerColor,
         IColorPickerSettings,
         IEvent,
@@ -138,6 +139,12 @@ export class DiagramToolsRight {
 
   public distributeElementsHorizontally(): void {
     this._distributeElementsHorizontally();
+  }
+
+  public fitDiagramToViewport(): void {
+    const canvas: ICanvas = this.modeler.get('canvas');
+
+    canvas.zoom('fit-viewport');
   }
 
   private _setColor(color: IColorPickerColor): void {

--- a/src/modules/design/diagram-tools-right/diagram-tools-right.ts
+++ b/src/modules/design/diagram-tools-right/diagram-tools-right.ts
@@ -15,6 +15,7 @@ import {defaultBpmnColors,
         IModdleElement,
         IModeling,
         IShape,
+        IViewbox,
         NotificationType} from '../../../contracts/index';
 import environment from '../../../environment';
 import {NotificationService} from '../../notification/notification.service';
@@ -145,6 +146,16 @@ export class DiagramToolsRight {
     const canvas: ICanvas = this.modeler.get('canvas');
 
     canvas.zoom('fit-viewport');
+  }
+
+  public moveViewportToZeroPoint(): void {
+    const canvas: ICanvas = this.modeler.get('canvas');
+
+    const previousViewbox: IViewbox = canvas.viewbox();
+    previousViewbox.x = 0;
+    previousViewbox.y = 0;
+
+    canvas.viewbox(previousViewbox);
   }
 
   private _setColor(color: IColorPickerColor): void {


### PR DESCRIPTION
> If you find a better icon, just let me know.

**Changes:**

1. Add fit to viewport functionality
2. Fit diagram to viewport on import

**Issues:**

Closes #1075 

PR: #1224

## How can others test the changes?

- Open up the BPMN-Studio 
- Go to the Detail View of any diagram
- **Notice that the diagram should now fit the viewport**


- Move the viewbox/ change the zoom level
- Click on the <img width="20" src="https://user-images.githubusercontent.com/20394992/50589835-7f901180-0e88-11e9-858f-267def095bb8.png"> icon
- **Notice that the diagram should now fit the viewport**

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).

## Example

<details>
<summary>
:warning: Before merging please click here to expand and follow the guide.
</summary>
<br>

Please use `:twisted_rightwards_arrows:` at the beginning of your merge commit title.

Example 1:

<pre>
<code>
:twisted_rightwards_arrows: :bug: Fix Wrong Text Decoration at ...
</code>
</pre>

To get your commit message, just copy the first part of this pull request.

Example 2:
<pre>
<code>
**Changes:**

- Fixes Wrong Text Decoration at ...
- Fixes some typos
- ...

**Issues:**

Closes #NumberOfFixedIssue

PR: #NumberOfThisPR
</code>
</pre>
</details>

## Emojis

<details>
<summary>
Expand for a list of most used Emojis.
</summary>
<br>

Please prefix your commit messages with an Emoji.

Ref: https://gitmoji.carloscuesta.me/

| Description              | Glyphe               | Emoji  |
|--------------------------|----------------------|--------|
| Bugfix                   | `:bug:`              | 🐛     |
| Configuration releated   | `:wrench:`           | 🔧     |
| Cosmetic                 | `:lipstick:`         | 💄     |
| Dependencies Downgrade   | `:arrow_down:`       | ⬇️     |
| Dependencies Upgrade     | `:arrow_up:`         | ⬆️     |
| Formatting               | `:art:`              | 🎨     |
| Improving Performance    | `:zap:`              | ⚡️     |
| Initial commit           | `:tada:`             | 🎉     |
| Linter                   | `:rotating_light:`   | 🚨     |
| Miscellaneous            | `:package:`          | 📦     |
| New Feature              | `:sparkles:`         | ✨     |
| Refactoring Code         | `:recycle:`          | ♻️     |
| Releasing / Version tags | `:bookmark:`         | 🔖     |
| Removing Stuff           | `:fire:`             | 🔥     |
| Tests                    | `:white_check_mark:` | ✅     |
| Work In Progress (WIP)   | `:construction:`     | 🚧     |

</details>
