### PR TITLE
✨Add super admin claim to ProcessEngine-Runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1204,9 +1204,9 @@
       }
     },
     "@process-engine/management_api_core": {
-      "version": "5.3.0-f297f19c-b2",
-      "resolved": "https://registry.npmjs.org/@process-engine/management_api_core/-/management_api_core-5.3.0-f297f19c-b2.tgz",
-      "integrity": "sha512-UmV7DvhUvh7NncI2UA3TWjqnpL3d10Ze5QYH5hGb2ZCEv5+2CoOq9lD9o1PevLiOqVC5pBsycnLIOoypmVZIBQ==",
+      "version": "5.3.0-371fbb08-b5",
+      "resolved": "https://registry.npmjs.org/@process-engine/management_api_core/-/management_api_core-5.3.0-371fbb08-b5.tgz",
+      "integrity": "sha512-/I5j9/0W58QVG2gBNsf1OWKPCkk0LlD3R0Rw3uV+7yxLIU2jhfy8PMpvRI4wujdr3SZhBxx4oTDbWvSsHEPybQ==",
       "requires": {
         "@process-engine/consumer_api_contracts": "^5.1.1",
         "@process-engine/correlation.contracts": "^2.0.0",
@@ -1355,9 +1355,9 @@
       }
     },
     "@process-engine/process_engine_core": {
-      "version": "12.7.0-30a51938-b6",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.7.0-30a51938-b6.tgz",
-      "integrity": "sha512-TpotquCCq23pV2eTgK2LD55rHnjh0ytkZsHsDmM5LQt5wt3BE14IVWuYsQ+xPhRQIQLTQPjLqThqJg1KoZ+Paw==",
+      "version": "12.7.0-14b34eb2-b7",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.7.0-14b34eb2-b7.tgz",
+      "integrity": "sha512-Y5vfSBVvWkc1g3+vlsM08V8JbBte4GYiXrrN/B8p9qSLrdYCDSFwNhHqpOYBlBRp+vaYJEK/xnrWSG9z5jyvdA==",
       "requires": {
         "@essential-projects/errors_ts": "^1.4.5",
         "@essential-projects/timing_contracts": "^4.0.0",
@@ -1393,9 +1393,9 @@
       }
     },
     "@process-engine/process_engine_runtime": {
-      "version": "8.1.0-85f6997f-b15",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_runtime/-/process_engine_runtime-8.1.0-85f6997f-b15.tgz",
-      "integrity": "sha512-eOzTu3AEEbVwHP3h7V/PkyX2yJXWfGaX/DSfWVZLkHVYakVSzWy1skP9gouWdTKZQaP4ZgBNuFKd8xkQYWRUUQ==",
+      "version": "8.1.0-cc0c33d7-b22",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_runtime/-/process_engine_runtime-8.1.0-cc0c33d7-b22.tgz",
+      "integrity": "sha512-db0lfkvGZ2690t3r16WZPqvElIcuEAHbPjZ2Ws9dxXI9+Ih/C6l0bBMSZXyf8I4Db4ZMcjtNQ/3rm/FTM9mzsQ==",
       "requires": {
         "@essential-projects/bootstrapper": "3.4.0",
         "@essential-projects/bootstrapper_node": "3.3.0",
@@ -1420,11 +1420,11 @@
         "@process-engine/logging.repository.file_system": "1.1.2",
         "@process-engine/logging_api_core": "1.0.3",
         "@process-engine/logging_api_http": "1.0.3",
-        "@process-engine/management_api_core": "^5.3.0-f297f19c-b2",
+        "@process-engine/management_api_core": "5.3.0-371fbb08-b5",
         "@process-engine/management_api_http": "4.3.0-7637a656-b3",
         "@process-engine/metrics.repository.file_system": "1.1.2",
         "@process-engine/metrics_api_core": "1.0.2",
-        "@process-engine/process_engine_core": "12.7.0-30a51938-b6",
+        "@process-engine/process_engine_core": "12.7.0-14b34eb2-b7",
         "@process-engine/process_model.repository.sequelize": "6.0.0-c6cf747a-b11",
         "@process-engine/process_model.service": "1.2.0-96e53e50-b7",
         "@process-engine/process_model.use_case": "1.3.0-273204ee-b7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,17 +20,17 @@
       }
     },
     "@babel/core": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.4.tgz",
-      "integrity": "sha512-lQgGX3FPRgbz2SKmhMtYgJvVzGZrmjaF4apZ2bLwofAKiSjxU0drPh4S/VasyYXwaTs+A1gvQ45BN8SQJzHsQQ==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.5.tgz",
+      "integrity": "sha512-OvjIh6aqXtlsA8ujtGKfC7LYWksYSX8yQcM8Ay3LuvVeQ63lcOKgoZWVqcpFwkd29aYU9rVx7jxhfhiEDV9MZA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/generator": "^7.4.4",
         "@babel/helpers": "^7.4.4",
-        "@babel/parser": "^7.4.4",
+        "@babel/parser": "^7.4.5",
         "@babel/template": "^7.4.4",
-        "@babel/traverse": "^7.4.4",
+        "@babel/traverse": "^7.4.5",
         "@babel/types": "^7.4.4",
         "convert-source-map": "^1.1.0",
         "debug": "^4.1.0",
@@ -206,9 +206,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.4.tgz",
-      "integrity": "sha512-5pCS4mOsL+ANsFZGdvNLybx4wtqAZJ0MJjMHxvzI3bvIsz6sQvzW8XX92EYIkiPtIvcfG3Aj+Ir5VNyjnZhP7w==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+      "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
       "dev": true
     },
     "@babel/plugin-proposal-class-properties": {
@@ -295,9 +295,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.0.1.tgz",
-          "integrity": "sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew==",
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.2.tgz",
+          "integrity": "sha512-3poRGjbu56leCtZCZCzCgQ7GcKOflDFnjWIepaPFUsM0IXUBrne10sl3aa2Bkcz3+FjRdIxBe9dAMhIJmEnQNA==",
           "dev": true
         }
       }
@@ -314,16 +314,16 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.4.tgz",
-      "integrity": "sha512-Gw6qqkw/e6AGzlyj9KnkabJX7VcubqPtkUQVAwkc0wUMldr3A/hezNB3Rc5eIvId95iSGkGIOe5hh1kMKf951A==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
+      "integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/generator": "^7.4.4",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-split-export-declaration": "^7.4.4",
-        "@babel/parser": "^7.4.4",
+        "@babel/parser": "^7.4.5",
         "@babel/types": "^7.4.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
@@ -359,44 +359,52 @@
       }
     },
     "@essential-projects/bootstrapper": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@essential-projects/bootstrapper/-/bootstrapper-3.3.2.tgz",
-      "integrity": "sha512-tsCaUCIER+M4CC5v8Jkm/fy8/7m2UJ2cQi6OzVllng6vMkrWud1Eg9Kg2LGsPuTQqe26xlODqIz3Cmm0TUrlPg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@essential-projects/bootstrapper/-/bootstrapper-3.4.0.tgz",
+      "integrity": "sha512-uFmMS0UvutstkUNgXK6/Kx+M3HhVEknGf0ks/imuxzLkcUE0Z5H/j5IbcYvV9MEJL3Vga7/GPBXCQNihbZTwew==",
       "requires": {
-        "@essential-projects/bootstrapper_contracts": "~1.3.0"
+        "@essential-projects/bootstrapper_contracts": "^1.4.0",
+        "addict-ioc": "^2.5.1"
       }
     },
     "@essential-projects/bootstrapper_contracts": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@essential-projects/bootstrapper_contracts/-/bootstrapper_contracts-1.3.2.tgz",
-      "integrity": "sha512-lwnFPPFHtM0lhkFyJPxJAabINPMtjt5Exk2gWLInETJHvZZzfzXC1kBACCq46kIEjK7+WXwdmFs1YKB5yj2znA=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@essential-projects/bootstrapper_contracts/-/bootstrapper_contracts-1.4.0.tgz",
+      "integrity": "sha512-yLJ1Q/REPa4N5P5p5bMVliI5mBF5M1KC+6p9Zbmd0813VhQm7AuopqiiuCctaZCtkvXPEaKTGEGHjSX88+A5GA=="
     },
     "@essential-projects/bootstrapper_node": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@essential-projects/bootstrapper_node/-/bootstrapper_node-3.2.7.tgz",
-      "integrity": "sha512-MiqIPXhd0VxFwuJQ6CZD9sPfFuTht9W+eKGzTIRkq8i6zrDH8/Zn/i3iV8+dw/peARtZqw/vko5PIaPFSbggYg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@essential-projects/bootstrapper_node/-/bootstrapper_node-3.3.0.tgz",
+      "integrity": "sha512-dnzCaWYp5hgleOJg7+1I8Wedo4Vlcg31XE8EgHsWA4dKI5dq72NkjyG2dnhQ9cpZ/pep10Q1f7jZ3pp4kMCY0A==",
       "requires": {
-        "@essential-projects/bootstrapper": "~3.3.0",
-        "@essential-projects/bootstrapper_contracts": "~1.3.0",
+        "@essential-projects/bootstrapper": "^3.4.0",
+        "@essential-projects/bootstrapper_contracts": "^1.4.0",
         "addict-ioc": "~2.5.1",
         "bluebird": "~3.5.2",
         "nconfetti": "~2.1.0"
       }
     },
     "@essential-projects/errors_ts": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@essential-projects/errors_ts/-/errors_ts-1.4.5.tgz",
