### PR TITLE
🔥 Prevent use of cyclic timers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,6 +49,7 @@ pipeline {
         }
         nodejs(configId: env.NPM_RC_FILE, nodeJSInstallationName: env.NODE_JS_VERSION) {
           sh('node --version')
+          sh('npm cache clear --force')
           sh('npm install')
           sh('npm rebuild')
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,6 @@ pipeline {
         }
         nodejs(configId: env.NPM_RC_FILE, nodeJSInstallationName: env.NODE_JS_VERSION) {
           sh('node --version')
-          sh('npm cache clear --force')
           sh('npm install')
           sh('npm rebuild')
         }

--- a/src/modules/design/property-panel/indextabs/general/sections/timer-event/timer-event.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/timer-event/timer-event.html
@@ -13,6 +13,7 @@
               <option model.bind="undefined">-Choose Option-</option>
               <option model.bind="TimerType.Date">Date</option>
               <option model.bind="TimerType.Duration">Duration</option>
+              <option if.bind="isTimerStartEvent === true" model.bind="TimerType.Cycle">Cycle</option>
             </select>
           </td>
         </tr>

--- a/src/modules/design/property-panel/indextabs/general/sections/timer-event/timer-event.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/timer-event/timer-event.html
@@ -13,7 +13,6 @@
               <option model.bind="undefined">-Choose Option-</option>
               <option model.bind="TimerType.Date">Date</option>
               <option model.bind="TimerType.Duration">Duration</option>
-              <option model.bind="TimerType.Cycle">Cycle</option>
             </select>
           </td>
         </tr>

--- a/src/modules/design/property-panel/indextabs/general/sections/timer-event/timer-event.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/timer-event/timer-event.ts
@@ -86,9 +86,9 @@ export class TimerEventSection implements ISection {
         break;
       }
       case TimerType.Cycle: {
-        timerTypeObject = {
-          timeCycle: moddleElement,
-        };
+        timerTypeObject = this.isTimerStartEvent
+          ? {timeCycle: moddleElement}
+          : {};
         break;
       }
       default: {
@@ -119,7 +119,7 @@ export class TimerEventSection implements ISection {
   private _init(): void {
     const {timeDate, timeDuration, timeCycle} = this._businessObjInPanel.eventDefinitions[0];
 
-    if (timeCycle !== undefined) {
+    if (timeCycle !== undefined &&  this.isTimerStartEvent) {
       this.timerType = TimerType.Cycle;
       return;
     }
@@ -145,7 +145,7 @@ export class TimerEventSection implements ISection {
       return timeDate;
     }
 
-    if (timeCycle !== undefined) {
+    if (timeCycle !== undefined && this.isTimerStartEvent) {
       return timeCycle;
     }
 

--- a/src/modules/design/property-panel/indextabs/general/sections/timer-event/timer-event.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/timer-event/timer-event.ts
@@ -109,10 +109,7 @@ export class TimerEventSection implements ISection {
   }
 
   public updateTimerDefinition(): void {
-    const timeElement: IModdleElement = this._getTimerElement();
-    timeElement.body = this.timerElement.body;
     this._publishDiagramChange();
-
     this._updateLinterWhenActive();
   }
 

--- a/src/modules/design/property-panel/indextabs/general/sections/timer-event/timer-event.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/timer-event/timer-event.ts
@@ -25,6 +25,7 @@ export class TimerEventSection implements ISection {
   public timerElement: IModdleElement;
   public TimerType: typeof TimerType = TimerType;
   public timerType: TimerType;
+  public isTimerStartEvent: boolean = false;
 
   private _businessObjInPanel: ITimerEventElement;
   private _moddle: IBpmnModdle;
@@ -42,6 +43,8 @@ export class TimerEventSection implements ISection {
     this._linter = model.modeler.get('linting');
 
     this.timerElement = this._getTimerElement();
+
+    this.isTimerStartEvent = this._businessObjInPanel.$type === 'bpmn:StartEvent';
 
     this._init();
   }

--- a/src/modules/design/property-panel/indextabs/general/sections/timer-event/timer-event.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/timer-event/timer-event.ts
@@ -119,12 +119,10 @@ export class TimerEventSection implements ISection {
   private _init(): void {
     const {timeDate, timeDuration, timeCycle} = this._businessObjInPanel.eventDefinitions[0];
 
-    // Note: Temporarily disabled, until Cyclic timer support is implemented in the runtime.
-    //
-    // if (timeCycle !== undefined) {
-    //   this.timerType = TimerType.Cycle;
-    //   return;
-    // }
+    if (timeCycle !== undefined) {
+      this.timerType = TimerType.Cycle;
+      return;
+    }
 
     if (timeDuration !== undefined) {
       this.timerType = TimerType.Duration;
@@ -147,11 +145,9 @@ export class TimerEventSection implements ISection {
       return timeDate;
     }
 
-    // Note: Temporarily disabled, until Cyclic timer support is implemented in the runtime.
-    //
-    // if (timeCycle !== undefined) {
-    //   return timeCycle;
-    // }
+    if (timeCycle !== undefined) {
+      return timeCycle;
+    }
 
     const timerEventDefinition: IModdleElement = this._moddle.create('bpmn:FormalExpression', {body: ''});
     return timerEventDefinition;

--- a/src/modules/design/property-panel/indextabs/general/sections/timer-event/timer-event.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/timer-event/timer-event.ts
@@ -116,16 +116,12 @@ export class TimerEventSection implements ISection {
   private _init(): void {
     const {timeDate, timeDuration, timeCycle} = this._businessObjInPanel.eventDefinitions[0];
 
-    if ((timeDate === undefined)
-        && (timeDuration === undefined)
-        && (timeCycle === undefined)) {
-      return;
-    }
-
-    if (timeCycle !== undefined) {
-      this.timerType = TimerType.Cycle;
-      return;
-    }
+    // Note: Temporarily disabled, until Cyclic timer support is implemented in the runtime.
+    //
+    // if (timeCycle !== undefined) {
+    //   this.timerType = TimerType.Cycle;
+    //   return;
+    // }
 
     if (timeDuration !== undefined) {
       this.timerType = TimerType.Duration;
@@ -147,9 +143,12 @@ export class TimerEventSection implements ISection {
     if (timeDate !== undefined) {
       return timeDate;
     }
-    if (timeCycle !== undefined) {
-      return timeCycle;
-    }
+
+    // Note: Temporarily disabled, until Cyclic timer support is implemented in the runtime.
+    //
+    // if (timeCycle !== undefined) {
+    //   return timeCycle;
+    // }
 
     const timerEventDefinition: IModdleElement = this._moddle.create('bpmn:FormalExpression', {body: ''});
     return timerEventDefinition;


### PR DESCRIPTION
## Changes

Remove the `Cyclic` Timer Option from the Property Panel, when modelling BoundaryEvents or IntermediateEvents. 

See issue for more details.

## Issues

Closes #1493

PR: #1495

## How to test the changes

When modelling IntermediateTimerCatchEvents and TimerBoundaryEvents, it will no longer be possible to select `cyclic`, when opening the DropDown Menu inside the Property-Panel.

The Option is still available for StartEvents.

![Bildschirmfoto 2019-06-07 um 09 21 50](https://user-images.githubusercontent.com/15343316/59087988-8f63c400-8906-11e9-87d1-e2e959ca4905.png)
![Bildschirmfoto 2019-06-07 um 09 21 25](https://user-images.githubusercontent.com/15343316/59087986-8f63c400-8906-11e9-9a33-bfd1f0072ff5.png)
![Bildschirmfoto 2019-06-07 um 09 21 36](https://user-images.githubusercontent.com/15343316/59087987-8f63c400-8906-11e9-85bb-5e101a014eef.png)