### PR TITLE
♻️ Make linter errors more prominent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -746,9 +746,9 @@
       }
     },
     "@process-engine/correlation.service": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@process-engine/correlation.service/-/correlation.service-1.1.1.tgz",
-      "integrity": "sha512-NhmrvCDhpbAuz8qQvVVZaq80YnbQGq4VQ/u6UDnU95SyIgGHoLdcflP5MhMneK2Eqa8b0jFIaqOGPkKzTxUCpg==",
+      "version": "1.1.1-cbe56904-b8",
+      "resolved": "https://registry.npmjs.org/@process-engine/correlation.service/-/correlation.service-1.1.1-cbe56904-b8.tgz",
+      "integrity": "sha512-j4SwKVlVE7105lLyqrRZZjucVwLf+bvWElfGhONKT1Eq3h8+POt61r/4dU8tk7lyDYZqYY40s6GurW4vqEv40A==",
       "requires": {
         "@essential-projects/errors_ts": "^1.4.3",
         "@process-engine/correlation.contracts": "^1.0.2",
@@ -1211,9 +1211,9 @@
       }
     },
     "@process-engine/process_engine_core": {
-      "version": "12.4.0",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.4.0.tgz",
-      "integrity": "sha512-ipUBDDl4/s2IK2YS7JMj6Gqsrqg1tj8T/x+vf7+6L8S1lqz7e85ttaZgdYdu58yp4SnkAztdWXPVO9NtJvQ6Hg==",
+      "version": "12.4.0-0abd3f08-b203",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.4.0-0abd3f08-b203.tgz",
+      "integrity": "sha512-Y6Xi1s2xcWB8HtMnK73nnGSgZiQFMTCaXYnN6qXAFLszrCVk/WsBzLxl6PHYnELz+tAWFqEII8/wsE0zrYLIiQ==",
       "requires": {
         "@essential-projects/errors_ts": "^1.4.0",
         "@essential-projects/timing_contracts": "^4.0.0",
@@ -1238,9 +1238,9 @@
       }
     },
     "@process-engine/process_engine_runtime": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_runtime/-/process_engine_runtime-7.2.0.tgz",
-      "integrity": "sha512-MAxE+t5R1J30O9lnTA3O6PuZLLojK1IC3Lu2SnAAQ36v4PQM35O+dCRXtMeAb+bfcefmi/LcKEB0j3tMikqvWw==",
+      "version": "7.2.0-2d3a6e5d-b291",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_runtime/-/process_engine_runtime-7.2.0-2d3a6e5d-b291.tgz",
+      "integrity": "sha512-dASxSx4BijHAB3R2YUjQ1Ul9RqAFegzFaZaXTnvboYKMhxQOB7IPEUZ7Zgu1BToOJIs+lHOfMLmc8ykVW7w3oQ==",
       "requires": {
         "@essential-projects/bootstrapper": "3.3.2",
         "@essential-projects/bootstrapper_node": "3.2.7",
@@ -1251,7 +1251,7 @@
         "@essential-projects/timing": "4.1.3",
         "@process-engine/consumer_api_core": "5.1.2",
         "@process-engine/consumer_api_http": "4.1.0",
-        "@process-engine/correlation.service": "1.1.1",
+        "@process-engine/correlation.service": "1.1.1-cbe56904-b8",
         "@process-engine/correlations.repository.sequelize": "5.0.2",
         "@process-engine/deployment_api_core": "2.2.0",
         "@process-engine/deployment_api_http": "1.2.0",
@@ -1270,7 +1270,7 @@
         "@process-engine/management_api_http": "4.2.0",
         "@process-engine/metrics.repository.file_system": "1.1.2",
         "@process-engine/metrics_api_core": "1.0.2",
-        "@process-engine/process_engine_core": "12.4.0",
+        "@process-engine/process_engine_core": "12.4.0-0abd3f08-b203",
         "@process-engine/process_model.repository.sequelize": "5.1.0",
         "@process-engine/process_model.service": "1.1.0",
         "@process-engine/process_model.use_case": "1.1.0",
@@ -8140,12 +8140,12 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "uglify-js": {
-          "version": "3.4.9",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-          "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+          "version": "3.4.10",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.10.tgz",
+          "integrity": "sha512-Y2VsbPVs0FIshJztycsO2SfPk7/KAF/T72qzv9u5EpQ4kB2hQoHlhNQTsNyy6ul7lQtqJN/AoWeS23OzEiEFxw==",
           "optional": true,
           "requires": {
-            "commander": "~2.17.1",
+            "commander": "~2.19.0",
             "source-map": "~0.6.1"
           }
         }
@@ -8338,9 +8338,9 @@
       "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
     },
     "highlightjs-line-numbers.js": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/highlightjs-line-numbers.js/-/highlightjs-line-numbers.js-2.6.0.tgz",
