### PR TITLE
🔧 Improve e2e Test Log

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,7 +101,7 @@ pipeline {
             sh("docker rm ${docker_e2e_container_name} || true")
           }
 
-          def parse_test_result_regex = /Executed\ (\d+)\ of\ \d+\ specs(\ \((\d+)\ FAILED\))?/;
+          def parse_test_result_regex = /Executed\ (\d+)\ of\ \d+\ specs(.*?\((\d+)\ FAILED\))?/;
 
           def test_result_log = readFile "e2e_test_results.txt"
           println(test_result_log);

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,7 +108,7 @@ pipeline {
 
           def total_tests_run = test_result_matcher[0][1] as Integer;
 
-          def tests_failed = test_result_matcher[0].length() > 1;
+          def tests_failed = test_result_matcher[0][2] != null;
           if (tests_failed) {
             error 'Some tests failed, build failed.';
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -119,13 +119,6 @@ pipeline {
           if (some_tests_failed) {
             error 'Some tests failed, build failed.';
           }
-
-          /*
-
-          def some_tests_failed = tests_failed != 0;
-          if (some_tests_failed) {
-            error 'Some tests failed, build failed.';
-          }*/
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,13 +108,18 @@ pipeline {
 
           def total_tests_run = test_result_matcher[0][1] as Integer;
 
-          def tests_failed = test_result_matcher[0][2] != null;
-          if (tests_failed) {
+          def some_tests_failed = test_result_matcher[0][2] != null;
+          def tests_failed = some_tests_failed
+                              ? test_result_matcher[0][3] as Integer
+                              : 0;
+
+          echo "${total_tests_run} Tests run. ${tests_failed} Tests failed."
+
+          if (some_tests_failed) {
             error 'Some tests failed, build failed.';
           }
 
           /*
-          echo "${total_tests_run} Tests run. ${tests_failed} Tests failed."
 
           def some_tests_failed = tests_failed != 0;
           if (some_tests_failed) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,20 +101,25 @@ pipeline {
             sh("docker rm ${docker_e2e_container_name} || true")
           }
 
-          def parse_test_result_regex = /(\d+) specs, (\d+) failures/;
+          def parse_test_result_regex = /Executed\ (\d+)\ of\ \d+\ specs(\ \((\d+)\ FAILED\))?/;
 
           def test_result_log = readFile "e2e_test_results.txt"
           def test_result_matcher = test_result_log =~ parse_test_result_regex
 
           def total_tests_run = test_result_matcher[0][1] as Integer;
-          def tests_failed = test_result_matcher[0][2] as Integer;
 
+          def tests_failed = test_result_matcher[0].length > 1;
+          if (tests_failed) {
+            error 'Some tests failed, build failed.';
+          }
+
+          /*
           echo "${total_tests_run} Tests run. ${tests_failed} Tests failed."
 
           def some_tests_failed = tests_failed != 0;
           if (some_tests_failed) {
             error 'Some tests failed, build failed.';
-          }
+          }*/
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,7 +108,7 @@ pipeline {
 
           def total_tests_run = test_result_matcher[0][1] as Integer;
 
-          def tests_failed = test_result_matcher[0].length > 1;
+          def tests_failed = test_result_matcher[0].length() > 1;
           if (tests_failed) {
             error 'Some tests failed, build failed.';
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,7 +104,6 @@ pipeline {
           def parse_test_result_regex = /Executed\ (\d+)\ of\ \d+\ specs(.*?\((\d+)\ FAILED\))?/;
 
           def test_result_log = readFile "e2e_test_results.txt"
-          println(test_result_log);
           def test_result_matcher = test_result_log =~ parse_test_result_regex
 
           def total_tests_run = test_result_matcher[0][1] as Integer;

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,6 +104,7 @@ pipeline {
           def parse_test_result_regex = /Executed\ (\d+)\ of\ \d+\ specs(\ \((\d+)\ FAILED\))?/;
 
           def test_result_log = readFile "e2e_test_results.txt"
+          println(test_result_log);
           def test_result_matcher = test_result_log =~ parse_test_result_regex
 
           def total_tests_run = test_result_matcher[0][1] as Integer;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9005,6 +9005,23 @@
       "integrity": "sha1-5kAN8ea1bhMLYcS80JPap/boyhU=",
       "dev": true
     },
+    "jasmine-spec-reporter": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jasmine-spec-reporter/-/jasmine-spec-reporter-4.2.1.tgz",
+      "integrity": "sha512-FZBoZu7VE5nR7Nilzy+Np8KuVIOxF4oXDPDknehCYBDE080EnlPu0afdZNmpGDBRCUBv3mj5qgqCRmk6W/K8vg==",
+      "dev": true,
+      "requires": {
+        "colors": "1.1.2"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+          "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+          "dev": true
+        }
+      }
+    },
     "jasminewd2": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/jasminewd2/-/jasminewd2-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -188,6 +188,7 @@
     "gulp-typescript": "^3.2.4",
     "gulp-watch": "^4.3.11",
     "jasmine-core": "^2.4.1",
+    "jasmine-spec-reporter": "4.2.1",
     "jquery": "^3.0.0",
     "minimatch": "^3.0.2",
     "ms": "^2.0.0",

--- a/test/e2e/src/dashboard.spec.ts
+++ b/test/e2e/src/dashboard.spec.ts
@@ -4,7 +4,7 @@ import {DiagramWithUserTask} from './diagrams/diagramWithUserTask';
 import {Dashboard} from './pages/dashboard';
 import {RouterView} from './pages/routerView';
 
-fdescribe('Dashboard', () => {
+describe('Dashboard', () => {
 
   let dashboard: Dashboard;
   let diagram: DiagramWithUserTask;

--- a/test/e2e/src/dashboard.spec.ts
+++ b/test/e2e/src/dashboard.spec.ts
@@ -33,8 +33,6 @@ fdescribe('Dashboard', () => {
     const visibilityOfProcessListContainer: boolean = await dashboard.getVisibilityOfProcessListContainer();
 
     expect(visibilityOfProcessListContainer).toBeTruthy();
-
-    expect(false).toBeTruthy();
   });
 
   it('should contain the task list.', async() => {

--- a/test/e2e/src/dashboard.spec.ts
+++ b/test/e2e/src/dashboard.spec.ts
@@ -4,7 +4,7 @@ import {DiagramWithUserTask} from './diagrams/diagramWithUserTask';
 import {Dashboard} from './pages/dashboard';
 import {RouterView} from './pages/routerView';
 
-describe('Dashboard', () => {
+fdescribe('Dashboard', () => {
 
   let dashboard: Dashboard;
   let diagram: DiagramWithUserTask;
@@ -33,6 +33,8 @@ describe('Dashboard', () => {
     const visibilityOfProcessListContainer: boolean = await dashboard.getVisibilityOfProcessListContainer();
 
     expect(visibilityOfProcessListContainer).toBeTruthy();
+
+    expect(false).toBeTruthy();
   });
 
   it('should contain the task list.', async() => {

--- a/test/protractor.conf.js
+++ b/test/protractor.conf.js
@@ -1,3 +1,5 @@
+let specReporter = require('jasmine-spec-reporter').SpecReporter;
+
 exports.config = {
   directConnect: false,
 
@@ -6,7 +8,7 @@ exports.config = {
       browserName: 'chrome',
       chromeOptions: {
         args: [
-          "--headless",
+          //"--headless",
           "--disable-gpu",
           "--no-sandbox",
           "--disable-dev-shm-usage",
@@ -42,9 +44,17 @@ exports.config = {
   jasmineNodeOpts: {
     showColors: true,
     defaultTimeoutInterval: 30000,
+    print: function() {},
   },
 
   onPrepare: function() {
+
+    jasmine.getEnv().addReporter(new specReporter({
+      spec: {
+        displayStacktrace: true,
+      }
+    }));
+
     browser.manage().window().maximize();
 
     afterEach(() => {

--- a/test/protractor.conf.js
+++ b/test/protractor.conf.js
@@ -8,7 +8,7 @@ exports.config = {
       browserName: 'chrome',
       chromeOptions: {
         args: [
-          //"--headless",
+          "--headless",
           "--disable-gpu",
           "--no-sandbox",
           "--disable-dev-shm-usage",


### PR DESCRIPTION
**Changes:**

1. Adds the `jasemine-spec-reporter` to view the current running test instead of just dots.

**Issues:**

PR: #1437

## How can others test the changes?

When running the e2e tests, you will now get a far more detailed log output.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).