-      "integrity": "sha512-9QyhpxcVaob1a/0kl8c0iTPcPJw4yBvtVyINs00LtUzF3S7D/cuE9AL/5FlKCx4Q4UT005t6L1aD1hSw9B5XQw=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@essential-projects/errors_ts/-/errors_ts-1.5.0.tgz",
+      "integrity": "sha512-ePb/JuGX6wVoZ98PhIZMgtrWMj7qIZHy/iuD6tR1udxfMUY1viISEgaPvTCSd9JUPETCsJyhCFnzLUod0kpPBA=="
     },
     "@essential-projects/event_aggregator": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@essential-projects/event_aggregator/-/event_aggregator-4.0.3.tgz",
-      "integrity": "sha512-y2u+Q/UjggIehxGjsK2SuhNoe29X3VFKGZq0srWE9iziLGqSDJnyArBZeMJGkbfHH1DmMazvfTkMKohUzfQJKg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@essential-projects/event_aggregator/-/event_aggregator-4.1.0.tgz",
+      "integrity": "sha512-c/M4GHhivj7ejEook7cgn6TV/T4NY7L3vXiAJdF4/0cXE2WTBNHZ7ifZ37MuflXfS9SoGI1UbVxORAj+2bFZiA==",
       "requires": {
-        "@essential-projects/errors_ts": "~1.4.2",
-        "@essential-projects/event_aggregator_contracts": "~4.0.0",
+        "@essential-projects/errors_ts": "^1.5.0",
+        "@essential-projects/event_aggregator_contracts": "^4.1.0",
         "loggerhythm": "~3.0.3",
         "node-uuid": "~1.4.8"
+      },
+      "dependencies": {
+        "@essential-projects/event_aggregator_contracts": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@essential-projects/event_aggregator_contracts/-/event_aggregator_contracts-4.1.0.tgz",
+          "integrity": "sha512-/cRthXepb56xb5rjRbeC+Xy+Uu/scExtoe5+f5ckfUKFimjycKtYgiq8wJKJp7QfwzBa1CWe6DTKoJrDX0eEuQ=="
+        }
       }
     },
     "@essential-projects/event_aggregator_contracts": {
@@ -413,27 +421,50 @@
         "@essential-projects/http_contracts": "~2.3.1",
         "bluebird": "3.5.2",
         "popsicle": "9.2.0"
+      },
+      "dependencies": {
+        "@essential-projects/errors_ts": {
+          "version": "1.4.5",
+          "resolved": "https://registry.npmjs.org/@essential-projects/errors_ts/-/errors_ts-1.4.5.tgz",
+          "integrity": "sha512-9QyhpxcVaob1a/0kl8c0iTPcPJw4yBvtVyINs00LtUzF3S7D/cuE9AL/5FlKCx4Q4UT005t6L1aD1hSw9B5XQw=="
+        },
+        "@essential-projects/http_contracts": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/@essential-projects/http_contracts/-/http_contracts-2.3.8.tgz",
+          "integrity": "sha512-T+gWdWgjJHJxbaS8/mk3gPopdtMAfcrjZxNHTDeX4OyGAj48swq8zegGqSczuRviuoP/y7eKie2zKRNNz14q4A==",
+          "requires": {
+            "@essential-projects/iam_contracts": "~3.4.0",
+            "@types/express": "^4.16.0",
+            "@types/socket.io": "^2.1.0",
+            "popsicle": "~9.2.0"
+          }
+        },
+        "@essential-projects/iam_contracts": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/@essential-projects/iam_contracts/-/iam_contracts-3.4.2.tgz",
+          "integrity": "sha512-XQt9rC545vVCpsyptqZzA2R8dKdKpoyHRnPdOifBH1kP0T9RBvcp/OOnlkrAiweyVRgIVK0RCJa3r4YgTp4nWg=="
+        }
       }
     },
     "@essential-projects/http_contracts": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@essential-projects/http_contracts/-/http_contracts-2.3.8.tgz",
-      "integrity": "sha512-T+gWdWgjJHJxbaS8/mk3gPopdtMAfcrjZxNHTDeX4OyGAj48swq8zegGqSczuRviuoP/y7eKie2zKRNNz14q4A==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@essential-projects/http_contracts/-/http_contracts-2.4.0.tgz",
+      "integrity": "sha512-G/E18fIQfR43q2Gq7Waw+dJTZd2/IOgG3yzFUkBaxgA6uUKn1s619OlAwbJDxPfQk/qsW1IkI1Bz+n5UXmHfSA==",
       "requires": {
-        "@essential-projects/iam_contracts": "~3.4.0",
+        "@essential-projects/iam_contracts": "^3.5.0",
         "@types/express": "^4.16.0",
         "@types/socket.io": "^2.1.0",
         "popsicle": "~9.2.0"
       }
     },
     "@essential-projects/http_extension": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/@essential-projects/http_extension/-/http_extension-6.5.2.tgz",
-      "integrity": "sha512-AV0xKVSXKYO+e5fKWg7/a0Hs0VZjKrcAk+WDad1ENpN0ldN2dh/bCovJzon0U+CZeJzkwx90vY5C367mJKKNvg==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@essential-projects/http_extension/-/http_extension-6.6.0.tgz",
+      "integrity": "sha512-5on/2wB4nX7D+LoBsVhYbmTkMnqR+LnglsriWf7IHRkgVQQ+SxNV7dKV+VFY2YuETHu+OKSWQzo9xtV2Zw45Mg==",
       "requires": {
-        "@essential-projects/bootstrapper_contracts": "~1.3.0",
-        "@essential-projects/errors_ts": "~1.4.0",
-        "@essential-projects/http_contracts": "~2.3.0",
+        "@essential-projects/bootstrapper_contracts": "^1.4.0",
+        "@essential-projects/errors_ts": "^1.5.0",
+        "@essential-projects/http_contracts": "^2.4.0",
         "addict-ioc": "~2.5.1",
         "body-parser": "~1.18.3",
         "compression": "~1.7.3",
@@ -448,24 +479,24 @@
       }
     },
     "@essential-projects/http_node": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@essential-projects/http_node/-/http_node-4.1.5.tgz",
-      "integrity": "sha512-dAC2O2dxHFhs0Ogt9yOE+kRdr/6yUpT2PtX59YP9axo6Hu5uQdYLFsM+bNDnsh6KpxjRdhc68aGE9eBgmKQS7w==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@essential-projects/http_node/-/http_node-4.2.0.tgz",
+      "integrity": "sha512-wzcfyLOkJMc05DvRPtBHVFs2BXz1JyFNs8moxDfy7lg+WsbxcUtwF54ArLBa7F/0IobzTsU1XEJkvptbS+ZxqA==",
       "requires": {
-        "@essential-projects/http_contracts": "~2.3.0",
+        "@essential-projects/http_contracts": "^2.4.0",
         "express": "~4.16.4",
         "socket.io": "~2.2.0"
       }
     },
     "@essential-projects/iam_contracts": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@essential-projects/iam_contracts/-/iam_contracts-3.4.2.tgz",
-      "integrity": "sha512-XQt9rC545vVCpsyptqZzA2R8dKdKpoyHRnPdOifBH1kP0T9RBvcp/OOnlkrAiweyVRgIVK0RCJa3r4YgTp4nWg=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@essential-projects/iam_contracts/-/iam_contracts-3.5.0.tgz",
+      "integrity": "sha512-FpYD5RPuTZnttR/Pr/uJ/GElmWMODd8t8KhcE6duk2QHjqPSwMkitAAtr7/D/vzBx4E7kFXW+p6gLvJ5lBO/kQ=="
     },
     "@essential-projects/sequelize_connection_manager": {
-      "version": "3.0.0-eb973ad4-b9",
-      "resolved": "https://registry.npmjs.org/@essential-projects/sequelize_connection_manager/-/sequelize_connection_manager-3.0.0-eb973ad4-b9.tgz",
-      "integrity": "sha512-8QHMizYhD7rym8rU34edmD0W60os5Rpse+UK8BTfJ30NIc9goD16fSRzLNwJjQFT9f+T0n6axS1zzBnoYYDvWg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@essential-projects/sequelize_connection_manager/-/sequelize_connection_manager-3.0.0.tgz",
+      "integrity": "sha512-LAAtqhxM7rZrEeW7UFLtd0BKUKvNJ4EkEH3kl9Jyu0ZjAGGHKav/JTKYbhpV2iJ30J/xjyWeDXd7nd0In2owvg==",
       "requires": {
         "fs-extra": "^7.0.0",
         "loggerhythm": "^3.0.3",
@@ -475,21 +506,28 @@
       }
     },
     "@essential-projects/timing": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@essential-projects/timing/-/timing-4.1.3.tgz",
-      "integrity": "sha512-MULhzrWOG7q5V6+fVh2zy9aAGksMGHutQ8y8ymTjpO4RfwtZu8Ou35sy8MSIsQVO462Um7FGgNGo1+p4fdhwwQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@essential-projects/timing/-/timing-4.2.0.tgz",
+      "integrity": "sha512-6s7X3+e46MCpPU1LBdIzC042E1G8wAL4MFt2pbiHO96vn7Mb/r3TQ3aYrm026RdwXCdZyXbt9b7lBgT3cYSIBA==",
       "requires": {
-        "@essential-projects/event_aggregator_contracts": "~4.0.0",
-        "@essential-projects/timing_contracts": "~4.0.0",
+        "@essential-projects/event_aggregator_contracts": "^4.1.0",
+        "@essential-projects/timing_contracts": "^4.1.0",
         "moment": "~2.24.0",
         "node-schedule": "~1.3.0",
         "node-uuid": "~1.4.8"
+      },
+      "dependencies": {
+        "@essential-projects/event_aggregator_contracts": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@essential-projects/event_aggregator_contracts/-/event_aggregator_contracts-4.1.0.tgz",
+          "integrity": "sha512-/cRthXepb56xb5rjRbeC+Xy+Uu/scExtoe5+f5ckfUKFimjycKtYgiq8wJKJp7QfwzBa1CWe6DTKoJrDX0eEuQ=="
+        }
       }
     },
     "@essential-projects/timing_contracts": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@essential-projects/timing_contracts/-/timing_contracts-4.0.2.tgz",