-      "integrity": "sha512-Ffx42SmswE41lKHafsXT7jGhao4Rn2TN/12y3MwzBn0b1MYGSd9kpW7fpnAEhXqUdBeCtgG78tmrqhIDNc21TQ=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/highlightjs-line-numbers.js/-/highlightjs-line-numbers.js-2.7.0.tgz",
+      "integrity": "sha512-2kgZkfGy3TB6rF1o1XJtUThDyraLAFd6iiAIE1MEH89om8VwyHsal6BBnIOP2yOuq2TCuuGd0YD6aGHa6iq3/g=="
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -9082,11 +9082,11 @@
       }
     },
     "jsonwebtoken": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.0.tgz",
-      "integrity": "sha512-IqEycp0znWHNA11TpYi77bVgyBO/pGESDh7Ajhas+u0ttkGkKYIIAjniL4Bw5+oVejVF+SYkaI7XKfwCCyeTuA==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
       "requires": {
-        "jws": "^3.2.1",
+        "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",
         "lodash.isboolean": "^3.0.3",
         "lodash.isinteger": "^4.0.4",
@@ -9135,9 +9135,9 @@
       "dev": true
     },
     "jwa": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.0.tgz",
-      "integrity": "sha512-mt6IHaq0ZZWDBspg0Pheu3r9sVNMEZn+GJe1zcdYyhFcDSclp3J8xEdO4PjZolZ2i8xlaVU1LetHM0nJejYsEw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -9145,11 +9145,11 @@
       }
     },
     "jws": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.1.tgz",
-      "integrity": "sha512-bGA2omSrFUkd72dhh05bIAN832znP4wOU3lfuXtRBuGTbsmNmDXMQg28f0Vsxaxgk4myF5YkKQpz6qeRpMgX9g==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
       "requires": {
-        "jwa": "^1.2.0",
+        "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -11004,9 +11004,9 @@
       "dev": true
     },
     "opn": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
-      "integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
+      "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
       "dev": true,
       "requires": {
         "is-wsl": "^1.1.0"
@@ -11049,9 +11049,9 @@
           "dev": true
         },
         "strip-ansi": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.1.0.tgz",
-          "integrity": "sha512-TjxrkPONqO2Z8QDCpeE2j6n0M6EwxzyDgzEeGp+FbdvaJAt//ClYi6W5my+3ROlC/hZX2KACUwDfK49Ka5eDvg==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -13740,12 +13740,6 @@
         "source-map-support": "~0.5.10"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-          "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
-          "dev": true
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@process-engine/bpmn-js-custom-bundle": "2.6.3",
     "@process-engine/bpmn-lint_rules": "1.6.0",
     "@process-engine/management_api_client": "4.2.0",
-    "@process-engine/process_engine_runtime": "7.2.0",
+    "@process-engine/process_engine_runtime": "7.2.0-2d3a6e5d-b291",
     "@process-engine/dynamic_ui_core": "1.4.0",
     "@process-engine/solutionexplorer.repository.filesystem": "4.0.1",
     "@process-engine/solutionexplorer.repository.management_api": "3.0.0",

--- a/src/app.scss
+++ b/src/app.scss
@@ -81,7 +81,7 @@ a:hover {
   background-color: #eee;
 }
 
-.btn-default:focus {
+.btn:focus {
   box-shadow: none;
 }
 

--- a/src/modules/design/bpmn-io/bpmn-io.html
+++ b/src/modules/design/bpmn-io/bpmn-io.html
@@ -28,7 +28,7 @@
       <div class="modeler">
         <div class="diagram" id="bpmnIoDiagram">
           <div ref="canvasModel" class="canvasModel"></div>
-          <button class.bind="diagramIsInvalid ? 'button btn btn-default-red linter-toggle-button-invalid-diagram' : 'button btn btn-default linter-toggle-button'"
+          <button class.bind="diagramIsInvalid ? 'button btn linter-toggle-button-invalid-diagram' : 'button btn btn-default linter-toggle-button'"
                   css.bind="showLinter || diagramIsInvalid? 'opacity: 1;' : ''"
                   title.bind="showLinter ? 'Hide Linter' : 'Show Linter'"
                   click.delegate="toggleLinter()">

--- a/src/modules/design/bpmn-io/bpmn-io.html
+++ b/src/modules/design/bpmn-io/bpmn-io.html
@@ -28,8 +28,8 @@
       <div class="modeler">
         <div class="diagram" id="bpmnIoDiagram">
           <div ref="canvasModel" class="canvasModel"></div>
-          <button class="button btn btn-default linter-toggle-button"
-                  css.bind="showLinter? 'opacity: 1;' : ''"
+          <button class.bind="diagramIsInvalid ? 'button btn btn-default-red linter-toggle-button-invalid-diagram' : 'button btn btn-default linter-toggle-button'"
+                  css.bind="showLinter || diagramIsInvalid? 'opacity: 1;' : ''"
                   title.bind="showLinter ? 'Hide Linter' : 'Show Linter'"
                   click.delegate="toggleLinter()">
             <i class.bind="diagramIsInvalid ? 'fas fa-times' : 'fas fa-check'"></i>

--- a/src/modules/design/bpmn-io/bpmn-io.scss
+++ b/src/modules/design/bpmn-io/bpmn-io.scss
@@ -225,9 +225,9 @@
 }
 
 .btn-default-red {
-  background-color: #f00;
-  border-color: #ccc;
-  color: #333;
+  background-color: rgba(204, 51, 00, 0.95);;
+  border-color: #cc3300;
+  color: white;
 }
 
 .linter-toggle-button-invalid-diagram {

--- a/src/modules/design/bpmn-io/bpmn-io.scss
+++ b/src/modules/design/bpmn-io/bpmn-io.scss
@@ -224,6 +224,27 @@
   border-radius: 2px;
 }
 
+.btn-default-red {
+  background-color: #f00;
+  border-color: #ccc;
+  color: #333;
+}
+
+.linter-toggle-button-invalid-diagram {
+  position: absolute;
+  bottom: 20px;
+  left: 10px;
+  width: 31px;
+  height: 31px;
+  padding: 0;
+  background-color: rgba(255, 0, 0, 0.95);
+  border: solid 1px #ccc;
+  border-radius: 2px;
+  :hover {
+    background-color: rgba(255, 0, 0, 0.95);
+  }
+}
+
 .bpmn-js-bpmnlint-process-issues {
   //Overwriting the existing style of the plugin
   top: unset;

--- a/src/modules/design/bpmn-io/bpmn-io.scss
+++ b/src/modules/design/bpmn-io/bpmn-io.scss
@@ -240,9 +240,6 @@
   background-color: rgba(255, 0, 0, 0.95);
   border: solid 1px #ccc;
   border-radius: 2px;
-  :hover {
-    background-color: rgba(255, 0, 0, 0.95);
-  }
 }
 
 .bpmn-js-bpmnlint-process-issues {

--- a/src/modules/design/bpmn-io/bpmn-io.scss
+++ b/src/modules/design/bpmn-io/bpmn-io.scss
@@ -224,12 +224,6 @@
   border-radius: 2px;
 }
 
-.btn-default-red {
-  background-color: rgba(204, 51, 00, 0.95);;
-  border-color: #cc3300;
-  color: white;
-}
-
 .linter-toggle-button-invalid-diagram {
   position: absolute;
   bottom: 20px;
@@ -237,9 +231,15 @@
   width: 31px;
   height: 31px;
   padding: 0;
-  background-color: rgba(255, 0, 0, 0.95);
+  background-color: rgba(204, 51, 0, 0.95);
   border: solid 1px #ccc;
+  color: white;
   border-radius: 2px;
+}
+
+.linter-toggle-button-invalid-diagram:hover {
+  background-color: rgb(230, 77, 26);
+  color: white;
 }
 
 .bpmn-js-bpmnlint-process-issues {


### PR DESCRIPTION
**Changes:**

Change the background of the linter button to red, if the diagram has linter errors.

This was done to make the linter button more prominent, in case the user makes errors and has the linter disabled.

**Issues:**

Closes #1405 

PR: #1438

## How can others test the changes?

- Create a diagram
- Keep the linter messages hidden
- Provoke a linter error
- See that the deploy button is disabled and the linter button is red.

Should look something like this:

![Bildschirmfoto 2019-03-18 um 13 49 44](https://user-images.githubusercontent.com/15343316/54531132-d637c280-4984-11e9-95af-6ce276414dfa.png)


## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).