### PR TITLE
Improve Discoverability of Docs Modal

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -22,10 +22,6 @@ input:focus {
   display: none;
 }
 
-a:hover {
-  color: inherit;
-}
-
 .bpmn-studio-layout {
   display: flex;
   height: 100%;

--- a/src/modules/design/property-panel/indextabs/general/sections/basics/basics.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/basics/basics.html
@@ -25,7 +25,7 @@
         <tr>
           <th>Docs</th>
           <td>
-            <textarea ref="docInput" type="text" class="props-input-textarea" value.bind="elementDocumentation" change.delegate="updateDocumentation()" disabled.bind="!isEditable" aria-multiline="true"></textarea>
+            <textarea type="text" class="props-input-textarea" value.bind="elementDocumentation" change.delegate="updateDocumentation()" disabled.bind="!isEditable" aria-multiline="true"></textarea>
           </td>
         </tr>
       </table>

--- a/src/modules/design/property-panel/indextabs/general/sections/basics/basics.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/basics/basics.html
@@ -22,9 +22,11 @@
             <input type="text" class="props-input" value.bind="businessObjInPanel.name" change.delegate="updateName()" disabled.bind="!isEditable">
           </td>
         </tr>
+      </table>
+      <table class="props-table-docs">
         <tr>
-          <th>Docs</th>
           <td>
+              Docs <a class="docs-enlarge-link" click.delegate="showModal = true"><small class="docs-enlarge-text">Enlarge</small></a>
             <textarea type="text" class="props-input-textarea" value.bind="elementDocumentation" change.delegate="updateDocumentation()" disabled.bind="!isEditable" aria-multiline="true"></textarea>
           </td>
         </tr>

--- a/src/modules/design/property-panel/indextabs/general/sections/basics/basics.scss
+++ b/src/modules/design/property-panel/indextabs/general/sections/basics/basics.scss
@@ -37,3 +37,22 @@
   pointer-events: none;
   opacity: 0.5;
 }
+
+.props-table-docs {
+  width: 100%;
+}
+
+.props-table-docs td {
+  width: 100%;
+  padding: 5px 0;
+  color: #a5a5a5;
+}
+
+.docs-enlarge-link {
+  cursor: pointer;
+  color: #333;
+}
+
+.docs-enlarge-text:hover {
+  text-decoration: underline;
+}

--- a/src/modules/design/property-panel/indextabs/general/sections/basics/basics.scss
+++ b/src/modules/design/property-panel/indextabs/general/sections/basics/basics.scss
@@ -50,7 +50,11 @@
 
 .docs-enlarge-link {
   cursor: pointer;
-  color: #333;
+  color: #007bff !important;
+}
+
+.docs-enlarge-link {
+  color: #0056b3;
 }
 
 .docs-enlarge-text:hover {

--- a/src/modules/design/property-panel/indextabs/general/sections/basics/basics.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/basics/basics.ts
@@ -22,7 +22,6 @@ export class BasicsSection implements ISection {
   public businessObjInPanel: IModdleElement;
   public elementDocumentation: string;
   public validationError: boolean = false;
-  public docInput: HTMLInputElement;
   public showModal: boolean = false;
 
   private _modeling: IModeling;
@@ -61,19 +60,12 @@ export class BasicsSection implements ISection {
     this._setValidationRules();
   }
 
-  public attached(): void {
-    this.docInput.addEventListener('dblclick', (event: MouseEvent) => {
-      this.showModal = true;
-    });
-  }
-
   public detached(): void {
     if (!this.validationError) {
       return;
     }
     this.businessObjInPanel.id = this._previousProcessRefId;
     this._validationController.validate();
-    this.docInput.removeEventListener('dblclick', () => true);
   }
 
   public isSuitableForElement(element: IShape): boolean {

--- a/src/modules/inspect/process-list/process-list.scss
+++ b/src/modules/inspect/process-list/process-list.scss
@@ -26,3 +26,7 @@
 .process-list-item-stopped {
   background-color: #ff00005c !important;
 }
+
+.process-list-item-modelname:hover {
+  color: inherit;
+}

--- a/src/modules/inspect/task-list/task-list.scss
+++ b/src/modules/inspect/task-list/task-list.scss
@@ -17,3 +17,7 @@
 .task-list-container {
   flex: 1;
 }
+
+.task-list-item-modelname:hover {
+  color: inherit;
+}

--- a/src/modules/navbar/navbar.scss
+++ b/src/modules/navbar/navbar.scss
@@ -74,6 +74,7 @@ button {
   cursor: default;
   text-decoration: inherit;
   -webkit-user-drag: none;
+  color: inherit;
 }
 
 .action-button {


### PR DESCRIPTION
## Changes

1. Remove dblclick EventListener
2. Improve discoverability of docs modal

Before:
![Screenshot 2019-06-12 at 09 25 07](https://user-images.githubusercontent.com/17065920/59337812-9113fa00-8d01-11e9-933f-2aa4d42c6601.png)

After:
![Screenshot 2019-06-12 at 15 38 53](https://user-images.githubusercontent.com/17065920/59355937-3641c900-8d28-11e9-9b47-27814d4b18e8.png)

## Issues

Closes #1499 

PR: #1503 

## How to test the changes

> Describe how others can test your changes (not required when fixing typos, linter errors and such)
