### PR TITLE
🐛 Fix Copy of UserTasks When no Fields are Specified

### DIFF
--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -488,6 +488,12 @@ export class BpmnIo {
       return field.$type === 'camunda:FormData';
     });
 
+    const noFieldsSpecified: boolean = formDataObject.fields === undefined
+                                    || formDataObject.fields === null;
+    if (noFieldsSpecified) {
+      return;
+    }
+
     formDataObject.fields.forEach((formField: IModdleElement) => {
       formField.id = `Form_${this._generateRandomId()}`;
     });


### PR DESCRIPTION
**Changes:**

1. Add an early exit when there are no FormFields specified yet.

**Issues:**

Closes #1445

PR: #PullRequest

## How can others test the changes?

Follow the instructions in the mentioned Issue.
See that the faulty behavior doesn't occur anymore.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).