-      "integrity": "sha512-wODlMoC6I5wmW/UaRgHQuAGh638K5xtL+yijhmO/osg0WskzMnMfey1X6dWBpC3NJoJfNKSJgnnT4WMgGqiBHw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@essential-projects/timing_contracts/-/timing_contracts-4.1.0.tgz",
+      "integrity": "sha512-iBPP1sZibEJvdqj1VtTTPqEC+pkaCcHy/h6LDWfIQstUTPun1KHxHWEpOynjwjZAaPZ1MRXOHOpbb9HyOp10Yg==",
       "requires": {
         "node-schedule": "~1.3.0"
       }
@@ -591,6 +629,27 @@
         "socket.io-client": "~2.2.0"
       },
       "dependencies": {
+        "@essential-projects/errors_ts": {
+          "version": "1.4.5",
+          "resolved": "https://registry.npmjs.org/@essential-projects/errors_ts/-/errors_ts-1.4.5.tgz",
+          "integrity": "sha512-9QyhpxcVaob1a/0kl8c0iTPcPJw4yBvtVyINs00LtUzF3S7D/cuE9AL/5FlKCx4Q4UT005t6L1aD1hSw9B5XQw=="
+        },
+        "@essential-projects/http_contracts": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/@essential-projects/http_contracts/-/http_contracts-2.3.8.tgz",
+          "integrity": "sha512-T+gWdWgjJHJxbaS8/mk3gPopdtMAfcrjZxNHTDeX4OyGAj48swq8zegGqSczuRviuoP/y7eKie2zKRNNz14q4A==",
+          "requires": {
+            "@essential-projects/iam_contracts": "~3.4.0",
+            "@types/express": "^4.16.0",
+            "@types/socket.io": "^2.1.0",
+            "popsicle": "~9.2.0"
+          }
+        },
+        "@essential-projects/iam_contracts": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/@essential-projects/iam_contracts/-/iam_contracts-3.4.2.tgz",
+          "integrity": "sha512-XQt9rC545vVCpsyptqZzA2R8dKdKpoyHRnPdOifBH1kP0T9RBvcp/OOnlkrAiweyVRgIVK0RCJa3r4YgTp4nWg=="
+        },
         "@process-engine/consumer_api_contracts": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/@process-engine/consumer_api_contracts/-/consumer_api_contracts-4.0.0.tgz",
@@ -667,9 +726,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.6.tgz",
-          "integrity": "sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg=="
+          "version": "10.14.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.7.tgz",
+          "integrity": "sha512-on4MmIDgHXiuJDELPk1NFaKVUxxCFr37tm8E9yN6rAiF5Pzp/9bBfBHkoexqRiY+hk/Z04EJU9kKEb59YqJ82A=="
         }
       }
     },
@@ -716,9 +775,9 @@
       }
     },
     "@process-engine/correlation.service": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@process-engine/correlation.service/-/correlation.service-1.2.0.tgz",
-      "integrity": "sha512-oPZyKaYW0nrsbiMtotgKvUNsZh8Wxg58acz1CtdWhptV7mIPQp2PVIpP+BW2NXEY+alh1gpEND+3FEE+qE5VWQ==",
+      "version": "1.3.0-904ccafc-b7",
+      "resolved": "https://registry.npmjs.org/@process-engine/correlation.service/-/correlation.service-1.3.0-904ccafc-b7.tgz",
+      "integrity": "sha512-Hm03uTcQ78wVpiMq3zLHyfBipL2oQD0HpDOB4qJYGVHOW9AibThKp/ftw4Ua4E6Oem322rMnue9/sGTYSiAOhw==",
       "requires": {
         "@essential-projects/errors_ts": "^1.4.3",
         "@process-engine/correlation.contracts": "^2.0.0",
@@ -726,13 +785,13 @@
       }
     },
     "@process-engine/correlations.repository.sequelize": {
-      "version": "6.0.0-22b40968-b7",
-      "resolved": "https://registry.npmjs.org/@process-engine/correlations.repository.sequelize/-/correlations.repository.sequelize-6.0.0-22b40968-b7.tgz",
-      "integrity": "sha512-uE2/Re3PcDKn/b/2wquoAvboPMs6ybnzt8e1pAbe2p0mOjbY4owBwFdntrzCodHWo35cNTGVL9LvGqf6xH1Plw==",
+      "version": "6.0.0-b7df7bb2-b8",
+      "resolved": "https://registry.npmjs.org/@process-engine/correlations.repository.sequelize/-/correlations.repository.sequelize-6.0.0-b7df7bb2-b8.tgz",
+      "integrity": "sha512-iaEbqPzFJYZ+ce6DE1cwEZKudr6gdk+j0beEPEtb+/3/mblFlvSDn8e8h6rcf/CXpYYS3dwA0KwoNC1YP/JVHA==",
       "requires": {
         "@essential-projects/bootstrapper_contracts": "^1.3.0",
         "@essential-projects/errors_ts": "^1.4.5",
-        "@essential-projects/sequelize_connection_manager": "3.0.0-eb973ad4-b9",
+        "@essential-projects/sequelize_connection_manager": "^3.0.0",
         "@process-engine/correlation.contracts": "^2.0.0",
         "@types/clone": "^0.1.30",
         "clone": "^2.1.2",
@@ -820,20 +879,20 @@
           }
         },
         "@types/node": {
-          "version": "10.14.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.6.tgz",
-          "integrity": "sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg=="
+          "version": "10.14.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.7.tgz",
+          "integrity": "sha512-on4MmIDgHXiuJDELPk1NFaKVUxxCFr37tm8E9yN6rAiF5Pzp/9bBfBHkoexqRiY+hk/Z04EJU9kKEb59YqJ82A=="
         }
       }
     },
     "@process-engine/external_task.repository.sequelize": {
-      "version": "3.0.0-95f64396-b7",
-      "resolved": "https://registry.npmjs.org/@process-engine/external_task.repository.sequelize/-/external_task.repository.sequelize-3.0.0-95f64396-b7.tgz",
-      "integrity": "sha512-VVhIV2QO38yvJrQtlP9rexW3Mb+YbGpX64C8ufBmidtazUQXITkNL6bFzkDONdrnFtPsLM9Q28Rb/OUrYR8/YA==",
+      "version": "3.0.0-28c54160-b8",
+      "resolved": "https://registry.npmjs.org/@process-engine/external_task.repository.sequelize/-/external_task.repository.sequelize-3.0.0-28c54160-b8.tgz",
+      "integrity": "sha512-YYS0gpIe2hnm+pOAn53mYRHei+8AfcFpSCeJ7sl9k90h77rvSrK0ZjxmgWheb4fHKUZ+mHOAXBQWXpYVf/ONfg==",
       "requires": {
         "@essential-projects/bootstrapper_contracts": "^1.3.0",
         "@essential-projects/errors_ts": "^1.4.5",
-        "@essential-projects/sequelize_connection_manager": "3.0.0-eb973ad4-b9",
+        "@essential-projects/sequelize_connection_manager": "^3.0.0",
         "@process-engine/external_task_api_contracts": "^1.0.0",
         "node-uuid": "^1.4.8",
         "reflect-metadata": "^0.1.13",
@@ -853,9 +912,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.6.tgz",
-          "integrity": "sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg=="
+          "version": "10.14.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.7.tgz",
+          "integrity": "sha512-on4MmIDgHXiuJDELPk1NFaKVUxxCFr37tm8E9yN6rAiF5Pzp/9bBfBHkoexqRiY+hk/Z04EJU9kKEb59YqJ82A=="
         }
       }
     },
@@ -906,27 +965,47 @@
       }
     },
     "@process-engine/flow_node_instance.repository.sequelize": {
-      "version": "10.0.0-47cdb2c5-b6",
-      "resolved": "https://registry.npmjs.org/@process-engine/flow_node_instance.repository.sequelize/-/flow_node_instance.repository.sequelize-10.0.0-47cdb2c5-b6.tgz",
-      "integrity": "sha512-aRlkBkokdXNiOB6O78YTb8BgLuDU3KzVScoTJ4nb0CJqmRs5YTyLAyFVq3vkNalR6GQZbq0D9CBXOmgMcvpD2g==",
+      "version": "10.0.0-cd979ac0-b8",
+      "resolved": "https://registry.npmjs.org/@process-engine/flow_node_instance.repository.sequelize/-/flow_node_instance.repository.sequelize-10.0.0-cd979ac0-b8.tgz",
+      "integrity": "sha512-1WDj6LLODb4Bfl9U9rZt1u6dGIR85bXclIN+zmZoW0im7lp0tDet+n+X2BxYevliqWTnYbfcCBMCa2mCBw0kYQ==",
       "requires": {
-        "@essential-projects/bootstrapper_contracts": "^1.3.0",
+        "@essential-projects/bootstrapper_contracts": "^1.3.2",
         "@essential-projects/errors_ts": "^1.4.5",
-        "@essential-projects/sequelize_connection_manager": "3.0.0-eb973ad4-b9",
-        "@process-engine/flow_node_instance.contracts": "^1.0.0",
+        "@essential-projects/sequelize_connection_manager": "^3.0.0",
+        "@process-engine/flow_node_instance.contracts": "1.2.0-9537af2d-b6",
         "@types/clone": "^0.1.30",
         "clone": "^2.1.2",
         "loggerhythm": "^3.0.3",
         "sequelize": "^5.8.0",
         "sequelize-typescript": "^1.0.0-beta.3"
+      },
+      "dependencies": {
+        "@process-engine/flow_node_instance.contracts": {
+          "version": "1.2.0-9537af2d-b6",
+          "resolved": "https://registry.npmjs.org/@process-engine/flow_node_instance.contracts/-/flow_node_instance.contracts-1.2.0-9537af2d-b6.tgz",
+          "integrity": "sha512-9VNV/Zb9HpnJY2WZws5Ydqdwj4Vtky921pfeC675EZ9Uzvb9MGfdh6pgwk9uRc3MuDO/vSNaMRpgsWCLkH0kbA==",
+          "requires": {
+            "@essential-projects/iam_contracts": "^3.4.2"
+          }
+        }
       }
     },
     "@process-engine/flow_node_instance.service": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@process-engine/flow_node_instance.service/-/flow_node_instance.service-1.0.1.tgz",
