### PR TITLE
✨ Add FlowNodeIds to LogViewer

### DIFF
--- a/src/contracts/inspect-correlation/inspect-panel/log-viewer/constants.ts
+++ b/src/contracts/inspect-correlation/inspect-panel/log-viewer/constants.ts
@@ -1,5 +1,7 @@
 export enum LogSortProperty {
-  Time = 'timestamp',
-  Message = 'message',
+  FlowNodeId = 'flowNodeId',
+  FlowNodeInstanceId = 'flowNodeInstanceId',
   LogLevel = 'logLevel',
+  Message = 'message',
+  Time = 'timestamp',
 }

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/components/log-viewer/log-viewer.html
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/components/log-viewer/log-viewer.html
@@ -25,8 +25,8 @@
       <tbody class="log-table__body">
         <tr class="log-table__table-row" repeat.for="logEntry of sortedLog" click.delegate="copyToClipboard(logEntry.message)">
           <td class="log-table__table-entry log-table__time-column">${getDateStringFromTimestamp(logEntry.timeStamp)}</td>
-          <td class="log-table__table-entry log-table__flow-node-id-column">${logEntry.flowNodeId}</td>
-          <td class="log-table__table-entry log-table__flow-node-instance-id-column">${logEntry.flowNodeInstanceId}</td>
+          <td class="log-table__table-entry log-table__flow-node-id-column">${logEntry.flowNodeId || '-'}</td>
+          <td class="log-table__table-entry log-table__flow-node-instance-id-column">${logEntry.flowNodeInstanceId || '-'}</td>
           <td class="log-table__table-entry log-table__log-level-column">${logEntry.logLevel.toUpperCase()}</td>
           <td class="log-table__table-entry log-table__message-column">${logEntry.message}</td>
         </tr>

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/components/log-viewer/log-viewer.html
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/components/log-viewer/log-viewer.html
@@ -8,6 +8,12 @@
           <th class="log-table__headline log-table__time-column" click.delegate="sortList(LogSortProperty.Time)">
             Time <i if.bind="sortSettings.sortProperty === LogSortProperty.Time" class.bind="sortSettings.ascending ? 'fas fa-caret-up' : ' fas fa-caret-down'"></i>
           </th>
+          <th class="log-table__headline log-table__flow-node-id-column" click.delegate="sortList(LogSortProperty.FlowNodeId)">
+            FlowNodeId <i if.bind="sortSettings.sortProperty === LogSortProperty.FlowNodeId" class.bind="sortSettings.ascending ? 'fas fa-caret-up' : ' fas fa-caret-down'"></i>
+          </th>
+          <th class="log-table__headline log-table__flow-node-instance-id-column" click.delegate="sortList(LogSortProperty.FlowNodeInstanceId)">
+            FlowNodeInstanceId <i if.bind="sortSettings.sortProperty === LogSortProperty.FlowNodeInstanceId" class.bind="sortSettings.ascending ? 'fas fa-caret-up' : ' fas fa-caret-down'"></i>
+          </th>
           <th class="log-table__headline log-table__log-level-column" click.delegate="sortList(LogSortProperty.LogLevel)">
             Level <i if.bind="sortSettings.sortProperty === LogSortProperty.LogLevel" class.bind="sortSettings.ascending ? 'fas fa-caret-up' : ' fas fa-caret-down'"></i>
           </th>
@@ -19,6 +25,8 @@
       <tbody class="log-table__body">
         <tr class="log-table__table-row" repeat.for="logEntry of sortedLog" click.delegate="copyToClipboard(logEntry.message)">
           <td class="log-table__table-entry log-table__time-column">${getDateStringFromTimestamp(logEntry.timeStamp)}</td>
+          <td class="log-table__table-entry log-table__flow-node-id-column">${logEntry.flowNodeId}</td>
+          <td class="log-table__table-entry log-table__flow-node-instance-id-column">${logEntry.flowNodeInstanceId}</td>
           <td class="log-table__table-entry log-table__log-level-column">${logEntry.logLevel.toUpperCase()}</td>
           <td class="log-table__table-entry log-table__message-column">${logEntry.message}</td>
         </tr>

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/components/log-viewer/log-viewer.scss
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/components/log-viewer/log-viewer.scss
@@ -64,11 +64,11 @@
 }
 
 .log-table__flow-node-instance-id-column {
-  width: 150px;
+  width: 200px;
 }
 
 .log-table__message-column {
-  width: calc(100% - 550px);
+  width: calc(100% - 600px);
 }
 
 .log-table__empty-message {

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/components/log-viewer/log-viewer.scss
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/components/log-viewer/log-viewer.scss
@@ -55,13 +55,20 @@
 .log-table__time-column {
   width: 150px;
 }
-
-.log-table__message-column {
-  width: calc(100% - 250px);
-}
-
 .log-table__log-level-column {
   width: 100px;
+}
+
+.log-table__flow-node-id-column {
+  width: 150px;
+}
+
+.log-table__flow-node-instance-id-column {
+  width: 150px;
+}
+
+.log-table__message-column {
+  width: calc(100% - 550px);
 }
 
 .log-table__empty-message {

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/components/log-viewer/log-viewer.ts
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/components/log-viewer/log-viewer.ts
@@ -85,6 +85,20 @@ export class LogViewer {
   private _getSortedLogByProperty(property: LogSortProperty): Array<DataModels.Logging.LogEntry> {
     const sortedLog: Array<DataModels.Logging.LogEntry> =
       this.log.sort((firstEntry: DataModels.Logging.LogEntry, secondEntry: DataModels.Logging.LogEntry) => {
+
+        // FlowNodeId and FlowNodeInstanceId can be 'undefined', if the LogEntry is for a ProcessInstance.
+        // Using 'greaterThan' in conjunction with 'undefined' will always be "false", which will mess up the sorting.
+        // So these cases must be handled separately.
+        const firstFieldIsUndefined: boolean = !firstEntry[property];
+        if (firstFieldIsUndefined) {
+          return -1;
+        }
+
+        const secondFieldIsUndefined: boolean = !secondEntry[property];
+        if (secondFieldIsUndefined) {
+          return 1;
+        }
+
         const firstEntryIsBigger: boolean = firstEntry[property] > secondEntry[property];
         if (firstEntryIsBigger) {
           return 1;


### PR DESCRIPTION
## Changes

1. Add the columns `FlowNodeId` and `FlowNodeInstanceId` to the LogViewer.
2. Enhance the LogViewer's sorting, so that it can deal with `undefined` values.

## Issues

Closes #1491

PR: #1492

## How to test the changes

- Run a ProcessModel
- After it is finished, go to the `Inspect` view and select the logs for the executed ProcessInstance
- See that the logs will now contain the `FlowNodeId` and `FlowNodeInstanceId` for each entry.
    - Note that ProcessInstance logs will not have any of those IDs associated with them.

The view should look like this:

![Bildschirmfoto 2019-06-06 um 14 15 58](https://user-images.githubusercontent.com/15343316/59032054-a56d7800-8865-11e9-8b59-b5dda6e7e2e1.png)

