### PR TITLE
✨ Show unsuccessful internal connection in SolutionExplorer

### DIFF
--- a/electron_app/electron.js
+++ b/electron_app/electron.js
@@ -554,124 +554,118 @@ Main._startInternalProcessEngine = async function () {
     process.env.CONFIG_PATH = path.join(__dirname, '..', '..', '..', 'config');
   }
 
+  const desiredPort = 8000;
   const getPortConfig = {
-    port: 8000,
-    host: '0.0.0.0'
+    port: desiredPort,
+    host: '0.0.0.0',
   };
 
-  return getPort(getPortConfig)
-    .then(async (port) => {
+  const port = await getPort(getPortConfig);
 
-      console.log(`Internal ProcessEngine starting on port ${port}.`);
+  console.log(`Internal ProcessEngine starting on port ${port}.`);
 
-      process.env.http__http_extension__server__port = port;
+  process.env.http__http_extension__server__port = port;
 
-      const processEngineDatabaseFolderName = 'process_engine_databases';
+  const processEngineDatabaseFolderName = 'process_engine_databases';
 
-      process.env.process_engine__process_model_repository__storage = path.join(userDataFolderPath, processEngineDatabaseFolderName, 'process_model.sqlite');
-      process.env.process_engine__flow_node_instance_repository__storage = path.join(userDataFolderPath, processEngineDatabaseFolderName, 'flow_node_instance.sqlite');
-      process.env.process_engine__timer_repository__storage = path.join(userDataFolderPath, processEngineDatabaseFolderName, 'timer.sqlite');
+  process.env.process_engine__process_model_repository__storage = path.join(userDataFolderPath, processEngineDatabaseFolderName, 'process_model.sqlite');
+  process.env.process_engine__flow_node_instance_repository__storage = path.join(userDataFolderPath, processEngineDatabaseFolderName, 'flow_node_instance.sqlite');
+  process.env.process_engine__timer_repository__storage = path.join(userDataFolderPath, processEngineDatabaseFolderName, 'timer.sqlite');
 
-      let internalProcessEngineStatus = undefined;
-      let internalProcessEngineStartupError = undefined;
-      const processEngineStatusListeners = [];
+  let internalProcessEngineStatus = undefined;
+  let internalProcessEngineStartupError = undefined;
+  const processEngineStatusListeners = [];
 
-      function _sendInternalProcessEngineStatus(sender) {
-        let serializedStartupError;
-        const processEngineStartSuccessful = (internalProcessEngineStartupError !== undefined &&
-          internalProcessEngineStartupError !== null);
+  function _sendInternalProcessEngineStatus(sender) {
+    let serializedStartupError;
+    const processEngineStartFailed = internalProcessEngineStartupError !== undefined;
 
-        if (processEngineStartSuccessful) {
-          serializedStartupError = JSON.stringify(
-            internalProcessEngineStartupError,
-            Object.getOwnPropertyNames(internalProcessEngineStartupError));
+    if (processEngineStartFailed) {
+      serializedStartupError = JSON.stringify(
+        internalProcessEngineStartupError,
+        Object.getOwnPropertyNames(internalProcessEngineStartupError));
+    }
 
-        } else {
-          serializedStartupError = undefined;
-        }
+    sender.send(
+      'internal_processengine_status',
+      internalProcessEngineStatus,
+      serializedStartupError);
+  }
 
-        sender.send(
-          'internal_processengine_status',
-          internalProcessEngineStatus,
-          serializedStartupError);
-      }
+  function _publishProcessEngineStatus(status) {
+    processEngineStatusListeners.forEach(_sendInternalProcessEngineStatus);
+  }
 
-      function _publishProcessEngineStatus() {
-        processEngineStatusListeners.forEach(_sendInternalProcessEngineStatus);
-      }
+  /* When someone wants to know to the internal processengine status, he
+   * must first send a `add_internal_processengine_status_listener` message
+   * to the event mechanism. We recieve this message here and add the sender
+   * to our listeners array.
+   *
+   * As soon, as the processengine status is updated, we send the listeners a
+   * notification about this change; this message contains the state and the
+   * error text (if there was an error).
+   *
+   * If the processengine status is known by the time the listener registers,
+   * we instantly respond to the listener with a notification message.
+   *
+   * This is quite a unusual pattern, the problem this approves solves is the
+   * following: It's impossible to do interactions between threads in
+   * electron like this:
+   *
+   *  'renderer process'              'main process'
+   *          |                             |
+   *          o   <<<- Send Message  -<<<   x
+   *
+   * -------------------------------------------------
+   *
+   * Instead our interaction now locks like this:
+   *
+   *  'renderer process'              'main process'
+   *          |                             |
+   *          x   >>>--  Subscribe  -->>>   o
+   *          o   <<<- Send Message  -<<<   x
+   *          |       (event occurs)        |
+   *          o   <<<- Send Message  -<<<   x
+   */
+  electron.ipcMain.on('add_internal_processengine_status_listener', (event) => {
+    if (!processEngineStatusListeners.includes(event.sender)) {
+      processEngineStatusListeners.push(event.sender);
+    }
 
-      /* When someone wants to know to the internal processengine status, he
-       * must first send a `add_internal_processengine_status_listener` message
-       * to the event mechanism. We recieve this message here and add the sender
-       * to our listeners array.
-       *
-       * As soon, as the processengine status is updated, we send the listeners a
-       * notification about this change; this message contains the state and the
-       * error text (if there was an error).
-       *
-       * If the processengine status is known by the time the listener registers,
-       * we instantly respond to the listener with a notification message.
-       *
-       * This is quite a unusual pattern, the problem this approves solves is the
-       * following: It's impossible to do interactions between threads in
-       * electron like this:
-       *
-       *  'renderer process'              'main process'
-       *          |                             |
-       *          o   <<<- Send Message  -<<<   x
-       *
-       * -------------------------------------------------
-       *
-       * Instead our interaction now locks like this:
-       *
-       *  'renderer process'              'main process'
-       *          |                             |
-       *          x   >>>--  Subscribe  -->>>   o
-       *          o   <<<- Send Message  -<<<   x
-       *          |       (event occurs)        |
-       *          o   <<<- Send Message  -<<<   x
-       */
-      electron.ipcMain.on('add_internal_processengine_status_listener', (event) => {
-        if (!processEngineStatusListeners.includes(event.sender)) {
-          processEngineStatusListeners.push(event.sender);
-        }
+    if (internalProcessEngineStatus !== undefined) {
+      _sendInternalProcessEngineStatus(event.sender);
+    }
+  });
 
-        if (internalProcessEngineStatus !== undefined) {
-          _sendInternalProcessEngineStatus(event.sender);
-        }
-      });
-
-      // This tells the frontend the location at which the electron-skeleton
-      // will be running; this 'get_host' request ist emitted in src/main.ts.
-      electron.ipcMain.on('get_host', (event) => {
-        event.returnValue = `localhost:${port}`;
-      });
+  // This tells the frontend the location at which the electron-skeleton
+  // will be running; this 'get_host' request ist emitted in src/main.ts.
+  electron.ipcMain.on('get_host', (event) => {
+    event.returnValue = `localhost:${port}`;
+  });
 
 
-      // TODO: Check if the ProcessEngine instance is now run on the UI thread.
-      // See issue https://github.com/process-engine/bpmn-studio/issues/312
-      try {
+  // TODO: Check if the ProcessEngine instance is now run on the UI thread.
+  // See issue https://github.com/process-engine/bpmn-studio/issues/312
+  try {
 
-        // Create path for sqlite database in BPMN-Studio context.
-        const userDataFolderPath = getUserConfigFolder();
-        const sqlitePath = `${userDataFolderPath}/bpmn-studio/process_engine_databases`;
+    // Create path for sqlite database in BPMN-Studio context.
+    const userDataFolderPath = getUserConfigFolder();
+    const sqlitePath = `${userDataFolderPath}/bpmn-studio/process_engine_databases`;
 
-        const pe = require('@process-engine/process_engine_runtime');
-        pe.startRuntime(sqlitePath);
+    const pe = require('@process-engine/process_engine_runtime');
+    pe.startRuntime(sqlitePath);
 
-        console.log('Internal ProcessEngine started successfully.');
-        internalProcessEngineStatus = 'success';
+    console.log('Internal ProcessEngine started successfully.');
+    internalProcessEngineStatus = 'success';
 
-        _publishProcessEngineStatus();
-      } catch (error) {
-        console.error('Failed to start internal ProcessEngine: ', error);
-        internalProcessEngineStatus = 'error';
-        internalProcessEngineStartupError = error;
+    _publishProcessEngineStatus();
+  } catch (error) {
+    console.error('Failed to start internal ProcessEngine: ', error);
+    internalProcessEngineStatus = 'error';
+    internalProcessEngineStartupError = error;
 
-        _publishProcessEngineStatus();
-      }
-
-    });
+    _publishProcessEngineStatus();
+  }
 
 }
 

