### PR TITLE
🚸 Improve error message when trying to open an already opened remote Solution

### DIFF
--- a/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.ts
+++ b/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.ts
@@ -134,7 +134,9 @@ export class SolutionExplorerPanel {
     try {
       await this.solutionExplorerList.openSolution(this.uriOfRemoteSolution);
     } catch (error) {
-      this._notificationService.showNotification(NotificationType.ERROR, `Unable to connect to ProcessEngine on: ${this.uriOfRemoteSolution}`);
+      const genericMessage: string = `Unable to connect to ProcessEngine on: ${this.uriOfRemoteSolution}`;
+      const cause: string = error.message ? `${error.message}` : '';
+      this._notificationService.showNotification(NotificationType.ERROR, `${genericMessage} ${cause}`);
     }
 
     this.uriOfRemoteSolution = undefined;

--- a/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.ts
+++ b/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.ts
@@ -135,7 +135,7 @@ export class SolutionExplorerPanel {
       await this.solutionExplorerList.openSolution(this.uriOfRemoteSolution);
     } catch (error) {
       const genericMessage: string = `Unable to connect to ProcessEngine on: ${this.uriOfRemoteSolution}`;
-      const cause: string = error.message ? `${error.message}` : '';
+      const cause: string = error.message ? error.message : '';
       this._notificationService.showNotification(NotificationType.ERROR, `${genericMessage} ${cause}`);
     }
 

--- a/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.ts
+++ b/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.ts
@@ -136,7 +136,7 @@ export class SolutionExplorerPanel {
     } catch (error) {
       const genericMessage: string = `Unable to connect to ProcessEngine on: ${this.uriOfRemoteSolution}`;
       const cause: string = error.message ? error.message : '';
-      this._notificationService.showNotification(NotificationType.ERROR, `${genericMessage} ${cause}`);
+      this._notificationService.showNotification(NotificationType.ERROR, `${genericMessage}<br />${cause}`);
     }
 
     this.uriOfRemoteSolution = undefined;


### PR DESCRIPTION
---

**Changes:**

1. Adds the cause to the error message when the user tries to open a remote Solution which is already opened.


**Issues:**

Closes #1260 

PR: #1261

---

See the [examples](#example) for inspiration.

## How can others test the changes?

> Describe how others can test your changes (you can remove this section for typo fixes etc.)

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).

## Example

<details>
<summary>
:warning: Before merging please click here to expand and follow the guide.
</summary>
<br>

Please use `:twisted_rightwards_arrows:` at the beginning of your merge commit title.

Example 1:

<pre>
<code>
:twisted_rightwards_arrows: :bug: Fix Wrong Text Decoration at ...
</code>
</pre>

To get your commit message, just copy the first part of this pull request.

Example 2:
<pre>
<code>
**Changes:**

- Fixes Wrong Text Decoration at ...
- Fixes some typos
- ...

**Issues:**

Closes #NumberOfFixedIssue

PR: #NumberOfThisPR
</code>
</pre>
</details>

## Emojis

<details>
<summary>
Expand for a list of most used Emojis.
</summary>
<br>

Please prefix your commit messages with an Emoji.

Ref: https://gitmoji.carloscuesta.me/

| Description              | Glyphe               | Emoji  |
|--------------------------|----------------------|--------|
| Bugfix                   | `:bug:`              | 🐛     |
| Configuration releated   | `:wrench:`           | 🔧     |
| Cosmetic                 | `:lipstick:`         | 💄     |
| Dependencies Downgrade   | `:arrow_down:`       | ⬇️     |
| Dependencies Upgrade     | `:arrow_up:`         | ⬆️     |
| Formatting               | `:art:`              | 🎨     |
| Improving Performance    | `:zap:`              | ⚡️     |
| Initial commit           | `:tada:`             | 🎉     |
| Linter                   | `:rotating_light:`   | 🚨     |
| Miscellaneous            | `:package:`          | 📦     |
| New Feature              | `:sparkles:`         | ✨     |
| Refactoring Code         | `:recycle:`          | ♻️     |
| Releasing / Version tags | `:bookmark:`         | 🔖     |
| Removing Stuff           | `:fire:`             | 🔥     |
| Tests                    | `:white_check_mark:` | ✅     |
| Work In Progress (WIP)   | `:construction:`     | 🚧     |

</details>