-      "integrity": "sha512-ut8QHAI+odYxSM7SUZ4B8Iw9U68EN/ku23WzWlZ4u1YyEh/Is+OS2PiJtlJ7aMHoNqjRRe5VMsYnSmU3mXjkiQ==",
+      "version": "1.0.1-72a8a688-b7",
+      "resolved": "https://registry.npmjs.org/@process-engine/flow_node_instance.service/-/flow_node_instance.service-1.0.1-72a8a688-b7.tgz",
+      "integrity": "sha512-W9HRBH9Opxc4damu+fqx6nmASm6ePqt+V4C3FmHsHGshAoW4UQ88hkvpLuClBOr+oTizq+8v6VN0iy2wVh1GNw==",
       "requires": {
-        "@process-engine/flow_node_instance.contracts": "^1.0.0"
+        "@process-engine/flow_node_instance.contracts": "1.2.0-9537af2d-b6"
+      },
+      "dependencies": {
+        "@process-engine/flow_node_instance.contracts": {
+          "version": "1.2.0-9537af2d-b6",
+          "resolved": "https://registry.npmjs.org/@process-engine/flow_node_instance.contracts/-/flow_node_instance.contracts-1.2.0-9537af2d-b6.tgz",
+          "integrity": "sha512-9VNV/Zb9HpnJY2WZws5Ydqdwj4Vtky921pfeC675EZ9Uzvb9MGfdh6pgwk9uRc3MuDO/vSNaMRpgsWCLkH0kbA==",
+          "requires": {
+            "@essential-projects/iam_contracts": "^3.4.2"
+          }
+        }
       }
     },
     "@process-engine/iam": {
@@ -946,6 +1025,13 @@
       "integrity": "sha512-+pTWEa8npPSmTquf8y31dYhaL9IQcK/rfEEVh9ry5t9z+nnoX03Y3InkiUhYzScW78S121otiDAsT5IeDflCqA==",
       "requires": {
         "@essential-projects/iam_contracts": "~3.4.0"
+      },
+      "dependencies": {
+        "@essential-projects/iam_contracts": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/@essential-projects/iam_contracts/-/iam_contracts-3.4.2.tgz",
+          "integrity": "sha512-XQt9rC545vVCpsyptqZzA2R8dKdKpoyHRnPdOifBH1kP0T9RBvcp/OOnlkrAiweyVRgIVK0RCJa3r4YgTp4nWg=="
+        }
       }
     },
     "@process-engine/kpi_api_core": {
@@ -970,6 +1056,44 @@
         "@process-engine/kpi_api_contracts": "~1.2.0",
         "async-middleware": "~1.2.1",
         "loggerhythm": "~3.0.3"
+      },
+      "dependencies": {
+        "@essential-projects/bootstrapper_contracts": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/@essential-projects/bootstrapper_contracts/-/bootstrapper_contracts-1.3.2.tgz",
+          "integrity": "sha512-lwnFPPFHtM0lhkFyJPxJAabINPMtjt5Exk2gWLInETJHvZZzfzXC1kBACCq46kIEjK7+WXwdmFs1YKB5yj2znA=="
+        },
+        "@essential-projects/errors_ts": {
+          "version": "1.4.5",
+          "resolved": "https://registry.npmjs.org/@essential-projects/errors_ts/-/errors_ts-1.4.5.tgz",
+          "integrity": "sha512-9QyhpxcVaob1a/0kl8c0iTPcPJw4yBvtVyINs00LtUzF3S7D/cuE9AL/5FlKCx4Q4UT005t6L1aD1hSw9B5XQw=="
+        },
+        "@essential-projects/http_contracts": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/@essential-projects/http_contracts/-/http_contracts-2.3.8.tgz",
+          "integrity": "sha512-T+gWdWgjJHJxbaS8/mk3gPopdtMAfcrjZxNHTDeX4OyGAj48swq8zegGqSczuRviuoP/y7eKie2zKRNNz14q4A==",
+          "requires": {
+            "@essential-projects/iam_contracts": "~3.4.0",
+            "@types/express": "^4.16.0",
+            "@types/socket.io": "^2.1.0",
+            "popsicle": "~9.2.0"
+          }
+        },
+        "@essential-projects/http_node": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/@essential-projects/http_node/-/http_node-4.1.5.tgz",
+          "integrity": "sha512-dAC2O2dxHFhs0Ogt9yOE+kRdr/6yUpT2PtX59YP9axo6Hu5uQdYLFsM+bNDnsh6KpxjRdhc68aGE9eBgmKQS7w==",
+          "requires": {
+            "@essential-projects/http_contracts": "~2.3.0",
+            "express": "~4.16.4",
+            "socket.io": "~2.2.0"
+          }
+        },
+        "@essential-projects/iam_contracts": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/@essential-projects/iam_contracts/-/iam_contracts-3.4.2.tgz",
+          "integrity": "sha512-XQt9rC545vVCpsyptqZzA2R8dKdKpoyHRnPdOifBH1kP0T9RBvcp/OOnlkrAiweyVRgIVK0RCJa3r4YgTp4nWg=="
+        }
       }
     },
     "@process-engine/logging.repository.file_system": {
@@ -992,9 +1116,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.6.tgz",
-          "integrity": "sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg=="
+          "version": "10.14.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.7.tgz",
+          "integrity": "sha512-on4MmIDgHXiuJDELPk1NFaKVUxxCFr37tm8E9yN6rAiF5Pzp/9bBfBHkoexqRiY+hk/Z04EJU9kKEb59YqJ82A=="
         }
       }
     },
@@ -1073,33 +1197,38 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.6.tgz",
-          "integrity": "sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg=="
+          "version": "10.14.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.7.tgz",
+          "integrity": "sha512-on4MmIDgHXiuJDELPk1NFaKVUxxCFr37tm8E9yN6rAiF5Pzp/9bBfBHkoexqRiY+hk/Z04EJU9kKEb59YqJ82A=="
         }
       }
     },
     "@process-engine/management_api_core": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@process-engine/management_api_core/-/management_api_core-5.3.0.tgz",
-      "integrity": "sha512-/6A21CmLs273jmRgcVq0KBQYcbfhbOFdAJc9wnipjBUvJx7RD1FYbWXAsNMaLKgL3m2PEziiMEu9L+55P0cOdQ==",
+      "version": "5.3.0-f297f19c-b2",
+      "resolved": "https://registry.npmjs.org/@process-engine/management_api_core/-/management_api_core-5.3.0-f297f19c-b2.tgz",
+      "integrity": "sha512-UmV7DvhUvh7NncI2UA3TWjqnpL3d10Ze5QYH5hGb2ZCEv5+2CoOq9lD9o1PevLiOqVC5pBsycnLIOoypmVZIBQ==",
       "requires": {
-        "@process-engine/consumer_api_contracts": "^5.1.0",
+        "@process-engine/consumer_api_contracts": "^5.1.1",
         "@process-engine/correlation.contracts": "^2.0.0",
         "@process-engine/deployment_api_contracts": "^1.0.0",
-        "@process-engine/flow_node_instance.contracts": "^1.1.0",
-        "@process-engine/kpi_api_contracts": "^1.2.0",
-        "@process-engine/logging_api_contracts": "^1.0.0",
-        "@process-engine/management_api_contracts": "^7.0.0",
-        "@process-engine/process_engine_contracts": "^43.0.0",
-        "@process-engine/process_model.contracts": "^2.1.0",
-        "@process-engine/token_history_api_contracts": "^1.4.0",
+        "@process-engine/flow_node_instance.contracts": "1.2.0-9537af2d-b6",
+        "@process-engine/kpi_api_contracts": "^1.2.4",
+        "@process-engine/logging_api_contracts": "^1.0.3",
+        "@process-engine/management_api_contracts": "7.0.0-589434c1-b6",
+        "@process-engine/process_engine_contracts": "^43.1.0",
+        "@process-engine/process_model.contracts": "^2.2.0",
+        "@process-engine/token_history_api_contracts": "1.4.2-57371b44-b6",
         "bluebird": "~3.5.2",
         "bluebird-global": "~1.0.1",
         "clone": "~2.1.2",
         "moment": "~2.24.0"
       },
       "dependencies": {
+        "@essential-projects/iam_contracts": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/@essential-projects/iam_contracts/-/iam_contracts-3.4.2.tgz",
+          "integrity": "sha512-XQt9rC545vVCpsyptqZzA2R8dKdKpoyHRnPdOifBH1kP0T9RBvcp/OOnlkrAiweyVRgIVK0RCJa3r4YgTp4nWg=="
+        },
         "@process-engine/deployment_api_contracts": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/@process-engine/deployment_api_contracts/-/deployment_api_contracts-1.0.5.tgz",
@@ -1107,23 +1236,65 @@
           "requires": {
             "@essential-projects/iam_contracts": "~3.4.0"
           }
+        },
+        "@process-engine/flow_node_instance.contracts": {
+          "version": "1.2.0-9537af2d-b6",
+          "resolved": "https://registry.npmjs.org/@process-engine/flow_node_instance.contracts/-/flow_node_instance.contracts-1.2.0-9537af2d-b6.tgz",
+          "integrity": "sha512-9VNV/Zb9HpnJY2WZws5Ydqdwj4Vtky921pfeC675EZ9Uzvb9MGfdh6pgwk9uRc3MuDO/vSNaMRpgsWCLkH0kbA==",
+          "requires": {
+            "@essential-projects/iam_contracts": "^3.4.2"
+          }
+        },
+        "@process-engine/management_api_contracts": {
+          "version": "7.0.0-589434c1-b6",
+          "resolved": "https://registry.npmjs.org/@process-engine/management_api_contracts/-/management_api_contracts-7.0.0-589434c1-b6.tgz",
+          "integrity": "sha512-j0mbjVXjdMuL94OvuIrryWkj0c2pZG6+ax45DMGPkPH11YWDndDhVkHTMOmc9pENes0vxKQSfpqHxQKPWw2m9g==",
+          "requires": {
+            "@essential-projects/event_aggregator_contracts": "^4.0.2",
+            "@essential-projects/iam_contracts": "^3.4.2",
+            "@types/express": "^4.16.1",
+            "@types/node": "^10.12.2"
+          }
+        },
+        "@types/node": {
+          "version": "10.14.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.7.tgz",
+          "integrity": "sha512-on4MmIDgHXiuJDELPk1NFaKVUxxCFr37tm8E9yN6rAiF5Pzp/9bBfBHkoexqRiY+hk/Z04EJU9kKEb59YqJ82A=="
         }
       }
     },
     "@process-engine/management_api_http": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@process-engine/management_api_http/-/management_api_http-4.3.0.tgz",
-      "integrity": "sha512-pLiM5GmmNaTHjn1ina5M+4QuNf0Pj+xDzD9L26eMf2M04+YDupwpaFpT0Pgn0Mx5j5+MqL7V2FqYfd3sJBcRbw==",
+      "version": "4.3.0-7637a656-b3",
+      "resolved": "https://registry.npmjs.org/@process-engine/management_api_http/-/management_api_http-4.3.0-7637a656-b3.tgz",
+      "integrity": "sha512-6wABjiN7T7q1A93ZftulfddF+L952dNSZxAUYzqPl6TTDt/qYK+CndGg+3/Zc/oepu60OINnLCo4dmebie3V4Q==",
       "requires": {
-        "@essential-projects/bootstrapper_contracts": "^1.2.0",
-        "@essential-projects/errors_ts": "^1.4.0",
-        "@essential-projects/event_aggregator_contracts": "^4.0.0",
-        "@essential-projects/http_contracts": "^2.3.0",
-        "@essential-projects/http_node": "^4.1.0",
-        "@essential-projects/iam_contracts": "^3.4.0",
-        "@process-engine/management_api_contracts": "^7.0.0",
+        "@essential-projects/bootstrapper_contracts": "^1.3.2",
+        "@essential-projects/errors_ts": "^1.4.2",
+        "@essential-projects/event_aggregator_contracts": "^4.0.2",
+        "@essential-projects/http_contracts": "^2.3.8",
+        "@essential-projects/http_node": "^4.1.5",
+        "@essential-projects/iam_contracts": "^3.4.2",
+        "@process-engine/management_api_contracts": "7.0.0-589434c1-b6",
         "async-middleware": "^1.2.1",
         "socket.io": "^2.2.0"
+      },
+      "dependencies": {
+        "@process-engine/management_api_contracts": {
+          "version": "7.0.0-589434c1-b6",
+          "resolved": "https://registry.npmjs.org/@process-engine/management_api_contracts/-/management_api_contracts-7.0.0-589434c1-b6.tgz",
+          "integrity": "sha512-j0mbjVXjdMuL94OvuIrryWkj0c2pZG6+ax45DMGPkPH11YWDndDhVkHTMOmc9pENes0vxKQSfpqHxQKPWw2m9g==",
+          "requires": {
+            "@essential-projects/event_aggregator_contracts": "^4.0.2",
+            "@essential-projects/iam_contracts": "^3.4.2",
+            "@types/express": "^4.16.1",
+            "@types/node": "^10.12.2"
+          }
+        },
+        "@types/node": {
+          "version": "10.14.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.7.tgz",
+          "integrity": "sha512-on4MmIDgHXiuJDELPk1NFaKVUxxCFr37tm8E9yN6rAiF5Pzp/9bBfBHkoexqRiY+hk/Z04EJU9kKEb59YqJ82A=="
+        }
       }
     },
     "@process-engine/metrics.repository.file_system": {
@@ -1146,10 +1317,15 @@
         "moment": "~2.24.0"
       },
       "dependencies": {
+        "@essential-projects/iam_contracts": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/@essential-projects/iam_contracts/-/iam_contracts-3.4.2.tgz",
+          "integrity": "sha512-XQt9rC545vVCpsyptqZzA2R8dKdKpoyHRnPdOifBH1kP0T9RBvcp/OOnlkrAiweyVRgIVK0RCJa3r4YgTp4nWg=="
+        },
         "@types/node": {
-          "version": "10.14.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.6.tgz",
-          "integrity": "sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg=="
+          "version": "10.14.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.7.tgz",
+          "integrity": "sha512-on4MmIDgHXiuJDELPk1NFaKVUxxCFr37tm8E9yN6rAiF5Pzp/9bBfBHkoexqRiY+hk/Z04EJU9kKEb59YqJ82A=="
         }
       }
     },
@@ -1169,12 +1345,19 @@
       "requires": {
         "@essential-projects/event_aggregator_contracts": "~4.0.0",
         "@essential-projects/iam_contracts": "~3.4.0"
+      },
+      "dependencies": {
+        "@essential-projects/iam_contracts": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/@essential-projects/iam_contracts/-/iam_contracts-3.4.2.tgz",
+          "integrity": "sha512-XQt9rC545vVCpsyptqZzA2R8dKdKpoyHRnPdOifBH1kP0T9RBvcp/OOnlkrAiweyVRgIVK0RCJa3r4YgTp4nWg=="
+        }
       }
     },
     "@process-engine/process_engine_core": {
-      "version": "12.7.0-0fd5dccd-b4",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.7.0-0fd5dccd-b4.tgz",
-      "integrity": "sha512-h3Mukor8SJhwWIHiuWT+vclcdqh96QpbTzU5DOTR9asRrRwt+VG6h2iLmjPy8Jxq+dChdHNJ3c5Unk/T8IpTQw==",
+      "version": "12.7.0-30a51938-b6",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.7.0-30a51938-b6.tgz",
+      "integrity": "sha512-TpotquCCq23pV2eTgK2LD55rHnjh0ytkZsHsDmM5LQt5wt3BE14IVWuYsQ+xPhRQIQLTQPjLqThqJg1KoZ+Paw==",
       "requires": {
         "@essential-projects/errors_ts": "^1.4.5",
         "@essential-projects/timing_contracts": "^4.0.0",
@@ -1183,7 +1366,7 @@
         "@process-engine/flow_node_instance.contracts": "^1.2.0",
         "@process-engine/logging_api_contracts": "^1.0.0",
         "@process-engine/metrics_api_contracts": "^1.0.0",
-        "@process-engine/process_engine_contracts": "43.2.0-c686b77c-b3",
+        "@process-engine/process_engine_contracts": "43.2.0-9ad3ed27-b4",
         "@process-engine/process_model.contracts": "^2.3.0",
         "@types/clone": "^0.1.30",
         "@types/socket.io": "^2.1.2",
@@ -1199,55 +1382,54 @@
       },
       "dependencies": {
         "@process-engine/process_engine_contracts": {
-          "version": "43.2.0-c686b77c-b3",
-          "resolved": "https://registry.npmjs.org/@process-engine/process_engine_contracts/-/process_engine_contracts-43.2.0-c686b77c-b3.tgz",
-          "integrity": "sha512-7cmXayexzJMRnBYQJMd+idmaL+Yd8o9iPYQPcDEB1eUTb6eHF9p00JXUBZcrszLM8AlHqW3UF1b+P3b2nynINA==",
+          "version": "43.2.0-9ad3ed27-b4",
+          "resolved": "https://registry.npmjs.org/@process-engine/process_engine_contracts/-/process_engine_contracts-43.2.0-9ad3ed27-b4.tgz",
+          "integrity": "sha512-EzyckFIQoJFni2tAOQa+TwyZjjjwWii2NHnhMkC/J2y9CSxUzt35gk0AI0FVKq5xMkx0o/2WuolA3WeNzl+mRQ==",
           "requires": {
-            "@essential-projects/event_aggregator_contracts": "~4.0.0",
+            "@essential-projects/event_aggregator_contracts": "^4.0.0",
             "@essential-projects/iam_contracts": "^3.4.2"
           }
         }
       }
     },
     "@process-engine/process_engine_runtime": {
-      "version": "8.1.0-17fd02c0-b14",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_runtime/-/process_engine_runtime-8.1.0-17fd02c0-b14.tgz",
-      "integrity": "sha512-yxFNBlsuIUiuw7yU8tMOcZ8TuCUgqmxGZg3D8IUX9vszi9E+MzsQu29tvTHHPoOXEER2jZWHRV48vEppcE627g==",
+      "version": "8.1.0-85f6997f-b15",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_runtime/-/process_engine_runtime-8.1.0-85f6997f-b15.tgz",
+      "integrity": "sha512-eOzTu3AEEbVwHP3h7V/PkyX2yJXWfGaX/DSfWVZLkHVYakVSzWy1skP9gouWdTKZQaP4ZgBNuFKd8xkQYWRUUQ==",
       "requires": {
-        "@essential-projects/bootstrapper": "3.3.2",
-        "@essential-projects/bootstrapper_node": "3.2.7",
-        "@essential-projects/event_aggregator": "4.0.3",
-        "@essential-projects/http": "2.3.1",
-        "@essential-projects/http_extension": "6.5.2",
-        "@essential-projects/sequelize_connection_manager": "3.0.0-eb973ad4-b9",
-        "@essential-projects/timing": "4.1.3",
+        "@essential-projects/bootstrapper": "3.4.0",
+        "@essential-projects/bootstrapper_node": "3.3.0",
+        "@essential-projects/event_aggregator": "4.1.0",
+        "@essential-projects/http": "2.4.0",
+        "@essential-projects/http_extension": "6.6.0",
+        "@essential-projects/timing": "4.2.0",
         "@process-engine/consumer_api_core": "5.2.0",
         "@process-engine/consumer_api_http": "4.1.0",
-        "@process-engine/correlation.service": "1.2.0",
-        "@process-engine/correlations.repository.sequelize": "6.0.0-22b40968-b7",
+        "@process-engine/correlation.service": "1.3.0-904ccafc-b7",
+        "@process-engine/correlations.repository.sequelize": "6.0.0-b7df7bb2-b8",
         "@process-engine/deployment_api_core": "2.2.0",
         "@process-engine/deployment_api_http": "1.2.0",
-        "@process-engine/external_task.repository.sequelize": "3.0.0-95f64396-b7",
+        "@process-engine/external_task.repository.sequelize": "3.0.0-28c54160-b8",
         "@process-engine/external_task_api_core": "1.1.4",
         "@process-engine/external_task_api_http": "1.1.1",
-        "@process-engine/flow_node_instance.repository.sequelize": "10.0.0-47cdb2c5-b6",
-        "@process-engine/flow_node_instance.service": "1.0.1",
+        "@process-engine/flow_node_instance.repository.sequelize": "10.0.0-cd979ac0-b8",
+        "@process-engine/flow_node_instance.service": "1.0.1-72a8a688-b7",
         "@process-engine/iam": "1.5.0-05fe78da-b4",
         "@process-engine/kpi_api_core": "2.0.1",
         "@process-engine/kpi_api_http": "1.3.1",
         "@process-engine/logging.repository.file_system": "1.1.2",
         "@process-engine/logging_api_core": "1.0.3",
         "@process-engine/logging_api_http": "1.0.3",
-        "@process-engine/management_api_core": "5.3.0",
-        "@process-engine/management_api_http": "4.3.0",
+        "@process-engine/management_api_core": "^5.3.0-f297f19c-b2",
+        "@process-engine/management_api_http": "4.3.0-7637a656-b3",
         "@process-engine/metrics.repository.file_system": "1.1.2",
         "@process-engine/metrics_api_core": "1.0.2",
-        "@process-engine/process_engine_core": "12.7.0-0fd5dccd-b4",
-        "@process-engine/process_model.repository.sequelize": "6.0.0-3eec0ab5-b10",
-        "@process-engine/process_model.service": "1.1.0",
-        "@process-engine/process_model.use_case": "1.2.0",
-        "@process-engine/token_history_api_core": "2.0.1",
-        "@process-engine/token_history_api_http": "1.4.2",
+        "@process-engine/process_engine_core": "12.7.0-30a51938-b6",
+        "@process-engine/process_model.repository.sequelize": "6.0.0-c6cf747a-b11",
+        "@process-engine/process_model.service": "1.2.0-96e53e50-b7",
+        "@process-engine/process_model.use_case": "1.3.0-273204ee-b7",
+        "@process-engine/token_history_api_core": "2.0.1-5d662331-b6",
+        "@process-engine/token_history_api_http": "1.4.2-791afa09-b7",
         "@types/socket.io": "^2.1.0",
         "@types/socket.io-client": "^1.4.32",
         "addict-ioc": "~2.5.3",
@@ -1272,12 +1454,12 @@
       },
       "dependencies": {
         "@essential-projects/http": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/@essential-projects/http/-/http-2.3.1.tgz",
-          "integrity": "sha512-B1a0n95QeQTZSvsuUm/+3OVcO7JTqBrcuqYUZn7CWK2+ksF+ur7P2cYQuerEFRS5Se40Knl330y+rzs8341gvg==",
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/@essential-projects/http/-/http-2.4.0.tgz",
+          "integrity": "sha512-UMMsLB3xoN349UyluJ/n6xw0hI7l1TnrdZHPoGsik0i0kkOBPhwELffdP0MNPyOEBs0WBtufJEylhb7yi+LsPw==",
           "requires": {
-            "@essential-projects/errors_ts": "~1.4.0",
-            "@essential-projects/http_contracts": "~2.3.1",
+            "@essential-projects/errors_ts": "^1.5.0",
+            "@essential-projects/http_contracts": "^2.4.0",
             "bluebird": "~3.5.2",
             "popsicle": "~9.2.0"
           }
@@ -1324,13 +1506,13 @@
       }
     },
     "@process-engine/process_model.repository.sequelize": {
-      "version": "6.0.0-3eec0ab5-b10",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_model.repository.sequelize/-/process_model.repository.sequelize-6.0.0-3eec0ab5-b10.tgz",
-      "integrity": "sha512-APhLU8d5TY9JCzszRI2tEYNSdc1zD2O8xlLNtvGTmQ9xJ84OZwPVk2deNzSVupfmbRFaOKlbtow6sLCxRQOWwQ==",
+      "version": "6.0.0-c6cf747a-b11",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_model.repository.sequelize/-/process_model.repository.sequelize-6.0.0-c6cf747a-b11.tgz",
+      "integrity": "sha512-ZmFP5DAeVmC9erdwh35nxMAsruGhHB68Kjn2cll9Idd8gSmDdU3jEYpcQEJSPPHFbaP/h7Cp8D3XJ6z5wkgiUQ==",
       "requires": {
         "@essential-projects/bootstrapper_contracts": "^1.3.0",
         "@essential-projects/errors_ts": "^1.4.0",
-        "@essential-projects/sequelize_connection_manager": "3.0.0-eb973ad4-b9",
+        "@essential-projects/sequelize_connection_manager": "^3.0.0",
         "@process-engine/process_model.contracts": "^2.0.0",
         "bcryptjs": "^2.4.3",
         "loggerhythm": "^3.0.3",
@@ -1339,28 +1521,28 @@
       }
     },
     "@process-engine/process_model.service": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_model.service/-/process_model.service-1.1.0.tgz",
-      "integrity": "sha512-0F10vnMPwi2KZzvRp9iXyL5x1OosOU1K+3FujpwQakklyBacxplkbjGL5IXHb3pAivt+2q4h/mBF8NP0D/B1Ag==",
+      "version": "1.2.0-96e53e50-b7",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_model.service/-/process_model.service-1.2.0-96e53e50-b7.tgz",
+      "integrity": "sha512-PIsIpOJ1TgS6B7MnTjFODqCtTOHN49Qo43AckOR/kNeuZ7xg1pTfaa7w8004yuoO16I2VDSPHoV+PWMlogCmpQ==",
       "requires": {
         "@essential-projects/errors_ts": "^1.4.4",
         "@process-engine/process_model.contracts": "^2.0.0",
         "bluebird-global": "^1.0.1",
+        "clone": "^2.1.2",
         "loggerhythm": "^3.0.3"
       }
     },
     "@process-engine/process_model.use_case": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_model.use_case/-/process_model.use_case-1.2.0.tgz",
-      "integrity": "sha512-RV1Dei3XhFRoyYW8vx0gattxhD7JFPHcgW/EyktHaJfvj+KY2/gMTGFR9QTTaJFAUB6P8jA/OQFbPcCLhIMSgg==",
+      "version": "1.3.0-273204ee-b7",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_model.use_case/-/process_model.use_case-1.3.0-273204ee-b7.tgz",
+      "integrity": "sha512-FRAmGGpdhoizi1Xw27BiGVQC5IaFzmGPx9/ziZeVk3k49Emy9eUdtrJEWHoKl84lmszhWzcZFfvI0fIJtKbsOg==",
       "requires": {
         "@essential-projects/errors_ts": "^1.4.3",
         "@essential-projects/iam_contracts": "^3.4.1",
         "@process-engine/correlation.contracts": "^2.0.0",
         "@process-engine/external_task_api_contracts": "^1.0.0",
         "@process-engine/flow_node_instance.contracts": "^1.0.0",
-        "@process-engine/process_model.contracts": "^2.0.0",
-        "bluebird-global": "^1.0.1"
+        "@process-engine/process_model.contracts": "^2.0.0"
       }
     },
     "@process-engine/solutionexplorer.contracts": {
@@ -1411,6 +1593,29 @@
             "@essential-projects/http_contracts": "~2.3.0",
             "@process-engine/management_api_contracts": "0.15.0",
             "socket.io-client": "2.1.1"
+          },
+          "dependencies": {
+            "@essential-projects/errors_ts": {
+              "version": "1.4.5",
+              "resolved": "https://registry.npmjs.org/@essential-projects/errors_ts/-/errors_ts-1.4.5.tgz",
+              "integrity": "sha512-9QyhpxcVaob1a/0kl8c0iTPcPJw4yBvtVyINs00LtUzF3S7D/cuE9AL/5FlKCx4Q4UT005t6L1aD1hSw9B5XQw=="
+            },
+            "@essential-projects/http_contracts": {
+              "version": "2.3.8",
+              "resolved": "https://registry.npmjs.org/@essential-projects/http_contracts/-/http_contracts-2.3.8.tgz",
+              "integrity": "sha512-T+gWdWgjJHJxbaS8/mk3gPopdtMAfcrjZxNHTDeX4OyGAj48swq8zegGqSczuRviuoP/y7eKie2zKRNNz14q4A==",
+              "requires": {
+                "@essential-projects/iam_contracts": "~3.4.0",
+                "@types/express": "^4.16.0",
+                "@types/socket.io": "^2.1.0",
+                "popsicle": "~9.2.0"
+              }
+            },
+            "@essential-projects/iam_contracts": {
+              "version": "3.4.2",
+              "resolved": "https://registry.npmjs.org/@essential-projects/iam_contracts/-/iam_contracts-3.4.2.tgz",
+              "integrity": "sha512-XQt9rC545vVCpsyptqZzA2R8dKdKpoyHRnPdOifBH1kP0T9RBvcp/OOnlkrAiweyVRgIVK0RCJa3r4YgTp4nWg=="
+            }
           }
         },
         "@process-engine/management_api_contracts": {
@@ -1466,40 +1671,50 @@
       }
     },
     "@process-engine/token_history_api_contracts": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@process-engine/token_history_api_contracts/-/token_history_api_contracts-1.4.2.tgz",
-      "integrity": "sha512-YsYFXHlqigAPyloaqS5lRbIP9aSUwVF4Mlf/xgndTy6eNS6o1/5PjMfcPxGbLqhU+nefIEqEkUrjmit+282BAQ==",
+      "version": "1.4.2-57371b44-b6",
+      "resolved": "https://registry.npmjs.org/@process-engine/token_history_api_contracts/-/token_history_api_contracts-1.4.2-57371b44-b6.tgz",
+      "integrity": "sha512-+EiXRDmt37UoAI+jziiKYlpK8fikRHfdnhAa17izdcAzpqHv0/YLiHKtS8gJh4wuSK+ARO5MWKFe4ZL9uQWQZg==",
       "requires": {
-        "@essential-projects/iam_contracts": "^3.4.0",
-        "@types/express": "^4.16.0",
+        "@essential-projects/iam_contracts": "^3.4.2",
+        "@types/express": "^4.16.1",
         "@types/node": "^10.12.2"
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.6.tgz",
-          "integrity": "sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg=="
+          "version": "10.14.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.7.tgz",
+          "integrity": "sha512-on4MmIDgHXiuJDELPk1NFaKVUxxCFr37tm8E9yN6rAiF5Pzp/9bBfBHkoexqRiY+hk/Z04EJU9kKEb59YqJ82A=="
         }
       }
     },
     "@process-engine/token_history_api_core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@process-engine/token_history_api_core/-/token_history_api_core-2.0.1.tgz",
-      "integrity": "sha512-qqSyYFfC9vE9ePoVxsCaLXrtn4lqLPZj7/hf+Eya4WPL4f+Fe/OLc4d3ZEoGhbXFzOjWpKuowb4m+BYFWx0pJg==",
+      "version": "2.0.1-5d662331-b6",
+      "resolved": "https://registry.npmjs.org/@process-engine/token_history_api_core/-/token_history_api_core-2.0.1-5d662331-b6.tgz",
+      "integrity": "sha512-W6N6gpKegB2M5YjGpP8XvulgFdds+BiSZgiDqmG0v2qb5CwLkhPObndTHYhaKB7DcRYwPWu+trv57AUJecuVJw==",
       "requires": {
-        "@process-engine/flow_node_instance.contracts": "^1.0.0",
-        "@process-engine/token_history_api_contracts": "^1.4.0"
+        "@process-engine/flow_node_instance.contracts": "1.2.0-9537af2d-b6",
+        "@process-engine/token_history_api_contracts": "1.4.2-57371b44-b6"
+      },
+      "dependencies": {
+        "@process-engine/flow_node_instance.contracts": {
+          "version": "1.2.0-9537af2d-b6",
+          "resolved": "https://registry.npmjs.org/@process-engine/flow_node_instance.contracts/-/flow_node_instance.contracts-1.2.0-9537af2d-b6.tgz",
+          "integrity": "sha512-9VNV/Zb9HpnJY2WZws5Ydqdwj4Vtky921pfeC675EZ9Uzvb9MGfdh6pgwk9uRc3MuDO/vSNaMRpgsWCLkH0kbA==",
+          "requires": {
+            "@essential-projects/iam_contracts": "^3.4.2"
+          }
+        }
       }
     },
     "@process-engine/token_history_api_http": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@process-engine/token_history_api_http/-/token_history_api_http-1.4.2.tgz",
-      "integrity": "sha512-AL9Ho/+ZqNQeY7623muPD7PmRj3cQ0WLmHHGEntSghIu8dt4n7uDhoPFlqiwjLIR+hwdXCDQUatVpYn0M5bGVA==",
+      "version": "1.4.2-791afa09-b7",
+      "resolved": "https://registry.npmjs.org/@process-engine/token_history_api_http/-/token_history_api_http-1.4.2-791afa09-b7.tgz",
+      "integrity": "sha512-jtOJoC4nUxYUOXviCoSCGIfF4C67nEQeCY+OZB6V+oovhDenlnTkib01Z9a8IuboWb0JnJ+++EORz4SsPHchgg==",
       "requires": {
-        "@essential-projects/bootstrapper_contracts": "^1.3.0",
-        "@essential-projects/errors_ts": "^1.4.0",
-        "@essential-projects/http_node": "^4.1.0",
-        "@process-engine/token_history_api_contracts": "^1.4.0",
+        "@essential-projects/bootstrapper_contracts": "^1.3.2",
+        "@essential-projects/errors_ts": "^1.4.4",
+        "@essential-projects/http_node": "^4.1.5",
+        "@process-engine/token_history_api_contracts": "1.4.2-57371b44-b6",
         "async-middleware": "^1.2.1",
         "loggerhythm": "^3.0.3"
       }
@@ -1514,9 +1729,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.0.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.1.tgz",
-          "integrity": "sha512-7sy7DKVJrCTbaAERJZq/CU12bzdmpjRr321/Ne9QmzhB3iZ//L16Cizcni5hHNbANxDbxwMb9EFoWkM8KPkp0A=="
+          "version": "12.0.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.2.tgz",
+          "integrity": "sha512-5tabW/i+9mhrfEOUcLDu2xBPsHJ+X5Orqy9FKpale3SjDA17j5AEpYq5vfy3oAeAHGcvANRCO3NV3d2D6q3NiA=="
         }
       }
     },
@@ -1534,9 +1749,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.0.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.1.tgz",
-          "integrity": "sha512-7sy7DKVJrCTbaAERJZq/CU12bzdmpjRr321/Ne9QmzhB3iZ//L16Cizcni5hHNbANxDbxwMb9EFoWkM8KPkp0A=="
+          "version": "12.0.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.2.tgz",
+          "integrity": "sha512-5tabW/i+9mhrfEOUcLDu2xBPsHJ+X5Orqy9FKpale3SjDA17j5AEpYq5vfy3oAeAHGcvANRCO3NV3d2D6q3NiA=="
         }
       }
     },
@@ -1571,9 +1786,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.0.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.1.tgz",
-          "integrity": "sha512-7sy7DKVJrCTbaAERJZq/CU12bzdmpjRr321/Ne9QmzhB3iZ//L16Cizcni5hHNbANxDbxwMb9EFoWkM8KPkp0A=="
+          "version": "12.0.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.2.tgz",
+          "integrity": "sha512-5tabW/i+9mhrfEOUcLDu2xBPsHJ+X5Orqy9FKpale3SjDA17j5AEpYq5vfy3oAeAHGcvANRCO3NV3d2D6q3NiA=="
         }
       }
     },
@@ -1661,9 +1876,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.0.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.1.tgz",
-          "integrity": "sha512-7sy7DKVJrCTbaAERJZq/CU12bzdmpjRr321/Ne9QmzhB3iZ//L16Cizcni5hHNbANxDbxwMb9EFoWkM8KPkp0A=="
+          "version": "12.0.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.2.tgz",
+          "integrity": "sha512-5tabW/i+9mhrfEOUcLDu2xBPsHJ+X5Orqy9FKpale3SjDA17j5AEpYq5vfy3oAeAHGcvANRCO3NV3d2D6q3NiA=="
         }
       }
     },
@@ -1673,9 +1888,9 @@
       "integrity": "sha512-Vs55Kq8F+OWvy1RLA31rT+cAyemzgm0EWNeax6BWF8H7QiiOYMJIdcwSDdm5LVgfEkoepsWkS+40+WNb7BUMbg=="
     },
     "@types/spectrum": {
-      "version": "1.5.30",
-      "resolved": "https://registry.npmjs.org/@types/spectrum/-/spectrum-1.5.30.tgz",
-      "integrity": "sha512-a/1XFynDyU/odCUDBxylFxG98sunTAuN/XKSbts5dPKc+XcsUTNXQpi59W0cXwpYTw6T9fS4GrpzISRmtRRMlw==",
+      "version": "1.5.31",
+      "resolved": "https://registry.npmjs.org/@types/spectrum/-/spectrum-1.5.31.tgz",
+      "integrity": "sha512-v1lU8dbHmiPgj1EXj/+Iwpfj7TRakiNzZspMdFSp17cDD7qdv7XgwcpzdfB5a3TNI0S9qHdvF5wEnLLSt2rcVw==",
       "dev": true,
       "requires": {
         "@types/jquery": "*",
@@ -1693,9 +1908,9 @@
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ=="
     },
     "@types/tinycolor2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.1.tgz",
-      "integrity": "sha512-25L/RL5tqZkquKXVHM1fM2bd23qjfbcPpAZ2N/H05Y45g3UEi+Hw8CbDV28shKY8gH1SHiLpZSxPI1lacqdpGg==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.2.tgz",
+      "integrity": "sha512-PeHg/AtdW6aaIO2a+98Xj7rWY4KC1E6yOy7AFknJQ7VXUGNrMlyxDFxJo7HqLtjQms/ZhhQX52mLVW/EX3JGOw==",
       "dev": true
     },
     "@types/toastr": {
@@ -3153,9 +3368,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "11.13.10",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.10.tgz",
-          "integrity": "sha512-leUNzbFTMX94TWaIKz8N15Chu55F9QSH+INKayQr5xpkasBQBRF3qQXfo3/dOnMU/dEIit+Y/SU8HyOjq++GwA=="
+          "version": "11.13.11",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.11.tgz",
+          "integrity": "sha512-blLeR+KIy26km1OU8yTLUlSyVCOvT6+wPq/77tIA+uSHHa4yYQosn+bbaJqPtWId0wjVClUtD7aXzDbZeKWqig=="
         }
       }
     },
@@ -3860,9 +4075,9 @@
       "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
     },
     "chokidar": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.5.tgz",
-      "integrity": "sha512-i0TprVWp+Kj4WRPtInjexJ8Q+BqTE909VpH8xVhXrJkoc5QC8VO9TryGOqTr+2hljzc1sC62t22h5tZePodM/A==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
+      "integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
       "dev": true,
       "requires": {
         "anymatch": "^2.0.0",
@@ -4382,9 +4597,9 @@
       }
     },
     "core-js": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.8.tgz",
+      "integrity": "sha512-RWlREFU74TEkdXzyl1bka66O3kYp8jeTXrvJZDzVVMH8AiHUSOFpL1yfhQJ+wHocAm1m+4971W1PPzfLuCv1vg=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -5147,9 +5362,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.6.tgz",
-          "integrity": "sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg==",
+          "version": "10.14.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.7.tgz",
+          "integrity": "sha512-on4MmIDgHXiuJDELPk1NFaKVUxxCFr37tm8E9yN6rAiF5Pzp/9bBfBHkoexqRiY+hk/Z04EJU9kKEb59YqJ82A==",
           "dev": true
         }
       }
@@ -5466,9 +5681,9 @@
       },
       "dependencies": {
         "mime": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.2.tgz",
-          "integrity": "sha512-zJBfZDkwRu+j3Pdd2aHsR5GfH2jIWhmL1ZzBoc+X+3JEti2hbArWcyJ+1laC1D2/U/W1a/+Cegj0/OnEU2ybjg==",
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.3.tgz",
+          "integrity": "sha512-QgrPRJfE+riq5TPZMcHZOtm8c6K/yYrMbKIoRfapfiGLxS8OTeIfRhUGW5LU7MlRa52KOAGCfUNruqLrIBvWZw==",
           "dev": true
         }
       }
@@ -6585,9 +6800,9 @@
       }
     },
     "fs-minipass": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
+      "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
       "requires": {
         "minipass": "^2.2.1"
       }
@@ -6875,9 +7090,9 @@
           "optional": true
         },
         "nan": {
-          "version": "2.13.2",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-          "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
           "dev": true,
           "optional": true
         },
@@ -7163,9 +7378,9 @@
       }
     },
     "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -8130,9 +8345,9 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "uglify-js": {
-          "version": "3.5.12",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.12.tgz",
-          "integrity": "sha512-KeQesOpPiZNgVwJj8Ge3P4JYbQHUdZzpx6Fahy6eKAYRSV4zhVmLXoC+JtOeYxcHCHTve8RG1ZGdTvpeOUM26Q==",
+          "version": "3.5.15",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.15.tgz",
+          "integrity": "sha512-fe7aYFotptIddkwcm6YuA0HmknBZ52ZzOsUxZEdhhkSsz7RfjHDX2QDxwKTiv4JQ5t5NhfmpgAK+J7LiDhKSqg==",
           "optional": true,
           "requires": {
             "commander": "~2.20.0",
@@ -10041,9 +10256,9 @@
       "dev": true
     },
     "min-dash": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.4.0.tgz",
-      "integrity": "sha512-oWvXhMRamUlr6wXZukVuxx0QKs6Fq/NXHSFUHM346C6jwxYbvH2jDdCaEQ6V5xz4omk3JN3Wbq5w+YSL41cV1g=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-3.5.0.tgz",
+      "integrity": "sha512-Y6xeHVOHr6bDZObKAQ53m7+OTzsp8QSoBzoiWt6z645fld+kzlDipNsXH5LUSE8+NEOkw2P242kxTooWos435A=="
     },
     "min-dom": {
       "version": "3.1.1",
@@ -10319,19 +10534,19 @@
       }
     },
     "needle": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.1.tgz",
-      "integrity": "sha512-CaLXV3W8Vnbps8ZANqDGz7j4x7Yj1LW4TWF/TQuDfj7Cfx4nAPTvw98qgTevtto1oHDrh3pQkaODbqupXlsWTg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
+      "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
       "requires": {
-        "debug": "^4.1.0",
+        "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
         "sax": "^1.2.4"
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
             "ms": "^2.1.1"
           }
@@ -10423,13 +10638,13 @@
           "dev": true
         },
         "tar": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+          "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
           "dev": true,
           "requires": {
             "block-stream": "*",
-            "fstream": "^1.0.2",
+            "fstream": "^1.0.12",
             "inherits": "2"
           }
         }
@@ -10645,9 +10860,9 @@
           }
         },
         "nan": {
-          "version": "2.13.2",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-          "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
           "dev": true
         },
         "parse-json": {
@@ -12548,9 +12763,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
-      "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
+      "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -12675,9 +12890,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.0.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.1.tgz",
-          "integrity": "sha512-7sy7DKVJrCTbaAERJZq/CU12bzdmpjRr321/Ne9QmzhB3iZ//L16Cizcni5hHNbANxDbxwMb9EFoWkM8KPkp0A=="
+          "version": "12.0.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.2.tgz",
+          "integrity": "sha512-5tabW/i+9mhrfEOUcLDu2xBPsHJ+X5Orqy9FKpale3SjDA17j5AEpYq5vfy3oAeAHGcvANRCO3NV3d2D6q3NiA=="
         }
       }
     },
@@ -12711,9 +12926,9 @@
       }
     },
     "rollup-pluginutils": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.6.0.tgz",
-      "integrity": "sha512-aGQwspEF8oPKvg37u3p7h0cYNwmJR1sCBMZGZ5b9qy8HGtETknqjzcxrDRrcAnJNXN18lBH4Q9vZYth/p4n8jQ==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.7.1.tgz",
+      "integrity": "sha512-3nRf3buQGR9qz/IsSzhZAJyoK663kzseps8itkYHr+Z7ESuaffEPfgRinxbCRA0pf0gzLqkNKkSb8aNVTq75NA==",
       "requires": {
         "estree-walker": "^0.6.0",
         "micromatch": "^3.1.10"
@@ -15367,9 +15582,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.0.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.1.tgz",
-          "integrity": "sha512-7sy7DKVJrCTbaAERJZq/CU12bzdmpjRr321/Ne9QmzhB3iZ//L16Cizcni5hHNbANxDbxwMb9EFoWkM8KPkp0A=="
+          "version": "12.0.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.2.tgz",
+          "integrity": "sha512-5tabW/i+9mhrfEOUcLDu2xBPsHJ+X5Orqy9FKpale3SjDA17j5AEpYq5vfy3oAeAHGcvANRCO3NV3d2D6q3NiA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@essential-projects/errors_ts": "^1.4.5",
+    "@essential-projects/errors_ts": "^1.5.0",
     "@fortawesome/fontawesome-free": "^5.1.0",
     "@process-engine/bpmn-js-custom-bundle": "2.6.3",
     "@process-engine/bpmn-lint_rules": "1.6.2",
@@ -125,8 +125,8 @@
   },
   "peerDependencies": {},
   "devDependencies": {
-    "@essential-projects/http_contracts": "~2.3.8",
-    "@essential-projects/iam_contracts": "~3.4.2",
+    "@essential-projects/http_contracts": "~2.4.0",
+    "@essential-projects/iam_contracts": "~3.5.0",
     "@process-engine/bpmn-elements_contracts": "2.0.0",
     "@process-engine/consumer_api_contracts": "5.1.1",
     "@process-engine/kpi_api_contracts": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@process-engine/bpmn-js-custom-bundle": "2.6.3",
     "@process-engine/bpmn-lint_rules": "1.6.2",
     "@process-engine/management_api_client": "5.0.0",
-    "@process-engine/process_engine_runtime": "feature~add_admin_claim_check",
+    "@process-engine/process_engine_runtime": "8.1.0-cc0c33d7-b22",
     "@process-engine/dynamic_ui_core": "1.4.0",
     "@process-engine/solutionexplorer.repository.filesystem": "4.1.0",
     "@process-engine/solutionexplorer.repository.management_api": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@process-engine/bpmn-js-custom-bundle": "2.6.3",
     "@process-engine/bpmn-lint_rules": "1.6.2",
     "@process-engine/management_api_client": "5.0.0",
-    "@process-engine/process_engine_runtime": "8.1.0-17fd02c0-b14",
+    "@process-engine/process_engine_runtime": "feature~add_admin_claim_check",
     "@process-engine/dynamic_ui_core": "1.4.0",
     "@process-engine/solutionexplorer.repository.filesystem": "4.1.0",
     "@process-engine/solutionexplorer.repository.management_api": "3.0.0",


### PR DESCRIPTION
## Changes

The Runtime now supports a `can_manage_process_instances` claim, which indicates a super admin. 
These types of admins are always allowed to see any Correlation and ProcessModel of any user.

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/336

PR: #1474

## How to test the changes

Best use our IdentityServer for this

- Start a ProcessInstance as User `alice` (has the super admin claim)
- Start a ProcessInstance as User `bob` (is a normal user)
- Login as `alice` and look at the Correlation list
    - The user can see two process instances
- Login as `bob` and look at the Correlation list
    - The user can only see his own process instance
