### PR TITLE
✨Add Docu Modal

### DIFF
--- a/src/modules/design/property-panel/indextabs/general/sections/basics/basics.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/basics/basics.html
@@ -31,4 +31,14 @@
       </table>
     </div>
   </div>
+
+  <modal show.bind="showModal"
+         header-text="Editing: Docs">
+    <template replace-part="modal-body" autofocus>
+      <textarea class="form-control docs" value.bind="elementDocumentation" change.delegate="updateDocumentation()" rows="10" aria-multiline="true" autofocus wrap="soft"></textarea>
+    </template>
+    <template replace-part="modal-footer">
+      <button type="button" class="btn btn-default" data-dismiss="modal" click.delegate="showModal = false">Okay</button>
+    </template>
+  </modal>
 </template>

--- a/src/modules/design/property-panel/indextabs/general/sections/basics/basics.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/basics/basics.html
@@ -25,7 +25,7 @@
         <tr>
           <th>Docs</th>
           <td>
-            <input type="text" class="props-input" value.bind="elementDocumentation" change.delegate="updateDocumentation()" disabled.bind="!isEditable">
+            <textarea ref="docInput" type="text" class="props-input-textarea" value.bind="elementDocumentation" change.delegate="updateDocumentation()" disabled.bind="!isEditable" aria-multiline="true"></textarea>
           </td>
         </tr>
       </table>

--- a/src/modules/design/property-panel/indextabs/general/sections/basics/basics.scss
+++ b/src/modules/design/property-panel/indextabs/general/sections/basics/basics.scss
@@ -13,3 +13,27 @@
   flex: 1 100%;
   margin-top: 0;
 }
+
+.docs {
+  min-height: 55px;
+  max-height: 400px;
+}
+
+.props-input-textarea {
+  width: 100%;
+  height: 25px;
+  min-height: 25px;
+  padding-bottom: 5px;
+  margin-top: 5px;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid #e9e9e9;
+  font-weight: 400;
+  color: #5c5c5c;
+  text-overflow: ellipsis;
+}
+
+.props-input-textarea:disabled {
+  pointer-events: none;
+  opacity: 0.5;
+}

--- a/src/modules/design/property-panel/indextabs/general/sections/basics/basics.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/basics/basics.ts
@@ -22,6 +22,7 @@ export class BasicsSection implements ISection {
   public businessObjInPanel: IModdleElement;
   public elementDocumentation: string;
   public validationError: boolean = false;
+  public showModal: boolean = false;
 
   private _modeling: IModeling;
   private _modeler: IBpmnModeler;

--- a/src/modules/design/property-panel/indextabs/general/sections/basics/basics.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/basics/basics.ts
@@ -61,7 +61,7 @@ export class BasicsSection implements ISection {
     this._setValidationRules();
   }
 
-  public attached() {
+  public attached(): void {
     this.docInput.addEventListener('dblclick', (event: MouseEvent) => {
       this.showModal = true;
     });

--- a/src/modules/design/property-panel/indextabs/general/sections/basics/basics.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/basics/basics.ts
@@ -22,6 +22,7 @@ export class BasicsSection implements ISection {
   public businessObjInPanel: IModdleElement;
   public elementDocumentation: string;
   public validationError: boolean = false;
+  public docInput: HTMLInputElement;
   public showModal: boolean = false;
 
   private _modeling: IModeling;
@@ -60,12 +61,19 @@ export class BasicsSection implements ISection {
     this._setValidationRules();
   }
 
+  public attached() {
+    this.docInput.addEventListener('dblclick', (event: MouseEvent) => {
+      this.showModal = true;
+    });
+  }
+
   public detached(): void {
     if (!this.validationError) {
       return;
     }
     this.businessObjInPanel.id = this._previousProcessRefId;
     this._validationController.validate();
+    this.docInput.removeEventListener('dblclick', () => true);
   }
 
   public isSuitableForElement(element: IShape): boolean {


### PR DESCRIPTION
## Changes

1. Add modal to edit an element's documentation on double click

PR: #1486 

## How to test the changes

- open a diagram from the file system
- double click on the docu input on the property panel
- see the modal
- edit the text
- close the modal
- save the diagram
