### PR TITLE
:twisted_rightwards_arrows: :recycle: Use setTimeout instead of setInterval

### DIFF
--- a/src/modules/inspect/process-list/process-list.ts
+++ b/src/modules/inspect/process-list/process-list.ts
@@ -30,7 +30,7 @@ export class ProcessList {
   private _activeSolutionUri: string;
   private _router: Router;
 
-  private timeout: NodeJS.Timer | number;
+  private _pollingTimeout: NodeJS.Timer | number;
   private _subscriptions: Array<Subscription>;
   private _correlations: Array<DataModels.Correlations.Correlation> = [];
 
@@ -91,14 +91,14 @@ export class ProcessList {
   }
 
   public startPolling(): void {
-    this.timeout = setTimeout(async() => {
+    this._pollingTimeout = setTimeout(async() => {
       await this.updateCorrelationList();
       this.startPolling();
     }, environment.processengine.dashboardPollingIntervalInMs);
   }
 
   public detached(): void {
-    clearTimeout(this.timeout as NodeJS.Timer);
+    clearTimeout(this._pollingTimeout as NodeJS.Timer);
 
     for (const subscription of this._subscriptions) {
       subscription.dispose();

--- a/src/modules/inspect/process-list/process-list.ts
+++ b/src/modules/inspect/process-list/process-list.ts
@@ -30,7 +30,7 @@ export class ProcessList {
   private _activeSolutionUri: string;
   private _router: Router;
 
-  private timeout: NodeJS.Timer;
+  private timeout: NodeJS.Timer | number;
   private _subscriptions: Array<Subscription>;
   private _correlations: Array<DataModels.Correlations.Correlation> = [];
 
@@ -98,7 +98,7 @@ export class ProcessList {
   }
 
   public detached(): void {
-    clearTimeout(this.timeout);
+    clearTimeout(this.timeout as NodeJS.Timer);
 
     for (const subscription of this._subscriptions) {
       subscription.dispose();

--- a/src/modules/inspect/process-list/process-list.ts
+++ b/src/modules/inspect/process-list/process-list.ts
@@ -90,6 +90,7 @@ export class ProcessList {
     ];
   }
 
+  private _startPolling(): void {
     this._pollingTimeout = setTimeout(async() => {
       await this.updateCorrelationList();
       this._startPolling();

--- a/src/modules/inspect/process-list/process-list.ts
+++ b/src/modules/inspect/process-list/process-list.ts
@@ -78,7 +78,7 @@ export class ProcessList {
     this.activeSolutionEntry = this._solutionService.getSolutionEntryForUri(this._activeSolutionUri);
 
     await this.updateCorrelationList();
-    this.startPolling();
+    this._startPolling();
 
     this._subscriptions = [
       this._eventAggregator.subscribe(AuthenticationStateEvent.LOGIN, () => {
@@ -90,10 +90,9 @@ export class ProcessList {
     ];
   }
 
-  public startPolling(): void {
     this._pollingTimeout = setTimeout(async() => {
       await this.updateCorrelationList();
-      this.startPolling();
+      this._startPolling();
     }, environment.processengine.dashboardPollingIntervalInMs);
   }
 

--- a/src/modules/inspect/process-list/process-list.ts
+++ b/src/modules/inspect/process-list/process-list.ts
@@ -30,7 +30,7 @@ export class ProcessList {
   private _activeSolutionUri: string;
   private _router: Router;
 
-  private _getCorrelationsIntervalId: number;
+  private timeout: NodeJS.Timer;
   private _subscriptions: Array<Subscription>;
   private _correlations: Array<DataModels.Correlations.Correlation> = [];
 
@@ -78,10 +78,7 @@ export class ProcessList {
     this.activeSolutionEntry = this._solutionService.getSolutionEntryForUri(this._activeSolutionUri);
 
     await this.updateCorrelationList();
-
-    this._getCorrelationsIntervalId = window.setInterval(async() => {
-      await this.updateCorrelationList();
-    }, environment.processengine.dashboardPollingIntervalInMs);
+    this.startPolling();
 
     this._subscriptions = [
       this._eventAggregator.subscribe(AuthenticationStateEvent.LOGIN, () => {
@@ -93,8 +90,15 @@ export class ProcessList {
     ];
   }
 
+  public startPolling(): void {
+    this.timeout = setTimeout(async() => {
+      await this.updateCorrelationList();
+      this.startPolling();
+    }, environment.processengine.dashboardPollingIntervalInMs);
+  }
+
   public detached(): void {
-    clearInterval(this._getCorrelationsIntervalId);
+    clearTimeout(this.timeout);
 
     for (const subscription of this._subscriptions) {
       subscription.dispose();

--- a/src/modules/inspect/task-list/task-list.ts
+++ b/src/modules/inspect/task-list/task-list.ts
@@ -122,13 +122,13 @@ export class TaskList {
     ];
 
     await this.updateTasks();
-    this.startPolling();
+    this._startPolling();
   }
 
-  public startPolling(): void {
+  private _startPolling(): void {
     this._pollingTimeout = setTimeout(async() => {
       await this.updateTasks();
-      this.startPolling();
+      this._startPolling();
     }, environment.processengine.dashboardPollingIntervalInMs);
   }
 

--- a/src/modules/inspect/task-list/task-list.ts
+++ b/src/modules/inspect/task-list/task-list.ts
@@ -187,8 +187,6 @@ export class TaskList {
     const allProcessModels: DataModels.ProcessModels.ProcessModelList = await this._managementApiService
       .getProcessModels(this.activeSolutionEntry.identity);
 
-    console.log(allProcessModels);
-
     // TODO (ph): This will create 1 + n http reqeusts, where n is the number of process models in the processengine.
     const promisesForAllUserTasks: Array<Promise<Array<IUserTaskWithProcessModel>>> = allProcessModels.processModels
       .map(async(processModel: DataModels.ProcessModels.ProcessModel): Promise<Array<IUserTaskWithProcessModel>> => {

--- a/src/modules/inspect/task-list/task-list.ts
+++ b/src/modules/inspect/task-list/task-list.ts
@@ -53,7 +53,7 @@ export class TaskList {
 
   private _subscriptions: Array<Subscription>;
   private _userTasks: Array<IUserTaskWithProcessModel>;
-  private timeout: NodeJS.Timer | number;
+  private _pollingTimeout: NodeJS.Timer | number;
   private _getTasks: () => Promise<Array<IUserTaskWithProcessModel>>;
 
   constructor(eventAggregator: EventAggregator,
@@ -126,14 +126,14 @@ export class TaskList {
   }
 
   public startPolling(): void {
-    this.timeout = setTimeout(async() => {
+    this._pollingTimeout = setTimeout(async() => {
       await this.updateTasks();
       this.startPolling();
     }, environment.processengine.dashboardPollingIntervalInMs);
   }
 
   public detached(): void {
-    clearTimeout(this.timeout as NodeJS.Timer);
+    clearTimeout(this._pollingTimeout as NodeJS.Timer);
 
     for (const subscription of this._subscriptions) {
       subscription.dispose();

--- a/src/modules/inspect/task-list/task-list.ts
+++ b/src/modules/inspect/task-list/task-list.ts
@@ -53,7 +53,7 @@ export class TaskList {
 
   private _subscriptions: Array<Subscription>;
   private _userTasks: Array<IUserTaskWithProcessModel>;
-  private timeout: NodeJS.Timer;
+  private timeout: NodeJS.Timer | number;
   private _getTasks: () => Promise<Array<IUserTaskWithProcessModel>>;
 
   constructor(eventAggregator: EventAggregator,
@@ -133,7 +133,7 @@ export class TaskList {
   }
 
   public detached(): void {
-    clearTimeout(this.timeout);
+    clearTimeout(this.timeout as NodeJS.Timer);
 
     for (const subscription of this._subscriptions) {
       subscription.dispose();

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -126,7 +126,7 @@ export class SolutionExplorerSolution {
     ];
 
     await this.updateSolution();
-    this.startPolling();
+    this._startPolling();
   }
 
   public detached(): void {
@@ -142,10 +142,10 @@ export class SolutionExplorerSolution {
     }
   }
 
-  public startPolling(): void {
+  private _startPolling(): void {
     this._refreshTimeoutTask = setTimeout(async() =>  {
       await this.updateSolution();
-      this.startPolling();
+      this._startPolling();
     }, environment.processengine.solutionExplorerPollingIntervalInMs);
   }
 

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -71,7 +71,7 @@ export class SolutionExplorerSolution {
   private _diagramRenamingState: IDiagramNameInputState = {
     currentDiagramInputValue: undefined,
   };
-  private _refreshTimeoutTask: NodeJS.Timer;
+  private _refreshTimeoutTask: NodeJS.Timer | number;
 
   private _diagramValidationRegExpList: Array<RegExp> =  [
     /^[a-z0-9]/i,
@@ -130,7 +130,7 @@ export class SolutionExplorerSolution {
   }
 
   public detached(): void {
-    clearTimeout(this._refreshTimeoutTask);
+    clearTimeout(this._refreshTimeoutTask as NodeJS.Timer);
     this._disposeSubscriptions();
 
     if (this.isCreateDiagramInputShown()) {

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -71,7 +71,7 @@ export class SolutionExplorerSolution {
   private _diagramRenamingState: IDiagramNameInputState = {
     currentDiagramInputValue: undefined,
   };
-  private _refreshIntervalTask: any;
+  private _refreshTimeoutTask: NodeJS.Timer;
 
   private _diagramValidationRegExpList: Array<RegExp> =  [
     /^[a-z0-9]/i,
@@ -114,7 +114,7 @@ export class SolutionExplorerSolution {
     this._globalSolutionService = solutionService;
   }
 
-  public attached(): void {
+  public async attached(): Promise<void> {
     this._originalIconClass = this.fontAwesomeIconClass;
     this._updateSolutionExplorer();
     this._setValidationRules();
@@ -125,14 +125,12 @@ export class SolutionExplorerSolution {
       }),
     ];
 
-    this._refreshIntervalTask = setInterval(async() =>  {
-      this.updateSolution();
-    }, environment.processengine.solutionExplorerPollingIntervalInMs);
-
+    await this.updateSolution();
+    this.startPolling();
   }
 
   public detached(): void {
-    clearInterval(this._refreshIntervalTask);
+    clearTimeout(this._refreshTimeoutTask);
     this._disposeSubscriptions();
 
     if (this.isCreateDiagramInputShown()) {
@@ -142,6 +140,13 @@ export class SolutionExplorerSolution {
     if (this._isCurrentlyRenamingDiagram) {
       this._resetDiagramRenaming();
     }
+  }
+
+  public startPolling(): void {
+    this._refreshTimeoutTask = setTimeout(async() =>  {
+      await this.updateSolution();
+      this.startPolling();
+    }, environment.processengine.solutionExplorerPollingIntervalInMs);
   }
 
   public async showDeleteDiagramModal(diagram: IDiagram, event: Event): Promise<void> {
@@ -304,7 +309,7 @@ export class SolutionExplorerSolution {
       await this._diagramCreationService.createNewDiagram(this.displayedSolutionEntry.uri, newName, this._diagramInContextMenu.xml);
 
     await this.solutionService.saveDiagram(duplicatedDiagram, duplicatedDiagram.uri);
-    this.updateSolution();
+    await this.updateSolution();
   }
 
   /*
@@ -601,7 +606,7 @@ export class SolutionExplorerSolution {
       return;
     }
 
-    this.updateSolution();
+    await this.updateSolution();
     this._resetDiagramCreation();
     this.navigateToDetailView(emptyDiagram);
   }
@@ -623,7 +628,7 @@ export class SolutionExplorerSolution {
         return;
       }
 
-      this.updateSolution();
+      await this.updateSolution();
       this._resetDiagramCreation();
       this.navigateToDetailView(emptyDiagram);
 

--- a/src/modules/think/diagram-list/diagram-list.ts
+++ b/src/modules/think/diagram-list/diagram-list.ts
@@ -16,7 +16,7 @@ export class DiagramList {
   private _eventAggregator: EventAggregator;
   private _router: Router;
   private _subscriptions: Array<Subscription>;
-  private _getProcessesIntervalId: number;
+  private timeout: NodeJS.Timer;
 
   constructor(eventAggregator: EventAggregator,
               router: Router) {
@@ -24,14 +24,10 @@ export class DiagramList {
     this._router = router;
   }
 
-  public attached(): void {
+  public async attached(): Promise<void> {
 
-    this._updateDiagramList();
-
-    this._getProcessesIntervalId = window.setInterval(() => {
-      this._updateDiagramList();
-      // tslint:disable-next-line
-    }, environment.processengine.processDefListPollingIntervalInMs);
+    await this._updateDiagramList();
+    this.startPolling();
 
     this._subscriptions = [
       this._eventAggregator.subscribe(AuthenticationStateEvent.LOGIN, () => {
@@ -44,10 +40,17 @@ export class DiagramList {
   }
 
   public detached(): void {
-    clearInterval(this._getProcessesIntervalId);
+    clearTimeout(this.timeout);
     for (const subscription of this._subscriptions) {
       subscription.dispose();
     }
+  }
+
+  public startPolling(): void {
+    this.timeout = setTimeout(async() => {
+      await this._updateDiagramList();
+      this.startPolling();
+    }, environment.processengine.processDefListPollingIntervalInMs);
   }
 
   public showDetails(diagramName: string): void {

--- a/src/modules/think/diagram-list/diagram-list.ts
+++ b/src/modules/think/diagram-list/diagram-list.ts
@@ -27,7 +27,7 @@ export class DiagramList {
   public async attached(): Promise<void> {
 
     await this._updateDiagramList();
-    this.startPolling();
+    this._startPolling();
 
     this._subscriptions = [
       this._eventAggregator.subscribe(AuthenticationStateEvent.LOGIN, () => {
@@ -46,10 +46,10 @@ export class DiagramList {
     }
   }
 
-  public startPolling(): void {
+  private _startPolling(): void {
     this._pollingTimeout = setTimeout(async() => {
       await this._updateDiagramList();
-      this.startPolling();
+      this._startPolling();
     }, environment.processengine.processDefListPollingIntervalInMs);
   }
 

--- a/src/modules/think/diagram-list/diagram-list.ts
+++ b/src/modules/think/diagram-list/diagram-list.ts
@@ -16,7 +16,7 @@ export class DiagramList {
   private _eventAggregator: EventAggregator;
   private _router: Router;
   private _subscriptions: Array<Subscription>;
-  private timeout: NodeJS.Timer | number;
+  private _pollingTimeout: NodeJS.Timer | number;
 
   constructor(eventAggregator: EventAggregator,
               router: Router) {
@@ -40,14 +40,14 @@ export class DiagramList {
   }
 
   public detached(): void {
-    clearTimeout(this.timeout as NodeJS.Timer);
+    clearTimeout(this._pollingTimeout as NodeJS.Timer);
     for (const subscription of this._subscriptions) {
       subscription.dispose();
     }
   }
 
   public startPolling(): void {
-    this.timeout = setTimeout(async() => {
+    this._pollingTimeout = setTimeout(async() => {
       await this._updateDiagramList();
       this.startPolling();
     }, environment.processengine.processDefListPollingIntervalInMs);

--- a/src/modules/think/diagram-list/diagram-list.ts
+++ b/src/modules/think/diagram-list/diagram-list.ts
@@ -16,7 +16,7 @@ export class DiagramList {
   private _eventAggregator: EventAggregator;
   private _router: Router;
   private _subscriptions: Array<Subscription>;
-  private timeout: NodeJS.Timer;
+  private timeout: NodeJS.Timer | number;
 
   constructor(eventAggregator: EventAggregator,
               router: Router) {
@@ -40,7 +40,7 @@ export class DiagramList {
   }
 
   public detached(): void {
-    clearTimeout(this.timeout);
+    clearTimeout(this.timeout as NodeJS.Timer);
     for (const subscription of this._subscriptions) {
       subscription.dispose();
     }


### PR DESCRIPTION
## Changes

This PR avoids an HTTP request overload what breaks the studio.

1. Use setTimeout instead of setInterval on ProcessList
2. Use setTimeout instead of setInterval on TaskList
3. Use setTimeout instead of setInterval on SolutionExplorer
4. Use setTimeout instead of setInterval on DiagramList

## Issues

Closes #1471 

PR: #1470 

## How to test the changes

> Describe how others can test your changes (not required when fixing typos, linter errors and such)
