### PR TITLE
♻️Solidify Diagram Change Handling in Service Tasks

### DIFF
--- a/src/modules/design/property-panel/indextabs/extensions/sections/basics/basics.ts
+++ b/src/modules/design/property-panel/indextabs/extensions/sections/basics/basics.ts
@@ -125,12 +125,14 @@ export class BasicsSection implements ISection {
   public changeName(index: number): void {
     this._propertiesElement.values[index].name = this.newNames[index];
     this._checkAndRemoveEmptyProperties(index);
+
     this._publishDiagramChange();
   }
 
   public changeValue(index: number): void {
     this._propertiesElement.values[index].value = this.newValues[index];
     this._checkAndRemoveEmptyProperties(index);
+
     this._publishDiagramChange();
   }
 

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.html
@@ -7,13 +7,13 @@
         <tr>
           <th>Topic</th>
           <td>
-            <input type="text" class="props-input name-input" value.bind="selectedTopic">
+            <input type="text" class="props-input name-input" value.bind="selectedTopic" change.delegate="topicChanged()">
           </td>
         </tr>
         <tr>
           <th>Payload</th>
           <td>
-            <textarea class="props-textarea name-input" value.bind="selectedPayload"></textarea>
+            <textarea class="props-textarea name-input" value.bind="selectedPayload" change.delegate="payloadChanged()"></textarea>
           </td>
         </tr>
       </table>

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.ts
@@ -11,8 +11,8 @@ export class ExternalTask {
 
   @bindable() public model: IPageModel;
   public businessObjInPanel: IServiceTaskElement;
-  @observable public selectedTopic: string;
-  @observable public selectedPayload: string;
+  public selectedTopic: string;
+  public selectedPayload: string;
 
   private _eventAggregator: EventAggregator;
   private _moddle: IBpmnModdle;
@@ -35,13 +35,15 @@ export class ExternalTask {
     this.selectedPayload = this._getPayloadFromModel();
   }
 
-  public selectedTopicChanged(): void {
+  public topicChanged(): void {
     this.businessObjInPanel.topic = this.selectedTopic;
+
     this._publishDiagramChange();
   }
 
-  public selectedPayloadChanged(): void {
+  public payloadChanged(): void {
     this._setPayloadToModel(this.selectedPayload);
+
     this._publishDiagramChange();
   }
 

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/components/http-service-task/http-service-task.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/components/http-service-task/http-service-task.html
@@ -7,7 +7,7 @@
         <tr>
           <th>Method</th>
           <td>
-            <select class="props-input props-select" value.bind="selectedHttpMethod">
+            <select class="props-input props-select" value.bind="selectedHttpMethod" change.delegate="httpMethodChanged()">
               <option value="null">-Choose Method-</option>
               <option value="get">GET</option>
               <option value="post">POST</option>

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/components/http-service-task/http-service-task.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/components/http-service-task/http-service-task.ts
@@ -17,7 +17,7 @@ export class HttpServiceTask {
 
   @bindable() public model: IPageModel;
   public businessObjInPanel: IServiceTaskElement;
-  @observable public selectedHttpMethod: string;
+  public selectedHttpMethod: string;
   public selectedHttpUrl: string;
   public selectedHttpBody: string;
   public selectedHttpAuth: string;
@@ -64,7 +64,7 @@ export class HttpServiceTask {
     this._publishDiagramChange();
   }
 
-  public selectedHttpMethodChanged(): void {
+  public httpMethodChanged(): void {
     const property: IProperty = this._getProperty('method');
     property.value = this.selectedHttpMethod;
 

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/service-task.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/service-task.html
@@ -11,9 +11,9 @@
           <th>Kind</th>
           <td>
             <select class="props-input props-select" value.bind="selectedKind" change.delegate="kindChanged()">
-              <option value="null">-Choose Kind-</option>
-              <option value="HttpClient">HTTP REST Service</option>
-              <option value="external">External Task</option>
+              <option value.one-time=ServiceKind.None>-Choose Kind-</option>
+              <option value.one-time=ServiceKind.HttpClient>HTTP REST Service</option>
+              <option value.one-time=ServiceKind.External>External Task</option>
             </select>
           </td>
         </tr>

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/service-task.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/service-task.html
@@ -10,7 +10,7 @@
         <tr>
           <th>Kind</th>
           <td>
-            <select class="props-input props-select" value.bind="selectedKind">
+            <select class="props-input props-select" value.bind="selectedKind" change.delegate="kindChanged()">
               <option value="null">-Choose Kind-</option>
               <option value="HttpClient">HTTP REST Service</option>
               <option value="external">External Task</option>

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/service-task.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/service-task.ts
@@ -13,7 +13,7 @@ export class ServiceTaskSection implements ISection {
   public canHandleElement: boolean = false;
   public businessObjInPanel: IServiceTaskElement;
   public model: IPageModel;
-  @observable public selectedKind: string;
+  public selectedKind: string;
 
   private _eventAggregator: EventAggregator;
   private _moddle: IBpmnModdle;
@@ -35,7 +35,7 @@ export class ServiceTaskSection implements ISection {
     return this._elementIsServiceTask(element);
   }
 
-  public selectedKindChanged(): void {
+  public kindChanged(): void {
     const selectedKindIsHttpService: boolean = this.selectedKind === 'HttpClient';
     const selectedKindIsExternalTask: boolean = this.selectedKind === 'external';
 
@@ -126,7 +126,6 @@ export class ServiceTaskSection implements ISection {
     }
 
     const modulePropertyExists: boolean = this._getProperty('module') !== undefined;
-
     if (modulePropertyExists) {
       this.selectedKind = this._getProperty('module').value;
 

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/service-task.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/service-task.ts
@@ -20,7 +20,7 @@ export class ServiceTaskSection implements ISection {
   public canHandleElement: boolean = false;
   public businessObjInPanel: IServiceTaskElement;
   public model: IPageModel;
-  public selectedKind: string;
+  public selectedKind: ServiceKind;
 
   private _eventAggregator: EventAggregator;
   private _moddle: IBpmnModdle;
@@ -30,7 +30,6 @@ export class ServiceTaskSection implements ISection {
   }
 
   public activate(model: IPageModel): void {
-    this.selectedKind = '';
     this.businessObjInPanel = model.elementInPanel.businessObject;
     this.model = model;
     this._moddle = model.modeler.get('moddle');
@@ -127,14 +126,13 @@ export class ServiceTaskSection implements ISection {
     const taskIsExternalTask: boolean = this.businessObjInPanel.type === 'external';
 
     if (taskIsExternalTask) {
-      this.selectedKind = this.businessObjInPanel.type;
-
+      this.selectedKind = ServiceKind.External;
       return;
     }
 
     const modulePropertyExists: boolean = this._getProperty('module') !== undefined;
     if (modulePropertyExists) {
-      this.selectedKind = this._getProperty('module').value;
+      this.selectedKind = ServiceKind[this._getProperty('module').value];
 
       return;
     }

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/service-task.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/service-task.ts
@@ -1,15 +1,22 @@
 import {EventAggregator} from 'aurelia-event-aggregator';
-import {inject, observable} from 'aurelia-framework';
+import {inject} from 'aurelia-framework';
 
 import {IExtensionElement, IModdleElement, IPropertiesElement, IProperty, IServiceTaskElement, IShape} from '@process-engine/bpmn-elements_contracts';
 
 import {IBpmnModdle, IPageModel, ISection} from '../../../../../../../contracts';
 import environment from '../../../../../../../environment';
 
+enum ServiceKind {
+  None = 'null',
+  HttpClient = 'HttpClient',
+  External = 'external',
+}
+
 @inject(EventAggregator)
 export class ServiceTaskSection implements ISection {
 
   public path: string = '/sections/service-task/service-task';
+  public ServiceKind: typeof ServiceKind = ServiceKind;
   public canHandleElement: boolean = false;
   public businessObjInPanel: IServiceTaskElement;
   public model: IPageModel;
@@ -36,8 +43,8 @@ export class ServiceTaskSection implements ISection {
   }
 
   public kindChanged(): void {
-    const selectedKindIsHttpService: boolean = this.selectedKind === 'HttpClient';
-    const selectedKindIsExternalTask: boolean = this.selectedKind === 'external';
+    const selectedKindIsHttpService: boolean = this.selectedKind === ServiceKind.HttpClient;
+    const selectedKindIsExternalTask: boolean = this.selectedKind === ServiceKind.External;
 
     if (selectedKindIsHttpService) {
       let moduleProperty: IProperty = this._getProperty('module');


### PR DESCRIPTION
This PRs aims to solve the sporadic appearance of a "diagram change" when the user is just clicking around the diagram and not really changing anything.

**Changes:**

1. Solidify Diagram Change Handling in Service Tasks

PR: #PullRequest

## How can others test the changes?

1. Start BPMN-Studio.
2. Open any diagram.
3. Create a Service Task.
4. Save the diagram.
5. Reload BPMN-Studio (Cmd+R).
6. Now Click around the diagram without changing anything.
7. There should be no "edited" appearing the navbar.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).