### PR TITLE
🐛Fix Double Click / Instance Handling on Windows

### DIFF
--- a/electron_app/electron.js
+++ b/electron_app/electron.js
@@ -68,7 +68,8 @@ Main.execute = function () {
         answerOpenFileEvent(filePath)
       }
 
-      if (argumentIsSignInRedirect || argumentIsSignOutRedirect) {
+      const argumentContainsRedirect = argumentIsSignInRedirect || argumentIsSignOutRedirect
+      if (argumentContainsRedirect) {
         const redirectUrl = argv[1];
 
         Main._window.loadURL(`file://${__dirname}/../index.html`);


### PR DESCRIPTION
With Version 4.0.0 the developers of Electron introduced some new functions that make the handling of instances in Windows much easier. This PR adds all changes needed to use the new Functions and therefore fix the double click feature on Windows.

**Changes:**

1. Add the correct functionality to handle instances and the double click on windows.

**Issues:**

Closes #1310 
Closes #646 

PR: #PullRequest

## How can others test the changes?

1. Build BPMN-Studio on Windows.
2. Install it.
3. Start it via double click on a .bpmn file.
4. Double click on another file.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).