--- a/src/contracts/solution-explorer/ISolutionEntry.ts
+++ b/src/contracts/solution-explorer/ISolutionEntry.ts
@@ -1,16 +1,16 @@
 import {IIdentity} from '@essential-projects/iam_contracts';
 import {ISolutionExplorerService} from '@process-engine/solutionexplorer.service.contracts';
 
+export type SolutionStatus = 'disconnected'| 'remote'| 'singleDiagram'| 'folder';
 /**
  * This entry keeps information about an opened solution. It is used to support
  * the HTML view and give an easy access to properties like the uri of the
  * solution.
  */
-
 export interface ISolutionEntry {
   service: ISolutionExplorerService;
   uri: string;
-  fontAwesomeIconClass: string;
+  status: SolutionStatus;
   isSingleDiagramService: boolean;
   canCloseSolution: boolean;
   canCreateNewDiagramsInSolution: boolean;

--- a/src/modules/design/design.ts
+++ b/src/modules/design/design.ts
@@ -10,7 +10,7 @@ import {activationStrategy, NavigationInstruction, Redirect, Router} from 'aurel
 
 import {IDiagram, ISolution} from '@process-engine/solutionexplorer.contracts';
 
-import {ISolutionEntry, ISolutionService, NotificationType} from '../../contracts/index';
+import {ISolutionEntry, ISolutionService, NotificationType, SolutionStatus} from '../../contracts/index';
 import environment from '../../environment';
 import {NotificationService} from '../../services/notification-service/notification.service';
 import {DiagramDetail} from './diagram-detail/diagram-detail';
@@ -376,7 +376,7 @@ export class Design {
     const remoteSolutions: Array<ISolutionEntry> = this._solutionService.getRemoteSolutionEntries();
 
     const remoteSolutionsWithoutActive: Array<ISolutionEntry> = remoteSolutions.filter((remoteSolution: ISolutionEntry) => {
-      return remoteSolution.uri !== this.activeSolutionEntry.uri && remoteSolution.fontAwesomeIconClass !== 'fa-bolt';
+      return remoteSolution.uri !== this.activeSolutionEntry.uri && remoteSolution.status !== 'disconnected';
     });
 
     return remoteSolutionsWithoutActive;

--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.html
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.html
@@ -23,7 +23,7 @@
 
           <div class="solution-entry__actions ">
             <button class="button"
-              if.bind="solutionEntry.uri.startsWith('http') && !solutionEntry.isLoggedIn"
+              if.bind="solutionEntry.status === 'remote' && !solutionEntry.isLoggedIn"
               click.delegate="login(solutionEntry)"
               title="Login">
 
@@ -39,7 +39,7 @@
             </button>
 
             <button class="button"
-              if.bind="solutionIsInternalSolution(solutionEntry)"
+              if.bind="solutionEntry.status !== 'disconnected' && solutionIsInternalSolution(solutionEntry)"
               click.delegate="openSettings()"
               title="Open settings of the internal ProcessEngine">
 
@@ -67,12 +67,12 @@
 
         </div>
 
-        <solution-explorer-solution
+        <solution-explorer-solution if.bind="solutionEntry.status !== 'disconnected'"
           displayed-solution-entry.bind="solutionEntry"
           solution-service.bind="solutionEntry.service"
           solution-is-single-diagrams.bind="solutionEntry.isSingleDiagramService"
           view-model.ref="solutionEntryViewModels[solutionEntry.uri]"
-          font-awesome-icon-class.two-way="solutionEntry.fontAwesomeIconClass">
+          solution-status.two-way="solutionEntry.status">
         </solution-explorer-solution>
       </div>
     </div>

--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.html
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.html
@@ -1,4 +1,5 @@
 <template>
+  <require from="./status-to-icon"></require>
   <require from="./solution-explorer-list.css"></require>
   <require from="../solution-explorer-solution/solution-explorer-solution"></require>
 
@@ -9,7 +10,7 @@
 
         <div class="solution-entry__header" title.bind="solutionEntry.processEngineVersion ? `${solutionEntry.uri} | Version: ${solutionEntry.processEngineVersion}` : solutionEntry.uri">
 
-          <i class="fa ${solutionEntry.fontAwesomeIconClass} solution-entry__solution-icon" title.bind="solutionEntry.fontAwesomeIconClass === 'fa-bolt' ? 'ProcessEngine Disconnected!' : ''"></i>
+          <i class="fa ${solutionEntry.status | statusToIcon} solution-entry__solution-icon" title.bind="solutionEntry.status === SolutionStatus.Disconnected ? 'ProcessEngine Disconnected!' : ''"></i>
 
           <span class="solution-entry__solution-name">${getSolutionName(solutionEntry.uri)}</span>
           <div class="solution-entry__solution-path">

--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.html
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.html
@@ -1,5 +1,5 @@
 <template>
-  <require from="./status-to-icon"></require>
+  <require from="./status-to-icon-class"></require>
   <require from="./solution-explorer-list.css"></require>
   <require from="../solution-explorer-solution/solution-explorer-solution"></require>
 
@@ -10,7 +10,7 @@
 
         <div class="solution-entry__header" title.bind="solutionEntry.processEngineVersion ? `${solutionEntry.uri} | Version: ${solutionEntry.processEngineVersion}` : solutionEntry.uri">
 
-          <i class="fa ${solutionEntry.status | statusToIcon} solution-entry__solution-icon" title.bind="solutionEntry.status === SolutionStatus.Disconnected ? 'ProcessEngine Disconnected!' : ''"></i>
+          <i class="fa ${solutionEntry.status | statusToIconClass} solution-entry__solution-icon" title.bind="solutionEntry.status === 'disconnected' ? 'ProcessEngine Disconnected!' : ''"></i>
 
           <span class="solution-entry__solution-name">${getSolutionName(solutionEntry.uri)}</span>
           <div class="solution-entry__solution-path">

--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
@@ -25,7 +25,9 @@ interface IUriToViewModelMap {
 
 @inject(Router, EventAggregator, 'SolutionExplorerServiceFactory', 'AuthenticationService', 'DiagramValidationService', 'SolutionService')
 export class SolutionExplorerList {
+
   public internalSolutionUri: string;
+  public solutionEntryViewModels: IUriToViewModelMap = {};
 
   private _router: Router;
   private _eventAggregator: EventAggregator;
@@ -47,7 +49,7 @@ export class SolutionExplorerList {
    * The uri maps to the viewmodel. The contents of this map get set by aurelia
    * in the html view.
    */
-  public solutionEntryViewModels: IUriToViewModelMap = {};
+
 
   constructor(
     router: Router,

--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
@@ -50,7 +50,6 @@ export class SolutionExplorerList {
    * in the html view.
    */
 
-
   constructor(
     router: Router,
     eventAggregator: EventAggregator,

--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
@@ -13,6 +13,7 @@ import {
   ISolutionEntry,
   ISolutionService,
   IUserIdentity,
+  SolutionStatus,
 } from '../../../contracts';
 import {SingleDiagramsSolutionExplorerService} from '../../../services/solution-explorer-services/SingleDiagramsSolutionExplorerService';
 import {SolutionExplorerServiceFactory} from '../../../services/solution-explorer-services/SolutionExplorerServiceFactory';
@@ -361,18 +362,18 @@ export class SolutionExplorerList {
     this._addSolutionEntry(uriOfSingleDiagramService, this._singleDiagramService, identity, true);
   }
 
-  private _getFontAwesomeIconForSolution(service: ISolutionExplorerService, uri: string): string {
+  private _getSolutionStatus(service: ISolutionExplorerService, uri: string): SolutionStatus {
     const solutionIsOpenedFromRemote: boolean = uri.startsWith('http');
     if (solutionIsOpenedFromRemote) {
-      return 'fa-database';
+      return 'remote';
     }
 
     const solutionIsSingleDiagrams: boolean = service === this._singleDiagramService;
     if (solutionIsSingleDiagrams) {
-      return 'fa-copy';
+      return 'singleDiagram';
     }
 
-    return 'fa-folder';
+    return 'folder';
   }
 
   private _canCreateNewDiagramsInSolution(service: ISolutionExplorerService, uri: string): boolean {
@@ -429,7 +430,7 @@ export class SolutionExplorerList {
     processEngineVersion?: string,
     ): Promise<void> {
     const isSingleDiagramService: boolean = this._isSingleDiagramService(service);
-    const fontAwesomeIconClass: string = this._getFontAwesomeIconForSolution(service, uri);
+    const status: SolutionStatus = this._getSolutionStatus(service, uri);
     const canCloseSolution: boolean = this._canCloseSolution(service, uri);
     const canCreateNewDiagramsInSolution: boolean = this._canCreateNewDiagramsInSolution(service, uri);
     const authority: string = await this._getAuthorityForSolution(uri);
@@ -450,7 +451,7 @@ export class SolutionExplorerList {
     const entry: ISolutionEntry = {
       uri,
       service,
-      fontAwesomeIconClass,
+      status,
       canCloseSolution,
       canCreateNewDiagramsInSolution,
       isSingleDiagramService,

--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
@@ -362,10 +362,15 @@ export class SolutionExplorerList {
     this._addSolutionEntry(uriOfSingleDiagramService, this._singleDiagramService, identity, true);
   }
 
-  private _getSolutionStatus(service: ISolutionExplorerService, uri: string): SolutionStatus {
+  private async _getSolutionStatus(service: ISolutionExplorerService, uri: string): Promise<SolutionStatus> {
     const solutionIsOpenedFromRemote: boolean = uri.startsWith('http');
     if (solutionIsOpenedFromRemote) {
-      return 'remote';
+      try {
+        await fetch(uri);
+        return 'remote';
+      } catch {
+        return 'disconnected';
+      }
     }
 
     const solutionIsSingleDiagrams: boolean = service === this._singleDiagramService;
@@ -424,13 +429,15 @@ export class SolutionExplorerList {
   }
 
   private async _addSolutionEntry(
-    uri: string, service: ISolutionExplorerService,
+    uri: string,
+    service: ISolutionExplorerService,
     identity: IIdentity,
     insertAtBeginning: boolean,
     processEngineVersion?: string,
-    ): Promise<void> {
+  ): Promise<void> {
+
     const isSingleDiagramService: boolean = this._isSingleDiagramService(service);
-    const status: SolutionStatus = this._getSolutionStatus(service, uri);
+    const status: SolutionStatus = await this._getSolutionStatus(service, uri);
     const canCloseSolution: boolean = this._canCloseSolution(service, uri);
     const canCreateNewDiagramsInSolution: boolean = this._canCreateNewDiagramsInSolution(service, uri);
     const authority: string = await this._getAuthorityForSolution(uri);

--- a/src/modules/solution-explorer/solution-explorer-list/status-to-icon-class.ts
+++ b/src/modules/solution-explorer/solution-explorer-list/status-to-icon-class.ts
@@ -1,0 +1,20 @@
+import {SolutionStatus} from '../../../contracts';
+
+export class StatusToIconClassValueConverter {
+
+  public toView(value: SolutionStatus): string {
+
+    if (value === 'disconnected') {
+      return 'fa-bolt';
+    }
+    if (value  === 'folder') {
+      return 'fa-folder';
+    }
+    if (value === 'singleDiagram') {
+      return 'fa-copy';
+    }
+    if (value === 'remote') {
+      return 'fa-database';
+    }
+  }
+}

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -19,11 +19,12 @@ import {ISolutionExplorerService} from '@process-engine/solutionexplorer.service
 import {join} from 'path';
 
 import {
-        IDiagramCreationService,
-        ISolutionEntry,
-        ISolutionService,
-        IUserInputValidationRule,
-        NotificationType,
+  IDiagramCreationService,
+  ISolutionEntry,
+  ISolutionService,
+  IUserInputValidationRule,
+  NotificationType,
+  SolutionStatus,
 } from '../../../contracts/index';
 import environment from '../../../environment';
 import {NotificationService} from '../../../services/notification-service/notification.service';
@@ -85,14 +86,14 @@ export class SolutionExplorerSolution {
   @bindable public solutionService: ISolutionExplorerService;
   @bindable public solutionIsSingleDiagrams: boolean;
   @bindable public displayedSolutionEntry: ISolutionEntry;
-  @bindable public fontAwesomeIconClass: string;
+  @bindable public solutionStatus: SolutionStatus;
   public createNewDiagramInput: HTMLInputElement;
   public diagramContextMenu: HTMLElement;
   public showContextMenu: boolean = false;
   public deleteDiagramModal: DeleteDiagramModal;
 
   private _renameDiagramInput: HTMLInputElement;
-  private _originalIconClass: string;
+  private _originalSolutionStatus: SolutionStatus;
   private _globalSolutionService: ISolutionService;
   private _diagramInContextMenu: IDiagram;
 
@@ -113,7 +114,7 @@ export class SolutionExplorerSolution {
   }
 
   public attached(): void {
-    this._originalIconClass = this.fontAwesomeIconClass;
+    this._originalSolutionStatus = this.solutionStatus;
     this._updateSolutionExplorer();
     this._setValidationRules();
 
@@ -180,7 +181,7 @@ export class SolutionExplorerSolution {
   public async updateSolution(): Promise<void> {
     try {
       this._openedSolution = await this.solutionService.loadSolution();
-      this.fontAwesomeIconClass = this._originalIconClass;
+      this.solutionStatus = this._originalSolutionStatus;
     } catch (error) {
       // In the future we can maybe display a small icon indicating the error.
       if (isError(error, UnauthorizedError)) {
@@ -189,7 +190,7 @@ export class SolutionExplorerSolution {
         this._notificationService.showNotification(NotificationType.ERROR, 'You don\'t have the required permissions to list process models.');
       } else {
         this._openedSolution.diagrams = undefined;
-        this.fontAwesomeIconClass = 'fa-bolt';
+        this.solutionStatus = 'disconnected';
       }
     }
   }

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -54,6 +54,14 @@ export class SolutionExplorerSolution {
 
   public activeDiagram: IDiagram;
 
+  // Fields below are bound from the html view.
+  @bindable public solutionService: ISolutionExplorerService;
+  @bindable public solutionIsSingleDiagrams: boolean;
+  @bindable public displayedSolutionEntry: ISolutionEntry;
+  @bindable public solutionStatus: SolutionStatus;
+  public createNewDiagramInput: HTMLInputElement;
+  public deleteDiagramModal: DeleteDiagramModal;
+
   private _router: Router;
   private _eventAggregator: EventAggregator;
   private _validationController: ValidationController;
@@ -81,16 +89,6 @@ export class SolutionExplorerSolution {
   ];
 
   private _currentlyRenamingDiagram: IDiagram | null = null;
-
-  // Fields below are bound from the html view.
-  @bindable public solutionService: ISolutionExplorerService;
-  @bindable public solutionIsSingleDiagrams: boolean;
-  @bindable public displayedSolutionEntry: ISolutionEntry;
-  @bindable public solutionStatus: SolutionStatus;
-  public createNewDiagramInput: HTMLInputElement;
-  public diagramContextMenu: HTMLElement;
-  public showContextMenu: boolean = false;
-  public deleteDiagramModal: DeleteDiagramModal;
 
   private _renameDiagramInput: HTMLInputElement;
   private _originalSolutionStatus: SolutionStatus;

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -61,6 +61,8 @@ export class SolutionExplorerSolution {
   @bindable public solutionStatus: SolutionStatus;
   public createNewDiagramInput: HTMLInputElement;
   public deleteDiagramModal: DeleteDiagramModal;
+  public diagramContextMenu: HTMLElement;
+  public showContextMenu: boolean = false;
 
   private _router: Router;
   private _eventAggregator: EventAggregator;


### PR DESCRIPTION
If for some reason the internal PE of the electron version fails to start, the disconnected solution should still appear in the solutionexplorer. This feature introduces that behaviour.

---

**Changes:**

1. Introduce SolutionStatus
1. Show failing internal connection

If the internal processEngine fails to start, it looks like this:
<img width="285" alt="Screenshot 2019-03-13 at 12 34 39" src="https://user-images.githubusercontent.com/21304781/54276020-7c05be80-458c-11e9-8dd5-90dcbf2b1b45.png">

**Issues:**

None

PR: #PullRequest

---

See the [examples](#example) for inspiration.

## How can others test the changes?

Insert `throw new Error('artifical error')` here:
https://github.com/process-engine/bpmn-studio/blob/a1679f895d401a3df2a401b1f81fbc430fe5c4bc/electron_app/electron.js#L633


## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).

## Example

<details>
<summary>
:warning: Before merging please click here to expand and follow the guide.
</summary>
<br>

Please use `:twisted_rightwards_arrows:` at the beginning of your merge commit title.

Example 1:

<pre>
<code>
:twisted_rightwards_arrows: :bug: Fix Wrong Text Decoration at ...
</code>
</pre>

To get your commit message, just copy the first part of this pull request.

Example 2:
<pre>
<code>
**Changes:**

- Fixes Wrong Text Decoration at ...
- Fixes some typos
- ...

**Issues:**

Closes #NumberOfFixedIssue

PR: #NumberOfThisPR
</code>
</pre>
</details>

## Emojis

<details>
<summary>
Expand for a list of most used Emojis.
</summary>
<br>

Please prefix your commit messages with an Emoji.

Ref: https://gitmoji.carloscuesta.me/

| Description              | Glyphe               | Emoji  |
|--------------------------|----------------------|--------|
| Bugfix                   | `:bug:`              | 🐛     |
| Configuration releated   | `:wrench:`           | 🔧     |
| Cosmetic                 | `:lipstick:`         | 💄     |
| Dependencies Downgrade   | `:arrow_down:`       | ⬇️     |
| Dependencies Upgrade     | `:arrow_up:`         | ⬆️     |
| Formatting               | `:art:`              | 🎨     |
| Improving Performance    | `:zap:`              | ⚡️     |
| Initial commit           | `:tada:`             | 🎉     |
| Linter                   | `:rotating_light:`   | 🚨     |
| Miscellaneous            | `:package:`          | 📦     |
| New Feature              | `:sparkles:`         | ✨     |
| Refactoring Code         | `:recycle:`          | ♻️     |
| Releasing / Version tags | `:bookmark:`         | 🔖     |
| Removing Stuff           | `:fire:`             | 🔥     |
| Tests                    | `:white_check_mark:` | ✅     |
| Work In Progress (WIP)   | `:construction:`     | 🚧     |

</details>
