### PR TITLE
✨Fit Diagram to Viewport on Inspect Correlation

### DIFF
--- a/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.ts
+++ b/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.ts
@@ -197,6 +197,11 @@ export class DiagramViewer {
     this.xmlIsNotSelected = this.xml === undefined;
   }
 
+  public fitDiagramToViewport(): void {
+    const canvas: ICanvas = this._diagramViewer.get('canvas');
+    canvas.zoom('fit-viewport');
+  }
+
   private async _getXmlByCorrelation(correlation: DataModels.Correlations.Correlation): Promise<string> {
     const processModelForCorrelation: DataModels.Correlations.CorrelationProcessModel =
       correlation.processModels.find((processModel: DataModels.Correlations.CorrelationProcessModel) => {

--- a/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.ts
+++ b/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.ts
@@ -9,6 +9,7 @@ import {
   defaultBpmnColors,
   IBpmnModeler,
   IBpmnXmlSaveOptions,
+  ICanvas,
   IColorPickerColor,
   IDiagramExportService,
   IElementRegistry,
@@ -179,6 +180,8 @@ export class DiagramViewer {
         return;
       }
     }
+
+    this.fitDiagramToViewport();
   }
 
   public activeDiagramChanged(): void {
@@ -191,6 +194,8 @@ export class DiagramViewer {
     this._diagramViewer.clear();
     this.xmlIsNotSelected = true;
     this.xml = undefined;
+
+    this.fitDiagramToViewport();
   }
 
   public xmlChanged(): void {


### PR DESCRIPTION
**Changes:**

1. Add fit to viewport functionality to inspect correlation.

**Issues:**

Closes #1288

PR: #PullRequest

## How can others test the changes?

1. Start BPMN-Studio
2. Start a process
3. Check the inspect correlation feature, see that the diagram now fits the viewport on opening.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).
