### PR TITLE
🐛Workaround for Dublicate Click on Cancel

### DIFF
--- a/src/modules/design/design.ts
+++ b/src/modules/design/design.ts
@@ -5,7 +5,7 @@
 */
 
 import {EventAggregator, Subscription} from 'aurelia-event-aggregator';
-import {bindable, bindingMode, inject, observable} from 'aurelia-framework';
+import {bindable, bindingMode, inject} from 'aurelia-framework';
 import {activationStrategy, NavigationInstruction, Redirect, Router} from 'aurelia-router';
 
 import {IDiagram, ISolution} from '@process-engine/solutionexplorer.contracts';

--- a/src/modules/design/design.ts
+++ b/src/modules/design/design.ts
@@ -282,7 +282,7 @@ export class Design {
     /**
      * Dirty quickfix: Because of this issue https://github.com/process-engine/bpmn-studio/issues/1384
      * we need to discard every routing instruction whose target uri/fragment contains
-     * an already escaped character.
+     * an already encoded character.
      */
     const instructionFragment: string = destinationInstruction.fragment;
     const instructionFragmentContainsUnescapedSpace: boolean = instructionFragment.includes('%');

--- a/src/modules/design/design.ts
+++ b/src/modules/design/design.ts
@@ -282,10 +282,10 @@ export class Design {
     /**
      * Dirty quickfix: Because of this issue https://github.com/process-engine/bpmn-studio/issues/1384
      * we need to discard every routing instruction whose target uri/fragment contains
-     * a character which needs to be escaped.
+     * an already escaped character.
      */
     const instructionFragment: string = destinationInstruction.fragment;
-    const instructionFragmentContainsUnescapedSpace: boolean = instructionFragment.includes('%20');
+    const instructionFragmentContainsUnescapedSpace: boolean = instructionFragment.includes('%');
     if (instructionFragmentContainsUnescapedSpace) {
 
       return false;


### PR DESCRIPTION
---

**Changes:**

1. This is a sloppy workaround to fix the need to double click the cancel button on the _Save Unsaved Changes_ dialog.


**Issues:**

References: #1384 

PR: #1385 

---


## How can others test the changes?

See reproducion section in the linked issues and check, if this Pr fixes the issue.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [ ] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [ ] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [ ] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).