### PR TITLE
Remove linux build from Jenkinsfile, README, et al.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -28,7 +28,7 @@
 #### What's your setup
 
 - BPMN-Studio Version (`4.x.x`):
-- OS (`Windows/OS X/Linux` + `version`):
+- OS (`Windows/OS X` + `version`):
 - Node (`node --version`):
 - NPM (`npm --version`):
 - Docker (`docker version --format '{{.Server.Version}}'`):

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,33 +130,6 @@ pipeline {
         }
       }
       parallel {
-        stage('Build on Linux') {
-          agent {
-            label "linux && snapcraft-2.41"
-          }
-          steps {
-            unstash('post_build')
-            unstash('post_build_node_modules')
-
-            sh('node --version')
-
-            // We copy the node_modules folder from the slave running
-            // prepare and install steps. That slave may run another OS
-            // than linux. Some dependencies may not be installed if
-            // they have an os restriction in their package.json.
-            sh('npm install')
-
-            sh('npm run jenkins-electron-install-app-deps')
-            sh('npm run jenkins-electron-rebuild-native')
-            sh('npm run jenkins-electron-build-linux')
-            stash(includes: 'dist/*.*', excludes: 'electron-builder-effective-config.yaml', name: 'linux_results')
-          }
-          post {
-            always {
-              cleanup_workspace()
-            }
-          }
-        }
         stage('Build on MacOS') {
           agent {
             label "macos"
@@ -280,7 +253,6 @@ pipeline {
         }
       }
       steps {
-        unstash('linux_results')
         unstash('macos_results')
         unstash('windows_results')
 
@@ -306,8 +278,6 @@ pipeline {
                   "dist/bpmn-studio-${full_electron_release_version_string}-x86_64.AppImage",
                   "dist/bpmn-studio-${full_electron_release_version_string}.dmg",
                   "dist/bpmn-studio-${full_electron_release_version_string}.dmg.blockmap",
-                  "dist/bpmn-studio_${full_electron_release_version_string}_amd64.snap",
-                  "dist/latest-linux.yml",
                   "dist/latest-mac.yml",
                   "dist/latest.yml",
                 ];

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Engine verbunden werden, um diese Diagramme auszuführen.
 
    Für den Platzhalter `<OS>` können folgende Werte eingesetzt werden:
 
-   - `linux` für Linux
    - `macos` für MacOS
    - `windows` für Windows
 
@@ -334,10 +333,6 @@ Die folgenden Skripte, werden in unserem Tooling verwendet:
 * `electron-build-macos`
 
   Baut die Electron-Anwendung für macOS.
-
-* `electron-build-linux`
-
-  Baut die Electron-Anwendung für Linux.
 
 * `electron-build-windows`
 

--- a/electron_app/electron.js
+++ b/electron_app/electron.js
@@ -290,7 +290,7 @@ Main._createMainWindow = function () {
     title: "BPMN-Studio",
     minWidth: 1300,
     minHeight: 800,
-    icon: path.join(__dirname, '../build/icon.png'), // only for windows and linux
+    icon: path.join(__dirname, '../build/icon.png'), // only for windows
     titleBarStyle: 'hiddenInset'
   });
 

--- a/package.json
+++ b/package.json
@@ -25,13 +25,11 @@
     "electron-start-dev": "npm run build && electron electron_app/electron.js",
     "electron-build-windows": "electron-rebuild && npm run build && build --publish never --windows",
     "electron-build-macos": "electron-rebuild && npm run build && build --publish never --macos",
-    "electron-build-linux": "electron-rebuild && npm run build && build --publish never --linux",
     "electron-shipit": "npm run build && build --publish always",
     "jenkins-electron-install-app-deps": "electron-builder install-app-deps",
     "jenkins-electron-rebuild-native": "electron-rebuild --force",
     "jenkins-electron-build-windows": "build --publish never --windows",
     "jenkins-electron-build-macos": "build --publish never --macos",
-    "jenkins-electron-build-linux": "build --publish never --linux",
     "jenkins-run-end-to-end-tests": "au e2eDocker",
     "jenkins-start-process-engine": "process-engine"
   },
@@ -75,18 +73,6 @@
           "name": "BPMN"
         }
       ]
-    },
-    "linux": {
-      "target": "snap",
-      "fileAssociations": [
-        {
-          "ext": [
-            "bpmn"
-          ],
-          "name": "BPMN"
-        }
-      ],
-      "category": "Development"
     }
   },
   "files": [

--- a/src/modules/start-page/start-page.html
+++ b/src/modules/start-page/start-page.html
@@ -9,20 +9,16 @@
           <div class="quick-start__topic" click.delegate="openSingleDiagram()">Open Diagram</div>
           <div show.bind="isRunningInElectron && isRunningOnMacOS" class="quick-start__shortcut">⌘ + O</div>
           <div show.bind="isRunningInElectron && isRunningOnWindows" class="quick-start__shortcut">Strg + O</div>
-          <div show.bind="isRunningInElectron && isRunningOnLinux" class="quick-start__shortcut">Strg + O</div>
         </div>
         <div class="quick-start__item">
           <div class="quick-start__topic" click.delegate="openLocalSolution()">Open Solution</div>
           <div show.bind="isRunningInElectron && isRunningOnMacOS" class="quick-start__shortcut">⌘ + ⇧ + O</div>
           <div show.bind="isRunningInElectron && isRunningOnWindows" class="quick-start__shortcut">Strg + Shift + O</div>
-          <div show.bind="isRunningInElectron && isRunningOnLinux" class="quick-start__shortcut">Strg + Shift + O</div>
         </div>
         <div class="quick-start__item">
           <div class="quick-start__topic" click.delegate="createNewSingleDiagram()">New Diagram</div>
           <div show.bind="isRunningInElectron && isRunningOnMacOS" class="quick-start__shortcut">⌘ + N</div>
           <div show.bind="isRunningInElectron && isRunningOnWindows" class="quick-start__shortcut">Strg + N</div>
-          <!--See https://github.com/process-engine/bpmn-studio/issues/1292-->
-          <!--<div show.bind="isRunningInElectron && isRunningOnLinux" class="quick-start__shortcut">Strg + N</div>-->
         </div>
       </div>
     </div>

--- a/src/modules/start-page/start-page.ts
+++ b/src/modules/start-page/start-page.ts
@@ -10,7 +10,6 @@ export class StartPage {
   public isRunningInElectron: boolean = (window as any).nodeRequire;
   public isRunningOnWindows: boolean = false;
   public isRunningOnMacOS: boolean = false;
-  public isRunningOnLinux: boolean = false;
 
   constructor(eventAggregator: EventAggregator) {
     this._eventAggregator = eventAggregator;
@@ -20,7 +19,6 @@ export class StartPage {
     if (this.isRunningInElectron) {
       this.isRunningOnWindows = process.platform === 'win32';
       this.isRunningOnMacOS = process.platform === 'darwin';
-      this.isRunningOnLinux = process.platform === 'linux';
     }
   }
 


### PR DESCRIPTION
We do not have any need for building a Linux version at the moment.

Should the need arise, we will revisit this decision. :+1:
