### PR TITLE
✨Allow Saving Diagrams With Linter Errors

### DIFF
--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -479,11 +479,7 @@ export class BpmnIo {
       }
     });
 
-    const eventToPublish: string = validationResultContainsErrors
-                                 ? environment.events.navBar.validationError
-                                 : environment.events.navBar.noValidationError;
-
-    this._eventAggregator.publish(eventToPublish);
+    this.diagramIsInvalid = validationResultContainsErrors;
   }
 
   public _togglePanel(): void {
@@ -785,15 +781,6 @@ export class BpmnIo {
     if (userWantsToPrint) {
       // Prevent the browser from handling the default action for CMD/CTRL + p.
       event.preventDefault();
-      /**
-       * We don't want the user to print an invalid diagram.
-       */
-      if (this.diagramIsInvalid) {
-        this._notificationService.showNotification(NotificationType.WARNING,
-          `The Diagram is invalid. Please resolve this issues to print the diagram`);
-
-        return;
-      }
 
       // TODO: Handle the promise properly
       this.getSVG().then((svg: string): void => {

--- a/src/modules/navbar/navbar.html
+++ b/src/modules/navbar/navbar.html
@@ -23,7 +23,7 @@
         <button class="button menu-bar__menu-center--action-button menu-bar__menu-center--back-button back-button" click.delegate="navigateBack()" title="Navigate back">
           <i class="fas fa-arrow-circle-left"></i>
         </button>
-        <button if.bind="!savingTargetIsRemoteSolution" class="button menu-bar__menu-center--action-button" class.bind="validationError ? 'button--disabled' : ''" click.delegate="saveDiagram()" disabled.bind="validationError" title.bind="saveButtonTitle">
+        <button if.bind="!savingTargetIsRemoteSolution" class="button menu-bar__menu-center--action-button" class.bind="validationError ? 'button--disabled' : ''" click.delegate="saveDiagram()" disabled.bind="validationError" title="Save Diagram">
           <i class="fas fa-save"></i>
         </button>
       </template>

--- a/src/modules/navbar/navbar.ts
+++ b/src/modules/navbar/navbar.ts
@@ -263,10 +263,6 @@ export class NavBar {
       return 'This process is already deployed to the remote ProcessEngine.';
     }
 
-    if (this.validationError) {
-      return 'There was a problem with this diagram. Please check the linter for more information.';
-    }
-
     return 'Deploy to ProcessEngine';
   }
 
@@ -275,19 +271,7 @@ export class NavBar {
       return 'Please deploy the process to a ProcessEngine before starting it.';
     }
 
-    if (this.validationError) {
-      return 'There was a problem with this diagram. Please check the linter for more information.';
-    }
-
     return 'Start Process';
-  }
-
-  public get saveButtonTitle(): string {
-    if (this.validationError || this.savingTargetIsRemoteSolution) {
-      return 'There was a problem with this diagram. Please check the linter for more information.';
-    }
-
-    return 'Save Diagram';
   }
 
   /**


### PR DESCRIPTION
## Changes

1. Remove unnecessary titles from the navbar
2. Allow saving diagrams with linter errors

## Issues

Closes #1482 

PR: #1485 

## How to test the changes

Follow the steps from the referenced issue.
