### PR TITLE
🐛 Fix Unsaved Change Modal When Switching to the Diff- or XML View

### DIFF
--- a/aurelia_project/environments/dev.ts
+++ b/aurelia_project/environments/dev.ts
@@ -66,6 +66,7 @@ export default {
       startProcessWithOptions: 'diagramdetail:process:startWithOptions',
       toggleXMLView: 'design:xmlview:toggle',
       uploadProcess: 'diagramdetail:process:upload',
+      suppressUnsavedChangesModal: 'diagramdetail:view:suppressUnsavedChangesModal',
     },
     bpmnio: {
       toggleXMLView: 'design:xmlview:toggle',

--- a/aurelia_project/environments/prod.ts
+++ b/aurelia_project/environments/prod.ts
@@ -66,6 +66,7 @@ export default {
       startProcessWithOptions: 'diagramdetail:process:startWithOptions',
       toggleXMLView: 'design:xmlview:toggle',
       uploadProcess: 'diagramdetail:process:upload',
+      suppressUnsavedChangesModal: 'diagramdetail:view:suppressUnsavedChangesModal',
     },
     bpmnio: {
       toggleXMLView: 'design:xmlview:toggle',

--- a/aurelia_project/environments/stage.ts
+++ b/aurelia_project/environments/stage.ts
@@ -62,6 +62,7 @@ export default {
       startProcessWithOptions: 'diagramdetail:process:startWithOptions',
       toggleXMLView: 'design:xmlview:toggle',
       uploadProcess: 'diagramdetail:process:upload',
+      suppressUnsavedChangesModal: 'diagramdetail:view:suppressUnsavedChangesModal',
     },
     bpmnio: {
       toggleXMLView: 'design:xmlview:toggle',

--- a/src/modules/design/diagram-detail/diagram-detail.ts
+++ b/src/modules/design/diagram-detail/diagram-detail.ts
@@ -55,6 +55,8 @@ export class DiagramDetail {
   public hasValidationError: boolean = false;
 
   @observable({ changeHandler: 'diagramHasChangedChanged'}) private _diagramHasChanged: boolean;
+
+  private _suppressSaveChangesModal: boolean = false;
   private _notificationService: NotificationService;
   private _eventAggregator: EventAggregator;
   private _subscriptions: Array<Subscription>;
@@ -128,6 +130,10 @@ export class DiagramDetail {
       this._eventAggregator.subscribe(environment.events.diagramDetail.startProcessWithOptions, () => {
         this.showStartWithOptionsModal = true;
       }),
+      this._eventAggregator.subscribe(environment.events.diagramDetail.suppressUnsavedChangesModal, () => {
+        console.log('suppress');
+        this._suppressSaveChangesModal = true;
+      }),
     ];
   }
 
@@ -157,6 +163,11 @@ export class DiagramDetail {
   }
 
   public async canDeactivate(): Promise<boolean> {
+
+    if (this._suppressSaveChangesModal) {
+      this._suppressSaveChangesModal = false;
+      return true;
+    }
 
     const _modal: Promise<boolean> = new Promise((resolve: Function, reject: Function): boolean | void => {
       if (!this._diagramHasChanged) {

--- a/src/modules/design/diagram-detail/diagram-detail.ts
+++ b/src/modules/design/diagram-detail/diagram-detail.ts
@@ -131,7 +131,6 @@ export class DiagramDetail {
         this.showStartWithOptionsModal = true;
       }),
       this._eventAggregator.subscribe(environment.events.diagramDetail.suppressUnsavedChangesModal, () => {
-        console.log('suppress');
         this._suppressSaveChangesModal = true;
       }),
     ];

--- a/src/modules/design/diagram-detail/diagram-detail.ts
+++ b/src/modules/design/diagram-detail/diagram-detail.ts
@@ -165,6 +165,7 @@ export class DiagramDetail {
 
     if (this._suppressSaveChangesModal) {
       this._suppressSaveChangesModal = false;
+
       return true;
     }
 

--- a/src/modules/status-bar/status-bar.ts
+++ b/src/modules/status-bar/status-bar.ts
@@ -107,6 +107,8 @@ export class StatusBar {
 
     this._designView = this.xmlIsShown ? 'detail' : 'xml';
 
+    this._eventAggregator.publish(environment.events.diagramDetail.suppressUnsavedChangesModal);
+
     this._router.navigateToRoute('design', {
       diagramName: this.activeDiagram ? this.activeDiagram.name : undefined,
       solutionUri: this.activeSolutionEntry.uri,
@@ -133,6 +135,8 @@ export class StatusBar {
     }
 
     this._designView = this.diffIsShown ? 'detail' : 'diff';
+
+    this._eventAggregator.publish(environment.events.diagramDetail.suppressUnsavedChangesModal);
 
     this._router.navigateToRoute('design', {
       diagramName: this.activeDiagram ? this.activeDiagram.name : undefined,


### PR DESCRIPTION
---

**Changes:**

1. Fixes the appearance of the _Save unsaved changes_ modal when trying to navigate to the XML- or Diff - View.


**Issues:**

Closes #1229 

PR: #1233 

---

See the [examples](#example) for inspiration.

## How can others test the changes?

> Describe how others can test your changes (you can remove this section for typo fixes etc.)

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).

## Example

<details>
<summary>
:warning: Before merging please click here to expand and follow the guide.
</summary>
<br>

Please use `:twisted_rightwards_arrows:` at the beginning of your merge commit title.

Example 1:

<pre>
<code>
:twisted_rightwards_arrows: :bug: Fix Wrong Text Decoration at ...
</code>
</pre>

To get your commit message, just copy the first part of this pull request.

Example 2:
<pre>
<code>
**Changes:**

- Fixes Wrong Text Decoration at ...
- Fixes some typos
- ...

**Issues:**

Closes #NumberOfFixedIssue

PR: #NumberOfThisPR
</code>
</pre>
</details>

## Emojis

<details>
<summary>
Expand for a list of most used Emojis.
</summary>
<br>

Please prefix your commit messages with an Emoji.

Ref: https://gitmoji.carloscuesta.me/

| Description              | Glyphe               | Emoji  |
|--------------------------|----------------------|--------|
| Bugfix                   | `:bug:`              | 🐛     |
| Configuration releated   | `:wrench:`           | 🔧     |
| Cosmetic                 | `:lipstick:`         | 💄     |
| Dependencies Downgrade   | `:arrow_down:`       | ⬇️     |
| Dependencies Upgrade     | `:arrow_up:`         | ⬆️     |
| Formatting               | `:art:`              | 🎨     |
| Improving Performance    | `:zap:`              | ⚡️     |
| Initial commit           | `:tada:`             | 🎉     |
| Linter                   | `:rotating_light:`   | 🚨     |
| Miscellaneous            | `:package:`          | 📦     |
| New Feature              | `:sparkles:`         | ✨     |
| Refactoring Code         | `:recycle:`          | ♻️     |
| Releasing / Version tags | `:bookmark:`         | 🔖     |
| Removing Stuff           | `:fire:`             | 🔥     |
| Tests                    | `:white_check_mark:` | ✅     |
| Work In Progress (WIP)   | `:construction:`     | 🚧     |

</details>
