### PR TITLE
✨ Add Open Diagrams Functionality

### DIFF
--- a/aurelia_project/environments/dev.ts
+++ b/aurelia_project/environments/dev.ts
@@ -98,6 +98,9 @@ export default {
       showTokenViewer: 'inspectCorrelation:tokenViewer:show',
       showLogViewer: 'inpsectCorrelation:logViewer:show',
     },
+    solutionExplorer: {
+      updateOpenDiagrams: 'solutioneExplorer:openDiagrams:update',
+    },
   },
   baseRoute: processEngineRoute,
   propertyPanel: {

--- a/aurelia_project/environments/dev.ts
+++ b/aurelia_project/environments/dev.ts
@@ -35,8 +35,8 @@ export default {
     xmlChanged: 'xmlChanged',
     startPage: {
       openLocalSolution: 'startpage:openlocalsolution',
-      openSingleDiagram: 'startpage:openSingleDiagram',
-      createSingleDiagram: 'startpage:createSingleDiagram',
+      openDiagram: 'startpage:openDiagram',
+      createDiagram: 'startpage:createDiagram',
     },
     statusBar: {
       showDiagramViewButtons: 'statusbar:diagramviewbuttons:show',

--- a/electron_app/electron.js
+++ b/electron_app/electron.js
@@ -19,8 +19,6 @@ const oidcConfig = require('./oidc-config');
 let filePath;
 let isInitialized = false;
 
-let canNotCloseApplication = false;
-
 const Main = {};
 
 /**
@@ -299,24 +297,6 @@ Main._createMainWindow = function () {
   // broken if we carry a file system link as the last item of the browser
   // history.
   Main._window.loadURL('/');
-
-  Main._window.on('close', (event) => {
-    if (canNotCloseApplication) {
-      event.preventDefault();
-
-      Main._window.webContents.send('show-close-modal');
-
-      return false;
-    }
-  });
-
-  electron.ipcMain.on('close-bpmn-studio', (event) => {
-    Main._window.close();
-  });
-
-  electron.ipcMain.on('can-not-close', (event, canCloseResult) => {
-    canNotCloseApplication = canCloseResult;
-  });
 
   Main._window.on('closed', (event) => {
     Main._window = null;

--- a/electron_app/electron.js
+++ b/electron_app/electron.js
@@ -322,7 +322,7 @@ Main._createMainWindow = function () {
     Main._window = null;
   });
 
-  setOpenSingleDiagram();
+  setOpenDiagram();
   setOpenSolutions();
 
   const platformIsWindows = process.platform === 'win32';
@@ -361,8 +361,8 @@ Main._createMainWindow = function () {
     });
   }
 
-  function setOpenSingleDiagram() {
-    electron.ipcMain.on('open_single_diagram', (event) => {
+  function setOpenDiagram() {
+    electron.ipcMain.on('open_diagram', (event) => {
       const openedFile = dialog.showOpenDialog({
         filters: [
           {
@@ -376,7 +376,7 @@ Main._createMainWindow = function () {
         ]
       });
 
-      event.sender.send('import_opened_single_diagram', openedFile);
+      event.sender.send('import_opened_diagram', openedFile);
     });
   }
 

--- a/src/contracts/diagram/IDiagramState.ts
+++ b/src/contracts/diagram/IDiagramState.ts
@@ -1,11 +1,12 @@
 import {IShape} from '@process-engine/bpmn-elements_contracts';
+import {IViewbox} from '../index';
 
 export interface IDiagramState {
   data: {
     xml: string,
   };
   metaData: {
-    location: any,
+    location: IViewbox,
     selectedElements: Array<IShape>,
   };
 }

--- a/src/contracts/diagram/IDiagramState.ts
+++ b/src/contracts/diagram/IDiagramState.ts
@@ -1,0 +1,11 @@
+import { IShape } from '@process-engine/bpmn-elements_contracts';
+
+export interface IDiagramState {
+  data: {
+    xml: string,
+  };
+  metaData: {
+    location: any,
+    selectedElements: Array<IShape>,
+  };
+}

--- a/src/contracts/diagram/IDiagramState.ts
+++ b/src/contracts/diagram/IDiagramState.ts
@@ -1,4 +1,4 @@
-import { IShape } from '@process-engine/bpmn-elements_contracts';
+import {IShape} from '@process-engine/bpmn-elements_contracts';
 
 export interface IDiagramState {
   data: {

--- a/src/contracts/diagram/IDiagramState.ts
+++ b/src/contracts/diagram/IDiagramState.ts
@@ -8,5 +8,6 @@ export interface IDiagramState {
   metaData: {
     location: IViewbox,
     selectedElements: Array<IShape>,
+    isChanged: boolean,
   };
 }

--- a/src/contracts/diagram/index.ts
+++ b/src/contracts/diagram/index.ts
@@ -1,0 +1,1 @@
+export * from './IDiagramState';

--- a/src/contracts/index.ts
+++ b/src/contracts/index.ts
@@ -19,3 +19,4 @@ export * from './user-input-validation/index';
 export * from './inspect-correlation/index';
 export * from './solution-explorer';
 export * from './navigation';
+export * from './diagram/index';

--- a/src/contracts/solution-explorer/ISolutionEntry.ts
+++ b/src/contracts/solution-explorer/ISolutionEntry.ts
@@ -11,7 +11,7 @@ export interface ISolutionEntry {
   service: ISolutionExplorerService;
   uri: string;
   fontAwesomeIconClass: string;
-  isSingleDiagramService: boolean;
+  isOpenDiagramService: boolean;
   canCloseSolution: boolean;
   canCreateNewDiagramsInSolution: boolean;
   authority: string;

--- a/src/contracts/solution-explorer/ISolutionService.ts
+++ b/src/contracts/solution-explorer/ISolutionService.ts
@@ -37,21 +37,21 @@ export interface ISolutionService {
   removeSolutionEntryByUri(uri: string): void;
 
   /**
-   * Adds a single diagram to the service.
+   * Adds a diagram to the service.
    * @param diagram The diagram to add.
    */
-  addSingleDiagram(diagram: IDiagram): void;
+  addOpenDiagram(diagram: IDiagram): void;
 
   /**
-   * Removes a single diagram from the service identified by its URI.
+   * Removes an open diagram from the service identified by its URI.
    * @param diagramUri The uri of the diagram to remove.
    */
-  removeSingleDiagramByUri(diagramUri: string): void;
+  removeOpenDiagramByUri(diagramUri: string): void;
 
   /**
-   * Returns a list of all single diagrams in the service.
+   * Returns a list of all open diagrams in the service.
    */
-  getSingleDiagrams(): Array<IDiagram>;
+  getOpenDiagrams(): Array<IDiagram>;
 
   /**
    * Persists the currently opened Solutions in the LocalStorage.

--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -12,6 +12,7 @@ import {
   ICanvas,
   IDiagramExportService,
   IDiagramPrintService,
+  IDiagramState,
   IEditorActions,
   IElementRegistry,
   IEvent,
@@ -27,12 +28,13 @@ import {
 } from '../../../contracts/index';
 import environment from '../../../environment';
 import {NotificationService} from '../../../services/notification-service/notification.service';
+import {OpenDiagramsStateService} from '../../../services/solution-explorer-services/OpenDiagramsStateService';
 import {DiagramExportService, DiagramPrintService} from './services/index';
 
 const sideBarRightSize: number = 35;
 const elementRegistryTimeoutMilliseconds: number = 50;
 
-@inject('NotificationService', EventAggregator)
+@inject('NotificationService', EventAggregator, 'OpenDiagramsStateService')
 export class BpmnIo {
   public modeler: IBpmnModeler;
   public viewer: IBpmnModeler;
@@ -66,6 +68,7 @@ export class BpmnIo {
   private _subscriptions: Array<Subscription>;
   private _diagramExportService: IDiagramExportService;
   private _diagramPrintService: IDiagramPrintService;
+  private _openDiagramStateService: OpenDiagramsStateService;
 
   private _tempProcess: IProcessRef;
   private _diagramHasChanges: boolean = false;
@@ -81,9 +84,10 @@ export class BpmnIo {
    */
   public paletteContainer: HTMLDivElement;
 
-  constructor(notificationService: NotificationService, eventAggregator: EventAggregator) {
+  constructor(notificationService: NotificationService, eventAggregator: EventAggregator, openDiagramStateService: OpenDiagramsStateService) {
     this._notificationService = notificationService;
     this._eventAggregator = eventAggregator;
+    this._openDiagramStateService = openDiagramStateService;
   }
 
   public created(): void {

--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -318,17 +318,9 @@ export class BpmnIo {
       }),
 
       this._eventAggregator.subscribe(environment.events.diagramChange, async() => {
-        /*
-        * This Regex removes all newlines and spaces to make sure that both xml
-        * are not formatted.
-        */
-        const whitespaceAndNewLineRegex: RegExp = /\r?\n|\r|\s/g;
-
         this.xml = await this.getXML();
-        const unformattedXml: string = this.xml.replace(whitespaceAndNewLineRegex, '');
-        const unformattedSaveXml: string = this.savedXml.replace(whitespaceAndNewLineRegex, '');
 
-        const diagramIsChanged: boolean = unformattedSaveXml !== unformattedXml;
+        const diagramIsChanged: boolean = !this._areXmlsIdentical(this.xml, this.savedXml);
 
         this._validateDiagram();
 
@@ -618,6 +610,19 @@ export class BpmnIo {
     const isChanged: boolean = this._diagramHasChanges;
 
     this._openDiagramStateService.saveDiagramState(diagramUri, xml, viewbox, selectedElement, isChanged);
+  }
+
+  private _areXmlsIdentical(firstXml: string, secondXml: string): boolean {
+    /*
+    * This Regex removes all newlines and spaces to make sure that both xml
+    * are not formatted.
+    */
+    const whitespaceAndNewLineRegex: RegExp = /\r?\n|\r|\s/g;
+
+    const unformattedXml: string = firstXml.replace(whitespaceAndNewLineRegex, '');
+    const unformattedSaveXml: string = secondXml.replace(whitespaceAndNewLineRegex, '');
+
+    return unformattedSaveXml === unformattedXml;
   }
 
   private _importXmlIntoModeler(xml: string): Promise<void> {

--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -416,6 +416,11 @@ export class BpmnIo {
       } else {
         this.modeler.importXML(this.xml);
       }
+
+      const diagramState: IDiagramState = this._openDiagramStateService.loadDiagramState(this.diagramUri);
+      const diagramContainsChanges: boolean = diagramState !== null && diagramState.metaData.isChanged;
+
+      this._eventAggregator.publish(environment.events.differsFromOriginal, diagramContainsChanges);
     } else {
       if (oldValue !== undefined) {
         this._saveDiagramState(this.diagramUri);

--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -432,7 +432,7 @@ export class BpmnIo {
     this.diagramHasChanged = false;
   }
 
-  public async diagramChanged(_: string, previousUri: string): Promise<void> {
+  public async diagramChanged(newUri: string, previousUri: string): Promise<void> {
     this.diagramHasChanged = true;
     this._tempProcess = undefined;
 

--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -414,7 +414,18 @@ export class BpmnIo {
     this.diagramHasChanged = false;
   }
 
-  public async diagramChanged(): Promise<void> {
+  public async diagramChanged(_: string, previousUri: string): Promise<void> {
+    const previousDiagramExists: boolean = previousUri !== undefined;
+    if (!this.solutionIsRemote && previousDiagramExists) {
+      const modelerCanvas: ICanvas = this.modeler.get('canvas');
+
+      const selectedElement: Array<IShape> = this.modeler.get('selection')._selectedElements;
+      const viewbox: IViewbox  = modelerCanvas.viewbox();
+      const xml: string = await this.getXML();
+
+      this._openDiagramStateService.saveDiagramState(previousUri, xml, viewbox, selectedElement);
+    }
+
     this.solutionIsRemote = this.diagramUri.startsWith('http');
     this._tempProcess = undefined;
     this.diagramHasChanged = true;

--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -614,7 +614,7 @@ export class BpmnIo {
     const selectedElement: Array<IShape> = this.modeler.get('selection')._selectedElements;
     const viewbox: IViewbox  = modelerCanvas.viewbox();
     const xml: string = await this.getXML();
-    const isChanged: boolean = this._areXmlsIdentical(xml, savedXml);
+    const isChanged: boolean = !this._areXmlsIdentical(xml, savedXml);
 
     this._openDiagramStateService.saveDiagramState(diagramUri, xml, viewbox, selectedElement, isChanged);
   }

--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -528,8 +528,9 @@ export class BpmnIo {
 
     await this._importXmlIntoModeler(xml);
 
-    // TODO: Refactor
-    this.modeler.get('canvas').viewbox(viewbox);
+    setTimeout(() => {
+      this.modeler.get('canvas').viewbox(viewbox);
+    }, 0);
   }
 
   private async _validateDiagram(): Promise<void> {

--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -28,13 +28,13 @@ import {
 } from '../../../contracts/index';
 import environment from '../../../environment';
 import {NotificationService} from '../../../services/notification-service/notification.service';
-import {OpenDiagramsStateService} from '../../../services/solution-explorer-services/OpenDiagramsStateService';
+import {OpenDiagramStateService} from '../../../services/solution-explorer-services/OpenDiagramStateService';
 import {DiagramExportService, DiagramPrintService} from './services/index';
 
 const sideBarRightSize: number = 35;
 const elementRegistryTimeoutMilliseconds: number = 50;
 
-@inject('NotificationService', EventAggregator, 'OpenDiagramsStateService')
+@inject('NotificationService', EventAggregator, 'OpenDiagramStateService')
 export class BpmnIo {
   public modeler: IBpmnModeler;
   public viewer: IBpmnModeler;
@@ -68,7 +68,7 @@ export class BpmnIo {
   private _subscriptions: Array<Subscription>;
   private _diagramExportService: IDiagramExportService;
   private _diagramPrintService: IDiagramPrintService;
-  private _openDiagramStateService: OpenDiagramsStateService;
+  private _openDiagramStateService: OpenDiagramStateService;
 
   private _tempProcess: IProcessRef;
   private _diagramHasChanges: boolean = false;
@@ -84,7 +84,7 @@ export class BpmnIo {
    */
   public paletteContainer: HTMLDivElement;
 
-  constructor(notificationService: NotificationService, eventAggregator: EventAggregator, openDiagramStateService: OpenDiagramsStateService) {
+  constructor(notificationService: NotificationService, eventAggregator: EventAggregator, openDiagramStateService: OpenDiagramStateService) {
     this._notificationService = notificationService;
     this._eventAggregator = eventAggregator;
     this._openDiagramStateService = openDiagramStateService;

--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -422,10 +422,11 @@ export class BpmnIo {
       const diagramContainsChanges: boolean = diagramState !== null && diagramState.metaData.isChanged;
 
       this._eventAggregator.publish(environment.events.differsFromOriginal, diagramContainsChanges);
-    } else {
-      if (oldValue !== undefined) {
-        await this._saveDiagramState(this.diagramUri);
-      }
+    }
+
+    const oldValueExists: boolean = oldValue !== undefined;
+    if (!this.diagramHasChanged && oldValueExists) {
+      await this._saveDiagramState(this.diagramUri);
     }
 
     this.diagramHasChanged = false;
@@ -519,7 +520,9 @@ export class BpmnIo {
 
   private async _recoverDiagramState(): Promise<void> {
     const diagramState: IDiagramState = this._loadDiagramState(this.diagramUri);
-    if (diagramState === null) {
+
+    const diagramHasState: boolean = diagramState !== null;
+    if (diagramHasState) {
       return;
     }
 

--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -312,6 +312,9 @@ export class BpmnIo {
 
       this._eventAggregator.subscribe(environment.events.diagramDetail.saveDiagram, async() => {
         this.savedXml = await this.getXML();
+        this._diagramHasChanges = false;
+
+        this._saveDiagramState(this.diagramUri);
       }),
 
       this._eventAggregator.subscribe(environment.events.diagramChange, async() => {
@@ -606,8 +609,9 @@ export class BpmnIo {
     const selectedElement: Array<IShape> = this.modeler.get('selection')._selectedElements;
     const viewbox: IViewbox  = modelerCanvas.viewbox();
     const xml: string = await this.getXML();
+    const isChanged: boolean = this._diagramHasChanges;
 
-    this._openDiagramStateService.saveDiagramState(diagramUri, xml, viewbox, selectedElement);
+    this._openDiagramStateService.saveDiagramState(diagramUri, xml, viewbox, selectedElement, isChanged);
   }
 
   private _importXmlIntoModeler(xml: string): Promise<void> {

--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -411,7 +411,7 @@ export class BpmnIo {
         this.modeler.importXML(this.xml);
       }
 
-      const diagramState: IDiagramState = this._openDiagramStateService.loadDiagramState(this.diagramUri);
+      const diagramState: IDiagramState = this._loadDiagramState(this.diagramUri);
       const diagramContainsChanges: boolean = diagramState !== null && diagramState.metaData.isChanged;
 
       this._eventAggregator.publish(environment.events.differsFromOriginal, diagramContainsChanges);
@@ -501,13 +501,17 @@ export class BpmnIo {
   }
 
   private _diagramHasState(uri: string): boolean {
-    const diagramState: IDiagramState = this._openDiagramStateService.loadDiagramState(uri);
+    const diagramState: IDiagramState = this._loadDiagramState(uri);
 
     return diagramState !== null;
   }
 
+  private _loadDiagramState(diagramUri: string): IDiagramState {
+    return this._openDiagramStateService.loadDiagramState(diagramUri);
+  }
+
   private async _recoverDiagramState(): Promise<void> {
-    const diagramState: IDiagramState = this._openDiagramStateService.loadDiagramState(this.diagramUri);
+    const diagramState: IDiagramState = this._loadDiagramState(this.diagramUri);
     if (diagramState === null) {
       return;
     }

--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -485,6 +485,7 @@ export class BpmnIo {
         }
       }, 0);
     }
+
     this._diagramHasChanges = false;
   }
 

--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -314,7 +314,7 @@ export class BpmnIo {
         this.savedXml = await this.getXML();
         this._diagramHasChanges = false;
 
-        this._saveDiagramState(this.diagramUri);
+        await this._saveDiagramState(this.diagramUri);
       }),
 
       this._eventAggregator.subscribe(environment.events.diagramChange, async() => {
@@ -397,7 +397,7 @@ export class BpmnIo {
     this._tempProcess = undefined;
   }
 
-  public xmlChanged(_: string, oldValue: string): void {
+  public async xmlChanged(newValue: string, oldValue: string): Promise<void> {
     if (this.diagramHasChanged) {
       this.savedXml = newValue;
 
@@ -417,7 +417,7 @@ export class BpmnIo {
       this._eventAggregator.publish(environment.events.differsFromOriginal, diagramContainsChanges);
     } else {
       if (oldValue !== undefined) {
-        this._saveDiagramState(this.diagramUri);
+        await this._saveDiagramState(this.diagramUri);
       }
     }
 

--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -511,8 +511,12 @@ export class BpmnIo {
     }
 
     const xml: string = diagramState.data.xml;
+    const viewbox: IViewbox = diagramState.metaData.location;
 
     await this._importXmlIntoModeler(xml);
+
+    // TODO: Refactor
+    this.modeler.get('canvas').viewbox(viewbox);
   }
 
   private async _validateDiagram(): Promise<void> {

--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -581,6 +581,7 @@ export class BpmnIo {
         resolve(result);
       });
     });
+
     return returnPromise;
   }
 

--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -690,8 +690,6 @@ export class BpmnIo {
         return element.type === 'bpmn:Participant';
       });
 
-      const multipleParticipants: boolean = participants.length > 1;
-
       if (this._diagramHasChanges) {
         participants.forEach((participant: IShape) => {
           participant.businessObject.processRef.id = this._tempProcess.id;

--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -399,6 +399,8 @@ export class BpmnIo {
 
   public xmlChanged(_: string, oldValue: string): void {
     if (this.diagramHasChanged) {
+      this.savedXml = newValue;
+
       if (this.solutionIsRemote) {
         this.viewer.importXML(this.xml);
       }
@@ -602,12 +604,13 @@ export class BpmnIo {
   }
 
   private async _saveDiagramState(diagramUri: string): Promise<void> {
+    const savedXml: string = this.savedXml;
     const modelerCanvas: ICanvas = this.modeler.get('canvas');
 
     const selectedElement: Array<IShape> = this.modeler.get('selection')._selectedElements;
     const viewbox: IViewbox  = modelerCanvas.viewbox();
     const xml: string = await this.getXML();
-    const isChanged: boolean = this._diagramHasChanges;
+    const isChanged: boolean = this._areXmlsIdentical(xml, savedXml);
 
     this._openDiagramStateService.saveDiagramState(diagramUri, xml, viewbox, selectedElement, isChanged);
   }

--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -419,6 +419,9 @@ export class BpmnIo {
   }
 
   public async diagramChanged(_: string, previousUri: string): Promise<void> {
+    this.diagramHasChanged = true;
+    this._tempProcess = undefined;
+
     const previousDiagramExists: boolean = previousUri !== undefined;
     if (!this.solutionIsRemote && previousDiagramExists) {
       const modelerCanvas: ICanvas = this.modeler.get('canvas');
@@ -431,8 +434,6 @@ export class BpmnIo {
     }
 
     this.solutionIsRemote = this.diagramUri.startsWith('http');
-    this._tempProcess = undefined;
-    this.diagramHasChanged = true;
 
     if (this.solutionIsRemote) {
       const viewerNotInitialized: boolean = this.viewer === undefined;

--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -521,8 +521,8 @@ export class BpmnIo {
   private async _recoverDiagramState(): Promise<void> {
     const diagramState: IDiagramState = this._loadDiagramState(this.diagramUri);
 
-    const diagramHasState: boolean = diagramState !== null;
-    if (diagramHasState) {
+    const diagramHasNoState: boolean = diagramState === null;
+    if (diagramHasNoState) {
       return;
     }
 

--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -201,21 +201,28 @@ export class BpmnIo {
   }
 
   public async attached(): Promise<void> {
-    const xmlIsNotEmpty: boolean = this.xml !== undefined && this.xml !== null;
-    if (xmlIsNotEmpty) {
-      this.modeler.importXML(this.xml, async(err: Error) => {
-        this.savedXml = await this.getXML();
-      });
+    if (this._diagramHasState(this.diagramUri)) {
+      const diagramState: IDiagramState = this._loadDiagramState(this.diagramUri);
 
-      // Wait until the HTML is rendered
-      setTimeout(() => {
-        this._bpmnLintButton = document.querySelector('.bpmn-js-bpmnlint-button');
+      await this._importXmlIntoModeler(diagramState.data.xml);
+    } else {
 
-        if (this._bpmnLintButton) {
-          this._bpmnLintButton.style.display = 'none';
-        }
-      }, 0);
+      const xmlIsNotEmpty: boolean = this.xml !== undefined && this.xml !== null;
+      if (xmlIsNotEmpty) {
+        this.modeler.importXML(this.xml, async(err: Error) => {
+          this.savedXml = await this.getXML();
+        });
+      }
     }
+
+    // Wait until the HTML is rendered
+    setTimeout(() => {
+      this._bpmnLintButton = document.querySelector('.bpmn-js-bpmnlint-button');
+
+      if (this._bpmnLintButton) {
+        this._bpmnLintButton.style.display = 'none';
+      }
+    }, 0);
 
     if (this.solutionIsRemote) {
       this.viewer.importXML(this.xml);

--- a/src/modules/design/design.html
+++ b/src/modules/design/design.html
@@ -37,16 +37,6 @@
       </div>
     </div>
 
-    <modal show.bind="showQuitModal"
-           header-text="Document Contains Changes"
-           body-text="Your process has unsaved changes. Save changes to diagram before quitting the BPMN-Studio?">
-      <template replace-part="modal-footer">
-        <button type="button" class="btn btn-default" data-dismiss="modal" click.delegate="cancelQuitting()">Cancel</button>
-        <button type="button" class="btn btn-secondary" data-dismiss="modal" click.delegate="quitWithoutSaving()">Quit and don't save</button>
-        <button type="button" class="btn btn-primary" data-dismiss="modal" click.delegate="quitWithSaving()">Save and quit</button>
-      </template>
-    </modal>
-
     <modal show.bind="showSaveBeforeDeployModal"
           header-text="Save Diagram Before Deploying"
           body-text="In order to deploy your diagram, you have to save your recent changes to disk.">

--- a/src/modules/design/design.html
+++ b/src/modules/design/design.html
@@ -47,16 +47,6 @@
       </template>
     </modal>
 
-    <modal show.bind="showLeaveModal"
-          header-text="Document Contains Changes"
-          body-text="Your process has unsaved changes. Save changes to diagram before leaving?">
-      <template replace-part="modal-footer">
-        <button type="button" class="btn btn-default" data-dismiss="modal" id="cancelButtonLeaveView">Cancel</button>
-        <button type="button" class="btn btn-secondary" data-dismiss="modal" id="dontSaveButtonLeaveView">Leave and don't save</button>
-        <button type="button" class="btn btn-primary" data-dismiss="modal" id="saveButtonLeaveView">Save and leave</button>
-      </template>
-    </modal>
-
     <modal show.bind="showSaveBeforeDeployModal"
           header-text="Save Diagram Before Deploying"
           body-text="In order to deploy your diagram, you have to save your recent changes to disk.">

--- a/src/modules/design/design.ts
+++ b/src/modules/design/design.ts
@@ -42,7 +42,6 @@ export class Design {
   @bindable({defaultBindingMode: bindingMode.oneWay}) public xml: string;
 
   public showQuitModal: boolean = false;
-  public showLeaveModal: boolean = false;
   public showSelectDiagramModal: boolean = false;
 
   public showDetail: boolean = true;
@@ -286,83 +285,6 @@ export class Design {
 
   public togglePanel(): void {
     this._eventAggregator.publish(environment.events.bpmnio.togglePropertyPanel);
-  }
-
-  public async canDeactivate(destinationInstruction: NavigationInstruction): Promise<Redirect> {
-    const userCanNotDeactivateRoute: boolean = !(await this.canDeactivateModal(destinationInstruction));
-    if (userCanNotDeactivateRoute) {
-
-      const redirectUrl: string = `${this._router.currentInstruction.fragment}?${this._router.currentInstruction.queryString}`;
-      /*
-      * As suggested in https://github.com/aurelia/router/issues/302, we use
-      * the router directly to navigate back, which results in staying on this
-      * component-- and this is the desired behaviour.
-      */
-      return new Redirect(redirectUrl, {trigger: false, replace: false});
-    }
-  }
-
-  public async canDeactivateModal(currentRouteInstruction: NavigationInstruction): Promise<boolean> {
-    const modalResult: Promise<boolean> = new Promise((resolve: Function, reject: Function): boolean | void => {
-
-      const modalCanBeSuppressed: boolean = !this.diagramDetail.diagramHasChanged || this._modalCanBeSuppressed(currentRouteInstruction);
-      if (modalCanBeSuppressed) {
-        resolve(true);
-
-        return;
-      }
-
-      const dontSaveAndLeaveFunction: EventListenerOrEventListenerObject = (): void => {
-        this.showLeaveModal = false;
-        this.diagramDetail.diagramHasChanged = false;
-        this._eventAggregator.publish(environment.events.navBar.diagramChangesResolved);
-
-        document.getElementById('dontSaveButtonLeaveView').removeEventListener('click', dontSaveAndLeaveFunction);
-        document.getElementById('saveButtonLeaveView').removeEventListener('click', saveAndLeaveFunction);
-        document.getElementById('cancelButtonLeaveView').removeEventListener('click', cancelAndLeaveFunction);
-
-        resolve(true);
-      };
-
-      const saveAndLeaveFunction: EventListenerOrEventListenerObject = async(): Promise<void> => {
-        if (this.diagramDetail.diagramIsInvalid) {
-          resolve(false);
-        }
-
-        try {
-          await this.diagramDetail.saveDiagram();
-          this.diagramDetail.diagramHasChanged = false;
-          this.showLeaveModal = false;
-
-          resolve(true);
-        } catch {
-          return;
-        }
-
-        document.getElementById('dontSaveButtonLeaveView').removeEventListener('click', dontSaveAndLeaveFunction);
-        document.getElementById('saveButtonLeaveView').removeEventListener('click', saveAndLeaveFunction);
-        document.getElementById('cancelButtonLeaveView').removeEventListener('click', cancelAndLeaveFunction);
-      };
-
-      const cancelAndLeaveFunction: EventListenerOrEventListenerObject = (): void => {
-        this.showLeaveModal = false;
-
-        document.getElementById('dontSaveButtonLeaveView').removeEventListener('click', dontSaveAndLeaveFunction);
-        document.getElementById('saveButtonLeaveView').removeEventListener('click', saveAndLeaveFunction);
-        document.getElementById('cancelButtonLeaveView').removeEventListener('click', cancelAndLeaveFunction);
-
-        resolve(false);
-      };
-
-      this.showLeaveModal = true;
-
-      // register onClick handler
-      document.getElementById('dontSaveButtonLeaveView').addEventListener('click', dontSaveAndLeaveFunction);
-      document.getElementById('saveButtonLeaveView').addEventListener('click', saveAndLeaveFunction);
-      document.getElementById('cancelButtonLeaveView').addEventListener('click', cancelAndLeaveFunction);
-    });
-
-    return modalResult;
   }
 
   public deactivate(): void {

--- a/src/modules/design/design.ts
+++ b/src/modules/design/design.ts
@@ -113,7 +113,7 @@ export class Design {
         this._eventAggregator.publish(environment.events.configPanel.processEngineRouteChanged, this.activeSolutionEntry.uri);
       }
 
-      const isOpenDiagram: boolean = this.activeSolutionEntry.uri === 'Open Diagrams';
+      const isOpenDiagram: boolean = this.activeSolutionEntry.uri === 'about:open-diagrams';
 
       if (isOpenDiagram) {
         const persistedDiagrams: Array<IDiagram> = this._solutionService.getOpenDiagrams();

--- a/src/modules/design/design.ts
+++ b/src/modules/design/design.ts
@@ -42,7 +42,6 @@ export class Design {
   @bindable({defaultBindingMode: bindingMode.oneWay}) public xml: string;
 
   public showSelectDiagramModal: boolean = false;
-
   public showDetail: boolean = true;
   public showXML: boolean = false;
   public showDiff: boolean = false;

--- a/src/modules/design/design.ts
+++ b/src/modules/design/design.ts
@@ -121,10 +121,10 @@ export class Design {
         this._eventAggregator.publish(environment.events.configPanel.processEngineRouteChanged, this.activeSolutionEntry.uri);
       }
 
-      const isSingleDiagram: boolean = this.activeSolutionEntry.uri === 'Single Diagrams';
+      const isOpenDiagram: boolean = this.activeSolutionEntry.uri === 'Open Diagrams';
 
-      if (isSingleDiagram) {
-        const persistedDiagrams: Array<IDiagram> = this._solutionService.getSingleDiagrams();
+      if (isOpenDiagram) {
+        const persistedDiagrams: Array<IDiagram> = this._solutionService.getOpenDiagrams();
 
         this.activeDiagram = persistedDiagrams.find((diagram: IDiagram) => {
           return diagram.name === routeParameters.diagramName &&

--- a/src/modules/design/design.ts
+++ b/src/modules/design/design.ts
@@ -41,7 +41,6 @@ export class Design {
   @bindable() public xmlForDiff: string;
   @bindable({defaultBindingMode: bindingMode.oneWay}) public xml: string;
 
-  public showQuitModal: boolean = false;
   public showSelectDiagramModal: boolean = false;
 
   public showDetail: boolean = true;
@@ -76,11 +75,6 @@ export class Design {
   // TODO: Refactor this function
   // tslint:disable-next-line cyclomatic-complexity
   public async activate(routeParameters: IDesignRouteParameters): Promise<void> {
-    const isRunningInElectron: boolean = Boolean((window as any).nodeRequire);
-    if (isRunningInElectron) {
-      this._prepareSaveModalForClosing();
-    }
-
     const solutionIsSet: boolean = routeParameters.solutionUri !== undefined;
     const diagramNameIsSet: boolean = routeParameters.diagramName !== undefined;
 
@@ -361,43 +355,6 @@ export class Design {
     this.showXML = false;
     this.showPropertyPanelButton = false;
     this.showDiffDestinationButton = true;
-  }
-
-  private _prepareSaveModalForClosing(): void {
-    this._ipcRenderer = (window as any).nodeRequire('electron').ipcRenderer;
-
-    const showCloseModalEventName: string = 'show-close-modal';
-
-    const showCloseModalFunction: Function = (): void => {
-      this.showQuitModal = true;
-    };
-
-    this._ipcRenderer.on(showCloseModalEventName, showCloseModalFunction);
-    this._ipcRendererEventListeners.push({
-                                            name: showCloseModalEventName,
-                                            function: showCloseModalFunction,
-                                        });
-
-  }
-
-  public quitWithoutSaving(): void {
-    this._ipcRenderer.send('can-not-close', false);
-    this._ipcRenderer.send('close-bpmn-studio');
-  }
-
-  public async quitWithSaving(): Promise<void> {
-    if (this.diagramDetail.diagramIsInvalid) {
-      return;
-    }
-
-    await this.diagramDetail.saveDiagram();
-    this.diagramDetail.diagramHasChanged = false;
-
-    this._ipcRenderer.send('close-bpmn-studio');
-  }
-
-  public cancelQuitting(): void {
-    this.showQuitModal = false;
   }
 
   /**

--- a/src/modules/design/diagram-detail/diagram-detail.ts
+++ b/src/modules/design/diagram-detail/diagram-detail.ts
@@ -240,15 +240,6 @@ export class DiagramDetail {
     }
   }
 
-  public diagramHasChangedChanged(): void {
-    const isRunningInElectron: boolean = this._ipcRenderer !== undefined;
-    if (isRunningInElectron) {
-      const canNotClose: boolean = this.diagramHasChanged;
-
-      this._ipcRenderer.send('can-not-close', canNotClose);
-    }
-  }
-
   public async setOptionsAndStart(): Promise<void> {
 
     if (this.hasValidationError) {

--- a/src/modules/design/property-panel/property-panel.ts
+++ b/src/modules/design/property-panel/property-panel.ts
@@ -73,11 +73,28 @@ export class PropertyPanel {
       this.checkIndexTabSuitability();
     });
 
-    this.setFirstElement();
+    setTimeout(() => {
+      this._selectAnElement();
+    }, 0);
   }
 
   public updateIndextab(selectedIndextab: IIndextab): void {
     this._currentIndextabTitle = selectedIndextab.title;
+  }
+
+  private _selectAnElement(): void {
+    const diagramState: IDiagramState = this._openDiagramsStateService.loadDiagramState(this.diagramUri);
+
+    const noSelectedElementState: boolean = diagramState === null || diagramState.metaData.selectedElements.length === 0;
+    if (noSelectedElementState) {
+      this.setFirstElement();
+
+      return;
+    }
+
+    const selectedElementId: string = diagramState.metaData.selectedElements[0].id;
+
+    this._selectElementById(selectedElementId);
   }
 
   private setFirstElement(): void {
@@ -106,11 +123,15 @@ export class PropertyPanel {
         firstElement = process;
       }
 
-      const elementRegistry: IElementRegistry = this.modeler.get('elementRegistry');
-      const elementInPanel: IShape = elementRegistry.get(firstElement.id);
-
-      this.modeler.get('selection').select(elementInPanel);
+      this._selectElementById(firstElement.id);
     }));
+  }
+
+  private _selectElementById(elementId: string): void {
+    const elementRegistry: IElementRegistry = this.modeler.get('elementRegistry');
+    const element: IShape = elementRegistry.get(elementId);
+
+    this.modeler.get('selection').select(element);
   }
 
   private processHasLanes(process: IModdleElement): boolean {
@@ -140,15 +161,14 @@ export class PropertyPanel {
     }
   }
 
-  public diagramUriChanged(newValue: string, oldValue: string): void {
+  public xmlChanged(_: string, oldValue: string): void {
     if (oldValue === undefined) {
       return;
     }
 
     // This is needed to make sure the xml was already imported into the modeler
     setTimeout(() => {
-      this.setFirstElement();
+      this._selectAnElement();
     }, 0);
   }
-
 }

--- a/src/modules/design/property-panel/property-panel.ts
+++ b/src/modules/design/property-panel/property-panel.ts
@@ -1,4 +1,4 @@
-import {bindable} from 'aurelia-framework';
+import {bindable, inject} from 'aurelia-framework';
 
 import {IModdleElement, IShape} from '@process-engine/bpmn-elements_contracts';
 
@@ -6,6 +6,7 @@ import {
   IBpmnModdle,
   IBpmnModeler,
   IDefinition,
+  IDiagramState,
   IElementRegistry,
   IEvent,
   IEventBus,
@@ -15,6 +16,9 @@ import {Extensions} from './indextabs/extensions/extensions';
 import {Forms} from './indextabs/forms/forms';
 import {General} from './indextabs/general/general';
 
+import {OpenDiagramsStateService} from '../../../services/solution-explorer-services/OpenDiagramsStateService';
+
+@inject('OpenDiagramsStateService')
 export class PropertyPanel {
 
   @bindable() public modeler: IBpmnModeler;
@@ -30,6 +34,11 @@ export class PropertyPanel {
   private _moddle: IBpmnModdle;
   private _eventBus: IEventBus;
   private _currentIndextabTitle: string = this.generalIndextab.title;
+  private _openDiagramsStateService: OpenDiagramsStateService;
+
+  constructor(openDiagramsStateService: OpenDiagramsStateService) {
+    this._openDiagramsStateService = openDiagramsStateService;
+  }
 
   public attached(): void {
     this._moddle = this.modeler.get('moddle');

--- a/src/modules/design/property-panel/property-panel.ts
+++ b/src/modules/design/property-panel/property-panel.ts
@@ -163,16 +163,19 @@ export class PropertyPanel {
     }
   }
 
-  public diagramUriChanged(_: string, oldValue: string): void {
-    if (oldValue === undefined) {
+  public diagramUriChanged(newUri: string, previousUri: string): void {
+    const previousUriDoesNotExist: boolean = previousUri === undefined;
+    if (previousUriDoesNotExist) {
       return;
     }
 
     this._diagramChanged = true;
   }
 
-  public xmlChanged(_: string, oldValue: string): void {
-    if (oldValue === undefined || !this._diagramChanged) {
+  public xmlChanged(newXml: string, previousXml: string): void {
+    const previousXmlDoesNotExist: boolean = previousXml === undefined;
+    const diagramDidNotChange: boolean = !this._diagramChanged;
+    if (previousXmlDoesNotExist || diagramDidNotChange) {
       return;
     }
 

--- a/src/modules/design/property-panel/property-panel.ts
+++ b/src/modules/design/property-panel/property-panel.ts
@@ -36,6 +36,8 @@ export class PropertyPanel {
   private _currentIndextabTitle: string = this.generalIndextab.title;
   private _openDiagramsStateService: OpenDiagramsStateService;
 
+  private _diagramChanged: boolean = false;
+
   constructor(openDiagramsStateService: OpenDiagramsStateService) {
     this._openDiagramsStateService = openDiagramsStateService;
   }
@@ -161,8 +163,16 @@ export class PropertyPanel {
     }
   }
 
-  public xmlChanged(_: string, oldValue: string): void {
+  public diagramUriChanged(_: string, oldValue: string): void {
     if (oldValue === undefined) {
+      return;
+    }
+
+    this._diagramChanged = true;
+  }
+
+  public xmlChanged(_: string, oldValue: string): void {
+    if (oldValue === undefined || !this._diagramChanged) {
       return;
     }
 
@@ -170,5 +180,7 @@ export class PropertyPanel {
     setTimeout(() => {
       this._selectAnElement();
     }, 0);
+
+    this._diagramChanged = false;
   }
 }

--- a/src/modules/design/property-panel/property-panel.ts
+++ b/src/modules/design/property-panel/property-panel.ts
@@ -76,7 +76,7 @@ export class PropertyPanel {
     });
 
     setTimeout(() => {
-      this._selectAnElement();
+      this._selectPreviouslySelectedOrFirstElement();
     }, 0);
   }
 
@@ -84,7 +84,7 @@ export class PropertyPanel {
     this._currentIndextabTitle = selectedIndextab.title;
   }
 
-  private _selectAnElement(): void {
+  private _selectPreviouslySelectedOrFirstElement(): void {
     const diagramState: IDiagramState = this._openDiagramStateService.loadDiagramState(this.diagramUri);
 
     const noSelectedElementState: boolean = diagramState === null || diagramState.metaData.selectedElements.length === 0;
@@ -178,7 +178,7 @@ export class PropertyPanel {
 
     // This is needed to make sure the xml was already imported into the modeler
     setTimeout(() => {
-      this._selectAnElement();
+      this._selectPreviouslySelectedOrFirstElement();
     }, 0);
 
     this._diagramChanged = false;

--- a/src/modules/design/property-panel/property-panel.ts
+++ b/src/modules/design/property-panel/property-panel.ts
@@ -16,9 +16,9 @@ import {Extensions} from './indextabs/extensions/extensions';
 import {Forms} from './indextabs/forms/forms';
 import {General} from './indextabs/general/general';
 
-import {OpenDiagramsStateService} from '../../../services/solution-explorer-services/OpenDiagramsStateService';
+import {OpenDiagramStateService} from '../../../services/solution-explorer-services/OpenDiagramStateService';
 
-@inject('OpenDiagramsStateService')
+@inject('OpenDiagramStateService')
 export class PropertyPanel {
 
   @bindable() public modeler: IBpmnModeler;
@@ -34,12 +34,12 @@ export class PropertyPanel {
   private _moddle: IBpmnModdle;
   private _eventBus: IEventBus;
   private _currentIndextabTitle: string = this.generalIndextab.title;
-  private _openDiagramsStateService: OpenDiagramsStateService;
+  private _openDiagramStateService: OpenDiagramStateService;
 
   private _diagramChanged: boolean = false;
 
-  constructor(openDiagramsStateService: OpenDiagramsStateService) {
-    this._openDiagramsStateService = openDiagramsStateService;
+  constructor(openDiagramStateService: OpenDiagramStateService) {
+    this._openDiagramStateService = openDiagramStateService;
   }
 
   public attached(): void {
@@ -85,7 +85,7 @@ export class PropertyPanel {
   }
 
   private _selectAnElement(): void {
-    const diagramState: IDiagramState = this._openDiagramsStateService.loadDiagramState(this.diagramUri);
+    const diagramState: IDiagramState = this._openDiagramStateService.loadDiagramState(this.diagramUri);
 
     const noSelectedElementState: boolean = diagramState === null || diagramState.metaData.selectedElements.length === 0;
     if (noSelectedElementState) {

--- a/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.ts
+++ b/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.ts
@@ -181,7 +181,7 @@ export class DiagramViewer {
       }
     }
 
-    this.fitDiagramToViewport();
+    this._fitDiagramToViewport();
   }
 
   public activeDiagramChanged(): void {
@@ -195,14 +195,14 @@ export class DiagramViewer {
     this.xmlIsNotSelected = true;
     this.xml = undefined;
 
-    this.fitDiagramToViewport();
+    this._fitDiagramToViewport();
   }
 
   public xmlChanged(): void {
     this.xmlIsNotSelected = this.xml === undefined;
   }
 
-  public fitDiagramToViewport(): void {
+  private _fitDiagramToViewport(): void {
     const canvas: ICanvas = this._diagramViewer.get('canvas');
     canvas.zoom('fit-viewport', 'auto');
   }

--- a/src/modules/inspect/inspect.ts
+++ b/src/modules/inspect/inspect.ts
@@ -150,7 +150,7 @@ export class Inspect {
     const diagramIsSet: boolean = diagramName !== undefined;
     if (diagramIsSet) {
 
-      const activeSolutionIsOpenSolution: boolean = solutionUri === 'Open Diagrams';
+      const activeSolutionIsOpenSolution: boolean = solutionUri === 'about:open-diagrams';
       if (activeSolutionIsOpenSolution) {
         const persistedDiagrams: Array<IDiagram> = this._solutionService.getOpenDiagrams();
 

--- a/src/modules/inspect/inspect.ts
+++ b/src/modules/inspect/inspect.ts
@@ -150,9 +150,9 @@ export class Inspect {
     const diagramIsSet: boolean = diagramName !== undefined;
     if (diagramIsSet) {
 
-      const activeSolutionIsSingleDiagramSolution: boolean = solutionUri === 'Single Diagrams';
-      if (activeSolutionIsSingleDiagramSolution) {
-        const persistedDiagrams: Array<IDiagram> = this._solutionService.getSingleDiagrams();
+      const activeSolutionIsOpenSolution: boolean = solutionUri === 'Open Diagrams';
+      if (activeSolutionIsOpenSolution) {
+        const persistedDiagrams: Array<IDiagram> = this._solutionService.getOpenDiagrams();
 
         this.activeDiagram = persistedDiagrams.find((diagram: IDiagram) => {
           return diagram.name === diagramName;

--- a/src/modules/navbar/navbar.ts
+++ b/src/modules/navbar/navbar.ts
@@ -370,7 +370,7 @@ export class NavBar {
 
     if (solutionIsSet && diagramIsSet) {
 
-      const activeSolutionIsOpenDiagramSolution: boolean = solutionUri === 'Open Diagrams';
+      const activeSolutionIsOpenDiagramSolution: boolean = solutionUri === 'about:open-diagrams';
       if (activeSolutionIsOpenDiagramSolution) {
         const persistedDiagrams: Array<IDiagram> = this._solutionService.getOpenDiagrams();
 

--- a/src/modules/navbar/navbar.ts
+++ b/src/modules/navbar/navbar.ts
@@ -370,9 +370,9 @@ export class NavBar {
 
     if (solutionIsSet && diagramIsSet) {
 
-      const activeSolutionIsSingleDiagramSolution: boolean = solutionUri === 'Single Diagrams';
-      if (activeSolutionIsSingleDiagramSolution) {
-        const persistedDiagrams: Array<IDiagram> = this._solutionService.getSingleDiagrams();
+      const activeSolutionIsOpenDiagramSolution: boolean = solutionUri === 'Open Diagrams';
+      if (activeSolutionIsOpenDiagramSolution) {
+        const persistedDiagrams: Array<IDiagram> = this._solutionService.getOpenDiagrams();
 
         this.activeDiagram = persistedDiagrams.find((diagram: IDiagram) => {
           return diagram.name === diagramName;

--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.html
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.html
@@ -14,7 +14,7 @@
           <span class="solution-entry__solution-name">${getSolutionName(solutionEntry.uri)}</span>
           <div class="solution-entry__solution-path">
             <span
-              if.bind="!solutionEntryIsRemote(solutionEntry) && getSolutionName(solutionEntry.uri) !== solutionEntry.uri"
+              if.bind="!solutionEntryIsRemote(solutionEntry) && getSolutionName(solutionEntry.uri) !== solutionEntry.uri && solutionEntry.uri !== 'about:open-diagrams'"
               title.bind="solutionEntry.uri">
               ${solutionEntry.uri}
             </span>

--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.html
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.html
@@ -70,8 +70,8 @@
         <solution-explorer-solution
           displayed-solution-entry.bind="solutionEntry"
           solution-service.bind="solutionEntry.service"
-          single-diagram-service.bind="singleDiagramService"
-          solution-is-single-diagrams.bind="solutionEntry.isSingleDiagramService"
+          open-diagram-service.bind="openDiagramService"
+          solution-is-open-diagrams.bind="solutionEntry.isOpenDiagramService"
           view-model.ref="solutionEntryViewModels[solutionEntry.uri]"
           font-awesome-icon-class.two-way="solutionEntry.fontAwesomeIconClass">
         </solution-explorer-solution>

--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
@@ -349,7 +349,7 @@ export class SolutionExplorerList {
     const fileSystemSolutionExplorer: ISolutionExplorerService = await this._solutionExplorerServiceFactory.newFileSystemSolutionExplorer();
 
     const uriOfOpenDiagramService: string = 'about:open-diagrams';
-    const nameOfOpenDiagramService: string = 'about:open-diagrams';
+    const nameOfOpenDiagramService: string = 'Open Diagrams';
 
     this.openDiagramService = new OpenDiagramsSolutionExplorerService(
         this._diagramValidationService,

--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
@@ -276,6 +276,11 @@ export class SolutionExplorerList {
       return solutionUri;
     }
 
+    const isOpenDiagrams: boolean = solutionUri === 'about:open-diagrams';
+    if (isOpenDiagrams) {
+      return 'Open Diagrams';
+    }
+
     const lastIndexOfSlash: number = solutionUri.lastIndexOf('/');
     const lastIndexOfBackSlash: number = solutionUri.lastIndexOf('\\');
     const lastFolderIndex: number = Math.max(lastIndexOfSlash, lastIndexOfBackSlash) + 1;

--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
@@ -118,7 +118,7 @@ export class SolutionExplorerList {
 
   public getOpenDiagramSolutionEntry(): ISolutionEntry {
     return this._openedSolutions.find((entry: ISolutionEntry) => {
-      return entry.uri === 'Open Diagrams';
+      return entry.uri === 'about:open-diagrams';
     });
   }
 
@@ -343,8 +343,8 @@ export class SolutionExplorerList {
 
     const fileSystemSolutionExplorer: ISolutionExplorerService = await this._solutionExplorerServiceFactory.newFileSystemSolutionExplorer();
 
-    const uriOfOpenDiagramService: string = 'Open Diagrams';
-    const nameOfOpenDiagramService: string = 'Open Diagrams';
+    const uriOfOpenDiagramService: string = 'about:open-diagrams';
+    const nameOfOpenDiagramService: string = 'about:open-diagrams';
 
     this.openDiagramService = new OpenDiagramsSolutionExplorerService(
         this._diagramValidationService,

--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
@@ -14,7 +14,7 @@ import {
   ISolutionService,
   IUserIdentity,
 } from '../../../contracts';
-import {SingleDiagramsSolutionExplorerService} from '../../../services/solution-explorer-services/SingleDiagramsSolutionExplorerService';
+import {OpenDiagramsSolutionExplorerService} from '../../../services/solution-explorer-services/OpenDiagramsSolutionExplorerService';
 import {SolutionExplorerServiceFactory} from '../../../services/solution-explorer-services/SolutionExplorerServiceFactory';
 import {SolutionExplorerSolution} from '../solution-explorer-solution/solution-explorer-solution';
 
@@ -26,10 +26,10 @@ interface IUriToViewModelMap {
 export class SolutionExplorerList {
   public internalSolutionUri: string;
   /**
-   * Reference on the service used to open single diagrams.
+   * Reference on the service used to open open diagrams.
    * This service is also put inside the map.
    */
-  public singleDiagramService: SingleDiagramsSolutionExplorerService;
+  public openDiagramService: OpenDiagramsSolutionExplorerService;
 
   private _router: Router;
   private _eventAggregator: EventAggregator;
@@ -65,7 +65,7 @@ export class SolutionExplorerList {
 
     const canReadFromFileSystem: boolean = (window as any).nodeRequire;
     if (canReadFromFileSystem) {
-      this._createSingleDiagramServiceEntry();
+      this._createOpenDiagramServiceEntry();
     }
 
     // Allows us to debug the solution explorer list.
@@ -100,25 +100,25 @@ export class SolutionExplorerList {
     this._router.navigateToRoute('settings');
   }
 
-  public async openSingleDiagram(uri: string): Promise<IDiagram> {
+  public async openDiagram(uri: string): Promise<IDiagram> {
     const identity: IIdentity = this._createIdentityForSolutionExplorer();
 
-    const diagram: IDiagram = await this.singleDiagramService.openSingleDiagram(uri, identity);
+    const diagram: IDiagram = await this.openDiagramService.openDiagram(uri, identity);
 
     return diagram;
   }
 
   /**
-   * Gets the single diagram with the given uri, if the diagram was opened
+   * Gets the diagram with the given uri, if the diagram was opened
    * before.
    */
-  public getOpenedSingleDiagramByURI(uri: string): IDiagram | null {
-    return this.singleDiagramService.getOpenedDiagramByURI(uri);
+  public getOpenedDiagramByURI(uri: string): IDiagram | null {
+    return this.openDiagramService.getOpenedDiagramByURI(uri);
   }
 
-  public getSingleDiagramSolutionEntry(): ISolutionEntry {
+  public getOpenDiagramSolutionEntry(): ISolutionEntry {
     return this._openedSolutions.find((entry: ISolutionEntry) => {
-      return entry.uri === 'Single Diagrams';
+      return entry.uri === 'Open Diagrams';
     });
   }
 
@@ -297,16 +297,16 @@ export class SolutionExplorerList {
   /*
    * Give aurelia a hint on what objects to observe.
    * If we dont do this, it falls back to active pooling which is slow.
-   * `singleDiagramService._openedDiagrams.length` observed because
+   * `openDiagramService._openedDiagrams.length` observed because
    * aurelia cannot see the business rules happening in this._shouldDisplaySolution().
    */
-  @computedFrom('_openedSolutions.length', 'singleDiagramService._openedDiagrams.length')
+  @computedFrom('_openedSolutions.length', 'openDiagramService._openedDiagrams.length')
   public get openedSolutions(): Array<ISolutionEntry> {
     const filteredEntries: Array<ISolutionEntry> = this._openedSolutions
       .filter(this._shouldDisplaySolution);
 
     const sortedEntries: Array<ISolutionEntry> = filteredEntries.sort((solutionA: ISolutionEntry, solutionB: ISolutionEntry) => {
-      if (solutionA.isSingleDiagramService) {
+      if (solutionA.isOpenDiagramService) {
         return -1;
       }
 
@@ -339,24 +339,24 @@ export class SolutionExplorerList {
   /**
    * Add entry for single file service.
    */
-  private async _createSingleDiagramServiceEntry(): Promise<void> {
+  private async _createOpenDiagramServiceEntry(): Promise<void> {
 
     const fileSystemSolutionExplorer: ISolutionExplorerService = await this._solutionExplorerServiceFactory.newFileSystemSolutionExplorer();
 
-    const uriOfSingleDiagramService: string = 'Single Diagrams';
-    const nameOfSingleDiagramService: string = 'Single Diagrams';
+    const uriOfOpenDiagramService: string = 'Open Diagrams';
+    const nameOfOpenDiagramService: string = 'Open Diagrams';
 
-    this.singleDiagramService = new SingleDiagramsSolutionExplorerService(
+    this.openDiagramService = new OpenDiagramsSolutionExplorerService(
         this._diagramValidationService,
         fileSystemSolutionExplorer,
-        uriOfSingleDiagramService,
-        nameOfSingleDiagramService,
+        uriOfOpenDiagramService,
+        nameOfOpenDiagramService,
         this._solutionService,
       );
 
     const identity: IIdentity = this._createIdentityForSolutionExplorer();
 
-    this._addSolutionEntry(uriOfSingleDiagramService, this.singleDiagramService, identity, true);
+    this._addSolutionEntry(uriOfOpenDiagramService, this.openDiagramService, identity, true);
   }
 
   private _getFontAwesomeIconForSolution(service: ISolutionExplorerService, uri: string): string {
@@ -365,8 +365,8 @@ export class SolutionExplorerList {
       return 'fa-database';
     }
 
-    const solutionIsSingleDiagrams: boolean = service === this.singleDiagramService;
-    if (solutionIsSingleDiagrams) {
+    const solutionIsOpenDiagrams: boolean = service === this.openDiagramService;
+    if (solutionIsOpenDiagrams) {
       return 'fa-copy';
     }
 
@@ -375,22 +375,22 @@ export class SolutionExplorerList {
 
   private _canCreateNewDiagramsInSolution(service: ISolutionExplorerService, uri: string): boolean {
     const solutionIsNotOpenedFromRemote: boolean = !uri.startsWith('http');
-    const solutionIsNotSingleDiagrams: boolean = service !== this.singleDiagramService;
+    const solutionIsNotOpenDiagrams: boolean = service !== this.openDiagramService;
 
-    return solutionIsNotOpenedFromRemote && solutionIsNotSingleDiagrams;
+    return solutionIsNotOpenedFromRemote && solutionIsNotOpenDiagrams;
   }
 
   private _canCloseSolution(service: ISolutionExplorerService, uri: string): boolean {
-    const solutionIsNotSingleDiagrams: boolean = !this._isSingleDiagramService(service);
+    const solutionIsNotOpenDiagrams: boolean = !this._isOpenDiagramService(service);
 
     const internalProcessEngineRoute: string = window.localStorage.getItem('InternalProcessEngineRoute');
     const solutionIsNotInternalSolution: boolean = uri !== internalProcessEngineRoute;
 
-    return solutionIsNotSingleDiagrams && solutionIsNotInternalSolution;
+    return solutionIsNotOpenDiagrams && solutionIsNotInternalSolution;
   }
 
-  private _isSingleDiagramService(service: ISolutionExplorerService): boolean {
-    return service === this.singleDiagramService;
+  private _isOpenDiagramService(service: ISolutionExplorerService): boolean {
+    return service === this.openDiagramService;
   }
 
   /**
@@ -400,11 +400,11 @@ export class SolutionExplorerList {
   private _shouldDisplaySolution(entry: ISolutionEntry): boolean {
     const service: ISolutionExplorerService = entry.service;
 
-    const isSingleDiagramService: boolean = (service as any).getOpenedDiagrams !== undefined;
-    if (isSingleDiagramService) {
-      const singleDiagramService: SingleDiagramsSolutionExplorerService = service as SingleDiagramsSolutionExplorerService;
+    const isOpenDiagramService: boolean = (service as any).getOpenedDiagrams !== undefined;
+    if (isOpenDiagramService) {
+      const openDiagramService: OpenDiagramsSolutionExplorerService = service as OpenDiagramsSolutionExplorerService;
 
-      const someDiagramsAreOpened: boolean = singleDiagramService.getOpenedDiagrams().length > 0;
+      const someDiagramsAreOpened: boolean = openDiagramService.getOpenedDiagrams().length > 0;
 
       return someDiagramsAreOpened;
     }
@@ -425,8 +425,8 @@ export class SolutionExplorerList {
     identity: IIdentity,
     insertAtBeginning: boolean,
     processEngineVersion?: string,
-    ): Promise<void> {
-    const isSingleDiagramService: boolean = this._isSingleDiagramService(service);
+  ): Promise<void> {
+    const isOpenDiagramService: boolean = this._isOpenDiagramService(service);
     const fontAwesomeIconClass: string = this._getFontAwesomeIconForSolution(service, uri);
     const canCloseSolution: boolean = this._canCloseSolution(service, uri);
     const canCreateNewDiagramsInSolution: boolean = this._canCreateNewDiagramsInSolution(service, uri);
@@ -451,7 +451,7 @@ export class SolutionExplorerList {
       fontAwesomeIconClass,
       canCloseSolution,
       canCreateNewDiagramsInSolution,
-      isSingleDiagramService,
+      isOpenDiagramService,
       identity,
       authority,
       isLoggedIn,

--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
@@ -312,12 +312,12 @@ export class SolutionExplorerList {
 
       const solutionAIsInternalProcessEngine: boolean = solutionA.uri === window.localStorage.getItem('InternalProcessEngineRoute');
       if (solutionAIsInternalProcessEngine) {
-        return -1;
+        return 1;
       }
 
       return solutionA.uri.startsWith('http') && !solutionB.uri.startsWith('http')
-              ? -1
-              : 1;
+              ? 1
+              : -1;
     });
 
     return sortedEntries;

--- a/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.html
+++ b/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.html
@@ -38,7 +38,7 @@
       </div>
 
       <input class="solution-explorer-panel__input d-none" ref="solutionInput" type="file" change.delegate="onSolutionInputChange($event)" webkitdirectory>
-      <input class="solution-explorer-panel__input d-none" ref="singleDiagramInput" type="file" change.delegate="onSingleDiagramInputChange($event)" accept=".xml, application/xml, .bpmn, application/bpmn20-xml">
+      <input class="solution-explorer-panel__input d-none" ref="openDiagramInput" type="file" change.delegate="onOpenDiagramInputChange($event)" accept=".xml, application/xml, .bpmn, application/bpmn20-xml">
 
       <solution-explorer-list view-model.ref="solutionExplorerList"></solution-explorer-list>
 

--- a/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.ts
+++ b/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.ts
@@ -36,7 +36,7 @@ export class SolutionExplorerPanel {
   // Fields below are bound from the html view.
   public solutionExplorerList: SolutionExplorerList;
   public solutionInput: HTMLInputElement;
-  public singleDiagramInput: HTMLInputElement;
+  public openDiagramInput: HTMLInputElement;
   public showOpenRemoteSolutionModal: boolean = false;
   public uriOfRemoteSolution: string;
   public solutionExplorerPanel: SolutionExplorerPanel = this;
@@ -91,10 +91,10 @@ export class SolutionExplorerPanel {
       }
     });
 
-    const persistedSingleDiagrams: Array<IDiagram> = this._solutionService.getSingleDiagrams();
-    persistedSingleDiagrams.forEach(async(diagram: IDiagram) => {
+    const persistedOpenDiagrams: Array<IDiagram> = this._solutionService.getOpenDiagrams();
+    persistedOpenDiagrams.forEach(async(diagram: IDiagram) => {
       try {
-        await this.solutionExplorerList.openSingleDiagram(diagram.uri);
+        await this.solutionExplorerList.openDiagram(diagram.uri);
       } catch {
         return;
       }
@@ -116,10 +116,10 @@ export class SolutionExplorerPanel {
       this._eventAggregator.subscribe(environment.events.startPage.openLocalSolution, () => {
         this.openSolution();
       }),
-      this._eventAggregator.subscribe(environment.events.startPage.openSingleDiagram, () => {
+      this._eventAggregator.subscribe(environment.events.startPage.openDiagram, () => {
         this.openDiagram();
       }),
-      this._eventAggregator.subscribe(environment.events.startPage.createSingleDiagram, () => {
+      this._eventAggregator.subscribe(environment.events.startPage.createDiagram, () => {
         this._createNewDiagram();
       }),
       this._eventAggregator.subscribe(AuthenticationStateEvent.LOGOUT, () => {
@@ -180,28 +180,28 @@ export class SolutionExplorerPanel {
   }
 
   /**
-   * Handles the file input change event for the single file input.
+   * Handles the file input change event for the open file input.
    * @param event An event that holds the files that were "uploaded" by the user.
    * Currently there is no type for this kind of event.
    */
-  public async onSingleDiagramInputChange(event: IInputEvent): Promise<void> {
+  public async onOpenDiagramInputChange(event: IInputEvent): Promise<void> {
     const uri: string = event.target.files[0].path;
-    this.singleDiagramInput.value = '';
+    this.openDiagramInput.value = '';
 
-    return this._openSingleDiagramOrDisplayError(uri);
+    return this._openDiagramOrDisplayError(uri);
   }
 
   public async openDiagram(): Promise<void> {
     const canNotReadFromFileSystem: boolean = !this.canReadFromFileSystem();
     if (canNotReadFromFileSystem) {
-      this.singleDiagramInput.click();
+      this.openDiagramInput.click();
 
       return;
     }
 
-    this._ipcRenderer.send('open_single_diagram');
+    this._ipcRenderer.send('open_diagram');
 
-    this._ipcRenderer.once('import_opened_single_diagram', async(event: Event, openedFile: File) => {
+    this._ipcRenderer.once('import_opened_diagram', async(event: Event, openedFile: File) => {
       const noFileSelected: boolean = openedFile === null;
       if (noFileSelected) {
         return;
@@ -209,7 +209,7 @@ export class SolutionExplorerPanel {
 
       const filePath: string = openedFile[0];
 
-      await this._openSingleDiagramOrDisplayError(filePath);
+      await this._openDiagramOrDisplayError(filePath);
     });
   }
 
@@ -270,20 +270,20 @@ export class SolutionExplorerPanel {
     }
   }
 
-  private async _openSingleDiagramOrDisplayError(uri: string): Promise<void> {
+  private async _openDiagramOrDisplayError(uri: string): Promise<void> {
     try {
 
-      const openedDiagram: IDiagram = await this.solutionExplorerList.openSingleDiagram(uri);
-      const solution: ISolutionEntry = this.solutionExplorerList.getSingleDiagramSolutionEntry();
+      const openedDiagram: IDiagram = await this.solutionExplorerList.openDiagram(uri);
+      const solution: ISolutionEntry = this.solutionExplorerList.getOpenDiagramSolutionEntry();
 
-      this._solutionService.addSingleDiagram(openedDiagram);
+      this._solutionService.addOpenDiagram(openedDiagram);
 
       await this._navigateToDetailView(openedDiagram, solution);
 
     } catch (error) {
       // The diagram may already be opened.
-      const diagram: IDiagram | null = await this.solutionExplorerList.getOpenedSingleDiagramByURI(uri);
-      const solution: ISolutionEntry = this.solutionExplorerList.getSingleDiagramSolutionEntry();
+      const diagram: IDiagram | null = await this.solutionExplorerList.getOpenedDiagramByURI(uri);
+      const solution: ISolutionEntry = this.solutionExplorerList.getOpenDiagramSolutionEntry();
 
       const diagramWithURIIsAlreadyOpened: boolean = diagram !== null;
       if (diagramWithURIIsAlreadyOpened) {
@@ -296,7 +296,7 @@ export class SolutionExplorerPanel {
 
   private _electronFileOpeningHook = async(_: Event, pathToFile: string): Promise<void> => {
     const uri: string = pathToFile;
-    this._openSingleDiagramOrDisplayError(uri);
+    this._openDiagramOrDisplayError(uri);
   }
 
   private _electronOnMenuOpenDiagramHook = async(_: Event): Promise<void> => {
@@ -344,7 +344,7 @@ export class SolutionExplorerPanel {
     if (fileInfo.path) {
       // There was a file opened before BPMN-Studio was loaded, open it.
       const uri: string = fileInfo.path;
-      this._openSingleDiagramOrDisplayError(uri);
+      this._openDiagramOrDisplayError(uri);
     }
   }
 
@@ -370,7 +370,7 @@ export class SolutionExplorerPanel {
 
     const openingPromises: Array<Promise<void>> = urisToOpen
       .map((uri: string): Promise<void> => {
-        return this._openSingleDiagramOrDisplayError(uri);
+        return this._openDiagramOrDisplayError(uri);
       });
 
     await Promise.all(openingPromises);

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.html
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.html
@@ -44,8 +44,8 @@
 
           <i if.bind="shouldFileIconBeShown()" class="diagram-entry__icon fa fa-cogs"></i>
           <div class="diagram-entry__name-container" contextmenu.delegate="activateContextMenu($event, diagram)">
-            <span class="diagram-entry__name" title="${diagram.name}" title.bind="solutionIsSingleDiagrams ? diagram.uri : ''">${diagram.name}</span>
-            <span class="diagram-entry__location" if.bind="solutionIsSingleDiagrams" title="${getDiagramLocation(diagram.uri)}">${getDiagramFolder(diagram.uri)}</span>
+            <span class="diagram-entry__name" title="${diagram.name}" title.bind="solutionIsOpenDiagrams ? diagram.uri : ''">${diagram.name}</span>
+            <span class="diagram-entry__location" if.bind="solutionIsOpenDiagrams" title="${getDiagramLocation(diagram.uri)}">${getDiagramFolder(diagram.uri)}</span>
           </div>
 
           <div class="diagram-entry__actions">
@@ -60,7 +60,7 @@
 
             <button
               class="button"
-              if.bind="solutionIsSingleDiagrams"
+              if.bind="solutionIsOpenDiagrams"
               click.delegate="closeDiagram(diagram, $event)"
               title="Close the diagram">
 

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.html
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.html
@@ -91,8 +91,8 @@
          body-text="Your diagram has unsaved changes. Save changes to diagram before closing?">
     <template replace-part="modal-footer">
       <button type="button" class="btn btn-default" data-dismiss="modal" id="cancelButtonCloseView">Cancel</button>
-      <button type="button" class="btn btn-default" data-dismiss="modal" id="dontSaveButtonCloseView">Don't save</button>
-      <button type="button" class="btn btn-default" data-dismiss="modal" id="saveButtonCloseView">Save</button>
+      <button type="button" class="btn btn-secondary" data-dismiss="modal" id="dontSaveButtonCloseView">Don't save</button>
+      <button type="button" class="btn btn-primary" data-dismiss="modal" id="saveButtonCloseView">Save</button>
     </template>
   </modal>
 

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.html
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.html
@@ -85,4 +85,14 @@
   <!--Delete Diagram Modal-->
   <delete-diagram-modal view-model.ref="deleteDiagramModal"></delete-diagram-modal>
 
+  <modal show.bind="showCloseModal"
+         header-text="Document Contains Changes"
+         body-text="Your diagram has unsaved changes. Save changes to diagram before closing?">
+    <template replace-part="modal-footer">
+      <button type="button" class="btn btn-default" data-dismiss="modal" id="cancelButtonCloseView">Cancel</button>
+      <button type="button" class="btn btn-default" data-dismiss="modal" id="dontSaveButtonCloseView">Don't save</button>
+      <button type="button" class="btn btn-default" data-dismiss="modal" id="saveButtonCloseView">Save</button>
+    </template>
+  </modal>
+
 </template>

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.html
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.html
@@ -43,7 +43,7 @@
         <template if.bind="currentlyRenamingDiagramUri !== diagram.uri">
 
           <i if.bind="shouldFileIconBeShown()" class="diagram-entry__icon fa fa-cogs"></i>
-          <i if.bind="solutionIsOpenDiagrams && diagramChangedStateMap.get(diagram.uri)" class="diagram-entry__icon fas fa-circle"></i>
+          <i if.bind="solutionIsOpenDiagrams && diagramChangedStateMap.get(diagram.uri)" class="diagram-entry__unsaved-icon fas fa-circle"></i>
           <div class="diagram-entry__name-container" contextmenu.delegate="activateContextMenu($event, diagram)">
             <span class="diagram-entry__name" title="${diagram.name}" title.bind="solutionIsOpenDiagrams ? diagram.uri : ''">${diagram.name}</span>
             <span class="diagram-entry__location" if.bind="solutionIsOpenDiagrams" title="${getDiagramLocation(diagram.uri)}">${getDiagramFolder(diagram.uri)}</span>

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.html
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.html
@@ -43,6 +43,7 @@
         <template if.bind="currentlyRenamingDiagramUri !== diagram.uri">
 
           <i if.bind="shouldFileIconBeShown()" class="diagram-entry__icon fa fa-cogs"></i>
+          <i if.bind="solutionIsOpenDiagrams && diagramChangedStateMap.get(diagram.uri)" class="diagram-entry__icon fas fa-circle"></i>
           <div class="diagram-entry__name-container" contextmenu.delegate="activateContextMenu($event, diagram)">
             <span class="diagram-entry__name" title="${diagram.name}" title.bind="solutionIsOpenDiagrams ? diagram.uri : ''">${diagram.name}</span>
             <span class="diagram-entry__location" if.bind="solutionIsOpenDiagrams" title="${getDiagramLocation(diagram.uri)}">${getDiagramFolder(diagram.uri)}</span>

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.scss
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.scss
@@ -87,6 +87,7 @@
   margin-top: 6px;
   margin-right: -9px;
   font-size: 9px;
+  opacity: 0.5;
 }
 
 .diagram-entry__name-container {

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.scss
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.scss
@@ -80,6 +80,15 @@
   margin-right: 6px;
 }
 
+.diagram-entry__unsaved-icon {
+  flex: 0;
+  position: relative;
+  left: -14px;
+  margin-top: 6px;
+  margin-right: -9px;
+  font-size: 9px;
+}
+
 .diagram-entry__name-container {
   flex: 1;
   overflow: hidden;

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -130,7 +130,7 @@ export class SolutionExplorerSolution {
     this._isAttached = true;
 
     this._originalIconClass = this.fontAwesomeIconClass;
-    this._updateSolutionExplorer();
+    await this._updateSolutionExplorer();
     this._setValidationRules();
 
     this._subscriptions = [
@@ -139,8 +139,10 @@ export class SolutionExplorerSolution {
       }),
     ];
 
+    setTimeout(async() => {
     await this.updateSolution();
     this._startPolling();
+    }, 0);
   }
 
   public detached(): void {

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -499,6 +499,7 @@ export class SolutionExplorerSolution {
 
     if (diagramIsNotYetOpened && diagramIsFromLocalSolution) {
       await this.singleDiagramService.openSingleDiagram(diagram.uri, this._createIdentityForSolutionExplorer());
+      await this.singleDiagramService.saveDiagram(openedDiagram);
     }
 
     this.navigateToDetailView(diagram);

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -207,6 +207,10 @@ export class SolutionExplorerSolution {
    * Reload the solution by requesting it from the solution service.
    */
   public async updateSolution(): Promise<void> {
+    if (this.solutionIsOpenDiagrams) {
+      return;
+    }
+
     try {
       this._openedSolution = await this.solutionService.loadSolution();
       const updatedDiagramList: Array<IDiagram> = this._openedSolution.diagrams.sort(this._diagramSorter);
@@ -514,6 +518,10 @@ export class SolutionExplorerSolution {
   }
 
   private _startPolling(): void {
+    if (this.solutionIsOpenDiagrams) {
+      return;
+    }
+
     this._refreshTimeoutTask = setTimeout(async() =>  {
 
       await this.updateSolution();

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -149,8 +149,8 @@ export class SolutionExplorerSolution {
     }
 
     setTimeout(async() => {
-    await this.updateSolution();
-    this._startPolling();
+      await this.updateSolution();
+      this._startPolling();
     }, 0);
   }
 

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -1,3 +1,4 @@
+// tslint:disable no-use-before-declare
 import {EventAggregator, Subscription} from 'aurelia-event-aggregator';
 import {
   bindable,
@@ -20,10 +21,11 @@ import {join} from 'path';
 
 import {IIdentity} from '@essential-projects/iam_contracts';
 import {
-        IDiagramCreationService,
-        ISolutionEntry,
-        ISolutionService,
-        NotificationType,
+  IDiagramCreationService,
+  IDiagramState,
+  ISolutionEntry,
+  ISolutionService,
+  NotificationType,
 } from '../../../contracts/index';
 import environment from '../../../environment';
 import {NotificationService} from '../../../services/notification-service/notification.service';
@@ -579,7 +581,7 @@ export class SolutionExplorerSolution {
     await this._navigateToDetailView(diagramToSave);
 
     const modalResult: Promise<boolean> = new Promise((resolve: Function, reject: Function): boolean | void => {
-      const dontSaveFunction: EventListenerOrEventListenerObject = async (): Promise<void> => {
+      const dontSaveFunction: EventListenerOrEventListenerObject = async(): Promise<void> => {
         this.showCloseModal = false;
 
         document.getElementById('dontSaveButtonCloseView').removeEventListener('click', dontSaveFunction);

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -433,35 +433,6 @@ export class SolutionExplorerSolution {
     return diagramFolder;
   }
 
-  // TODO: This method is copied all over the place.
-  public async navigateToDetailView(diagram: IDiagram): Promise<void> {
-    const diagramIsNoRemoteDiagram: boolean = !diagram.uri.startsWith('http');
-    if (diagramIsNoRemoteDiagram) {
-      const viewIsHeatmapOrInspectCorrelation: boolean = this._inspectView === 'inspect-correlation'
-                                                      || this._inspectView === 'heatmap';
-
-      if (viewIsHeatmapOrInspectCorrelation) {
-        this._inspectView = 'dashboard';
-      }
-
-      this._eventAggregator.publish(environment.events.navBar.inspectNavigateToDashboard);
-
-      const activeRouteIsInspect: boolean = this._diagramRoute === 'inspect';
-      if (activeRouteIsInspect) {
-        this._notificationService.showNotification(NotificationType.INFO,
-          'There are currently no runtime information about this process available.');
-      }
-    }
-
-    await this._router.navigateToRoute(this._diagramRoute, {
-      view: this._inspectView ? this._inspectView : this._designView,
-      diagramName: diagram.name,
-      diagramUri: diagram.uri,
-      solutionUri: this.displayedSolutionEntry.uri,
-    });
-
-  }
-
   @computedFrom('activeDiagram.uri')
   public get activeDiagramUri(): string {
     const activeDiagramIsNotSet: boolean = this.activeDiagram === undefined;
@@ -513,7 +484,36 @@ export class SolutionExplorerSolution {
       await this.openDiagramService.saveDiagram(openedDiagram);
     }
 
-    this.navigateToDetailView(diagram);
+    this._navigateToDetailView(diagram);
+  }
+
+  // TODO: This method is copied all over the place.
+  private async _navigateToDetailView(diagram: IDiagram): Promise<void> {
+    const diagramIsNoRemoteDiagram: boolean = !diagram.uri.startsWith('http');
+    if (diagramIsNoRemoteDiagram) {
+      const viewIsHeatmapOrInspectCorrelation: boolean = this._inspectView === 'inspect-correlation'
+                                                      || this._inspectView === 'heatmap';
+
+      if (viewIsHeatmapOrInspectCorrelation) {
+        this._inspectView = 'dashboard';
+      }
+
+      this._eventAggregator.publish(environment.events.navBar.inspectNavigateToDashboard);
+
+      const activeRouteIsInspect: boolean = this._diagramRoute === 'inspect';
+      if (activeRouteIsInspect) {
+        this._notificationService.showNotification(NotificationType.INFO,
+          'There are currently no runtime information about this process available.');
+      }
+    }
+
+    await this._router.navigateToRoute(this._diagramRoute, {
+      view: this._inspectView ? this._inspectView : this._designView,
+      diagramName: diagram.name,
+      diagramUri: diagram.uri,
+      solutionUri: this.displayedSolutionEntry.uri,
+    });
+
   }
 
   private _createIdentityForSolutionExplorer(): IIdentity {
@@ -561,7 +561,7 @@ export class SolutionExplorerSolution {
   }
 
   private async _shouldCloseDiagramModal(diagramToSave: IDiagram): Promise<boolean> {
-    await this.navigateToDetailView(diagramToSave);
+    await this._navigateToDetailView(diagramToSave);
 
     const modalResult: Promise<boolean> = new Promise((resolve: Function, reject: Function): boolean | void => {
       const dontSaveFunction: EventListenerOrEventListenerObject = async (): Promise<void> => {
@@ -718,7 +718,7 @@ export class SolutionExplorerSolution {
 
     await this.updateSolution();
     this._resetDiagramCreation();
-    this.navigateToDetailView(emptyDiagram);
+    this._navigateToDetailView(emptyDiagram);
   }
 
   /**
@@ -740,7 +740,7 @@ export class SolutionExplorerSolution {
 
       await this.updateSolution();
       this._resetDiagramCreation();
-      this.navigateToDetailView(emptyDiagram);
+      this._navigateToDetailView(emptyDiagram);
 
     } else if (pressedKey === ESCAPE_KEY) {
       this._resetDiagramCreation();

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -507,12 +507,7 @@ export class SolutionExplorerSolution {
     const diagramIsFromLocalSolution: boolean = !this._isUriFromRemoteSolution(diagram.uri);
 
     if (diagramIsNotYetOpened && diagramIsFromLocalSolution) {
-      const openedDiagram: IDiagram = await this.openDiagramService.openDiagram(diagram.uri, this._createIdentityForSolutionExplorer());
-      await this.openDiagramService.saveDiagram(openedDiagram);
-    }
-
-    if (!this._isUriFromRemoteSolution(diagram.uri) && !this.solutionIsOpenDiagrams) {
-      this._eventAggregator.publish(environment.events.solutionExplorer.updateOpenDiagrams);
+      await this.openDiagramService.openDiagramFromSolution(diagram.uri, this._createIdentityForSolutionExplorer());
     }
 
     this._navigateToDetailView(diagram);

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -622,12 +622,12 @@ export class SolutionExplorerSolution {
         resolve(false);
       };
 
-      this.showCloseModal = true;
-
       // register onClick handler
       document.getElementById('dontSaveButtonCloseView').addEventListener('click', dontSaveFunction);
       document.getElementById('saveButtonCloseView').addEventListener('click', saveFunction);
       document.getElementById('cancelButtonCloseView').addEventListener('click', cancelFunction);
+
+      this.showCloseModal = true;
     });
 
     return modalResult;

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -515,6 +515,7 @@ export class SolutionExplorerSolution {
 
   private _startPolling(): void {
     this._refreshTimeoutTask = setTimeout(async() =>  {
+
       await this.updateSolution();
 
       if (this._isAttached) {

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -28,6 +28,7 @@ import {
 import environment from '../../../environment';
 import {NotificationService} from '../../../services/notification-service/notification.service';
 import {OpenDiagramsSolutionExplorerService} from '../../../services/solution-explorer-services/OpenDiagramsSolutionExplorerService';
+import {OpenDiagramsStateService} from '../../../services/solution-explorer-services/OpenDiagramsStateService';
 import {DeleteDiagramModal} from './delete-diagram-modal/delete-diagram-modal';
 
 const ENTER_KEY: string = 'Enter';
@@ -50,6 +51,7 @@ interface IDiagramCreationState extends IDiagramNameInputState {
   'DiagramCreationService',
   'NotificationService',
   'SolutionService',
+  'OpenDiagramsStateService',
 )
 export class SolutionExplorerSolution {
 
@@ -60,6 +62,7 @@ export class SolutionExplorerSolution {
   private _validationController: ValidationController;
   private _diagramCreationService: IDiagramCreationService;
   private _notificationService: NotificationService;
+  private _openDiagramStateService: OpenDiagramsStateService;
 
   private _diagramRoute: string = 'design';
   private _inspectView: string;
@@ -109,6 +112,7 @@ export class SolutionExplorerSolution {
     diagramCreationService: IDiagramCreationService,
     notificationService: NotificationService,
     solutionService: ISolutionService,
+    openDiagramStateService: OpenDiagramsStateService,
   ) {
     this._router = router;
     this._eventAggregator = eventAggregator;
@@ -116,6 +120,7 @@ export class SolutionExplorerSolution {
     this._diagramCreationService = diagramCreationService;
     this._notificationService = notificationService;
     this._globalSolutionService = solutionService;
+    this._openDiagramStateService = openDiagramStateService;
   }
 
   public async attached(): Promise<void> {

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -245,6 +245,7 @@ export class SolutionExplorerSolution {
 
     if (diagramHasUnsavedChanges) {
       const cancelClosing: boolean = !(await this._shouldCloseDiagramModal(diagram));
+
       if (cancelClosing) {
         return;
       }

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -479,7 +479,7 @@ export class SolutionExplorerSolution {
      * because it is our special case here and if the ACTIVE solution is the
      * "Open Diagrams"-Solution we need to return the uri anyway.
      */
-    const openDiagramSolutionIsActive: boolean = solutionUri === 'Open Diagrams';
+    const openDiagramSolutionIsActive: boolean = solutionUri === 'about:open-diagrams';
     if (this.solutionIsOpenDiagrams && openDiagramSolutionIsActive) {
       return this.activeDiagram.uri;
     }

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -389,6 +389,21 @@ export class SolutionExplorerSolution {
             && !this._openedSolution.uri.startsWith('http');
   }
 
+  public get diagramChangedStateMap(): Map<string, boolean> {
+
+    const isChangedMap: Map<string, boolean> = new Map<string, boolean>();
+
+    this.openedDiagrams.forEach((diagram: IDiagram): void => {
+      const diagramState: IDiagramState = this._openDiagramStateService.loadDiagramState(diagram.uri);
+
+      const isChanged: boolean = diagramState !== null && diagramState.metaData.isChanged;
+
+      isChangedMap.set(diagram.uri, isChanged);
+    });
+
+    return isChangedMap;
+  }
+
   public canDeleteDiagram(): boolean {
     return !this.solutionIsOpenDiagrams && this._openedSolution !== undefined;
   }

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -157,16 +157,6 @@ export class SolutionExplorerSolution {
     }
   }
 
-  private _startPolling(): void {
-    this._refreshTimeoutTask = setTimeout(async() =>  {
-      await this.updateSolution();
-
-      if (this._isAttached) {
-        this._startPolling();
-      }
-    }, environment.processengine.solutionExplorerPollingIntervalInMs);
-  }
-
   public async showDeleteDiagramModal(diagram: IDiagram, event: Event): Promise<void> {
     /**
      * We are stopping the event propagation here, because we don't want
@@ -485,6 +475,16 @@ export class SolutionExplorerSolution {
     }
 
     this._navigateToDetailView(diagram);
+  }
+
+  private _startPolling(): void {
+    this._refreshTimeoutTask = setTimeout(async() =>  {
+      await this.updateSolution();
+
+      if (this._isAttached) {
+        this._startPolling();
+      }
+    }, environment.processengine.solutionExplorerPollingIntervalInMs);
   }
 
   // TODO: This method is copied all over the place.

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -28,7 +28,7 @@ import {
 import environment from '../../../environment';
 import {NotificationService} from '../../../services/notification-service/notification.service';
 import {OpenDiagramsSolutionExplorerService} from '../../../services/solution-explorer-services/OpenDiagramsSolutionExplorerService';
-import {OpenDiagramsStateService} from '../../../services/solution-explorer-services/OpenDiagramsStateService';
+import {OpenDiagramStateService} from '../../../services/solution-explorer-services/OpenDiagramStateService';
 import {DeleteDiagramModal} from './delete-diagram-modal/delete-diagram-modal';
 
 const ENTER_KEY: string = 'Enter';
@@ -51,7 +51,7 @@ interface IDiagramCreationState extends IDiagramNameInputState {
   'DiagramCreationService',
   'NotificationService',
   'SolutionService',
-  'OpenDiagramsStateService',
+  'OpenDiagramStateService',
 )
 export class SolutionExplorerSolution {
 
@@ -62,7 +62,7 @@ export class SolutionExplorerSolution {
   private _validationController: ValidationController;
   private _diagramCreationService: IDiagramCreationService;
   private _notificationService: NotificationService;
-  private _openDiagramStateService: OpenDiagramsStateService;
+  private _openDiagramStateService: OpenDiagramStateService;
 
   private _diagramRoute: string = 'design';
   private _inspectView: string;
@@ -112,7 +112,7 @@ export class SolutionExplorerSolution {
     diagramCreationService: IDiagramCreationService,
     notificationService: NotificationService,
     solutionService: ISolutionService,
-    openDiagramStateService: OpenDiagramsStateService,
+    openDiagramStateService: OpenDiagramStateService,
   ) {
     this._router = router;
     this._eventAggregator = eventAggregator;

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -395,7 +395,7 @@ export class SolutionExplorerSolution {
   public canRenameDiagram(): boolean {
     return !this.solutionIsOpenDiagrams
             && this._openedSolution
-            && !this._openedSolution.uri.startsWith('http');
+            && !this._isUriFromRemoteSolution(this._openedSolution.uri);
   }
 
   public get diagramChangedStateMap(): Map<string, boolean> {
@@ -491,7 +491,7 @@ export class SolutionExplorerSolution {
       return openedDiagram.uri === diagram.uri;
     });
 
-    const diagramIsFromLocalSolution: boolean = !diagram.uri.startsWith('http');
+    const diagramIsFromLocalSolution: boolean = !this._isUriFromRemoteSolution(diagram.uri);
 
     if (diagramIsNotYetOpened && diagramIsFromLocalSolution) {
       const openedDiagram: IDiagram = await this.openDiagramService.openDiagram(diagram.uri, this._createIdentityForSolutionExplorer());
@@ -513,7 +513,7 @@ export class SolutionExplorerSolution {
 
   // TODO: This method is copied all over the place.
   private async _navigateToDetailView(diagram: IDiagram): Promise<void> {
-    const diagramIsNoRemoteDiagram: boolean = !diagram.uri.startsWith('http');
+    const diagramIsNoRemoteDiagram: boolean = !this._isUriFromRemoteSolution(diagram.uri);
     if (diagramIsNoRemoteDiagram) {
       const viewIsHeatmapOrInspectCorrelation: boolean = this._inspectView === 'inspect-correlation'
                                                       || this._inspectView === 'heatmap';
@@ -1068,7 +1068,7 @@ export class SolutionExplorerSolution {
         // The solution may have changed on the file system.
         await this.updateSolution();
 
-        const isRemoteSolution: boolean = this._openedSolution.uri.startsWith('http');
+        const isRemoteSolution: boolean = this._isUriFromRemoteSolution(this._openedSolution.uri);
         const isRunningInElectron: boolean = (window as any).nodeRequire;
 
         let expectedDiagramUri: string;
@@ -1087,4 +1087,7 @@ export class SolutionExplorerSolution {
       .on(this._diagramCreationState);
   }
 
+  private _isUriFromRemoteSolution(uri: string): boolean {
+    return uri.startsWith('http');
+  }
 }

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -490,6 +490,17 @@ export class SolutionExplorerSolution {
   }
 
   public async openDiagram(diagram: IDiagram): Promise<void> {
+
+    const diagramIsNotYetOpened: boolean = !this.singleDiagramService.getOpenedDiagrams().some((openedDiagram: IDiagram): boolean => {
+      return openedDiagram.uri === diagram.uri;
+    });
+
+    const diagramIsFromLocalSolution: boolean = !diagram.uri.startsWith('http');
+
+    if (diagramIsNotYetOpened && diagramIsFromLocalSolution) {
+      await this.singleDiagramService.openSingleDiagram(diagram.uri, this._createIdentityForSolutionExplorer());
+    }
+
     this.navigateToDetailView(diagram);
   }
 

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -607,7 +607,10 @@ export class SolutionExplorerSolution {
   }
 
   private async _shouldCloseDiagramModal(diagramToSave: IDiagram): Promise<boolean> {
-    await this._navigateToDetailView(diagramToSave);
+    const diagramToSaveIsNotActiveDiagram: boolean = diagramToSave.uri !== this.activeDiagramUri;
+    if (diagramToSaveIsNotActiveDiagram) {
+      await this._navigateToDetailView(diagramToSave);
+    }
 
     const modalResult: Promise<boolean> = new Promise((resolve: Function, reject: Function): boolean | void => {
       const dontSaveFunction: EventListenerOrEventListenerObject = async(): Promise<void> => {
@@ -617,7 +620,9 @@ export class SolutionExplorerSolution {
         document.getElementById('saveButtonCloseView').removeEventListener('click', saveFunction);
         document.getElementById('cancelButtonCloseView').removeEventListener('click', cancelFunction);
 
-        await this._router.navigateBack();
+        if (diagramToSaveIsNotActiveDiagram) {
+          await this._router.navigateBack();
+        }
 
         resolve(true);
       };
@@ -646,7 +651,9 @@ export class SolutionExplorerSolution {
         document.getElementById('saveButtonCloseView').removeEventListener('click', saveFunction);
         document.getElementById('cancelButtonCloseView').removeEventListener('click', cancelFunction);
 
-        await this._router.navigateBack();
+        if (diagramToSaveIsNotActiveDiagram) {
+          await this._router.navigateBack();
+        }
 
         resolve(false);
       };

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -549,6 +549,8 @@ export class SolutionExplorerSolution {
     const openDiagramService: OpenDiagramsSolutionExplorerService = this.solutionService as OpenDiagramsSolutionExplorerService;
     openDiagramService.closeDiagram(diagramToClose);
 
+    this._openDiagramStateService.deleteDiagramState(diagramToClose.uri);
+
     this._globalSolutionService.removeOpenDiagramByUri(diagramToClose.uri);
   }
 

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -495,7 +495,6 @@ export class SolutionExplorerSolution {
   }
 
   public async openDiagram(diagram: IDiagram): Promise<void> {
-
     const diagramIsNotYetOpened: boolean = !this.openDiagramService.getOpenedDiagrams().some((openedDiagram: IDiagram): boolean => {
       return openedDiagram.uri === diagram.uri;
     });

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -139,6 +139,15 @@ export class SolutionExplorerSolution {
       }),
     ];
 
+    if (this.solutionIsOpenDiagrams) {
+      const updateSubscription: Subscription =
+        this._eventAggregator.subscribe(environment.events.solutionExplorer.updateOpenDiagrams, (): void => {
+          this.updateSolution();
+        });
+
+      this._subscriptions.push(updateSubscription);
+    }
+
     setTimeout(async() => {
     await this.updateSolution();
     this._startPolling();
@@ -496,6 +505,10 @@ export class SolutionExplorerSolution {
     if (diagramIsNotYetOpened && diagramIsFromLocalSolution) {
       const openedDiagram: IDiagram = await this.openDiagramService.openDiagram(diagram.uri, this._createIdentityForSolutionExplorer());
       await this.openDiagramService.saveDiagram(openedDiagram);
+    }
+
+    if (!this._isUriFromRemoteSolution(diagram.uri) && !this.solutionIsOpenDiagrams) {
+      this._eventAggregator.publish(environment.events.solutionExplorer.updateOpenDiagrams);
     }
 
     this._navigateToDetailView(diagram);

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -225,9 +225,14 @@ export class SolutionExplorerSolution {
   public async closeDiagram(diagram: IDiagram, event: Event): Promise<void> {
     event.stopPropagation();
 
-    const cancelClosing: boolean = !(await this._shouldCloseDiagramModal(diagram));
-    if (cancelClosing) {
-      return;
+    const diagramState: IDiagramState = this._openDiagramStateService.loadDiagramState(diagram.uri);
+    const diagramHasUnsavedChanges: boolean = diagramState !== null && diagramState.metaData.isChanged;
+
+    if (diagramHasUnsavedChanges) {
+      const cancelClosing: boolean = !(await this._shouldCloseDiagramModal(diagram));
+      if (cancelClosing) {
+        return;
+      }
     }
 
     const closedDiagramWasActiveDiagram: boolean = this.activeDiagramUri === diagram.uri;

--- a/src/modules/start-page/start-page.html
+++ b/src/modules/start-page/start-page.html
@@ -6,7 +6,7 @@
       <img class="start-page__icon" src="src/resources/images/icon.png">
       <div class="start-page__quick-start" show.bind="isRunningInElectron">
         <div class="quick-start__item">
-          <div class="quick-start__topic" click.delegate="openSingleDiagram()">Open Diagram</div>
+          <div class="quick-start__topic" click.delegate="openDiagram()">Open Diagram</div>
           <div show.bind="isRunningInElectron && isRunningOnMacOS" class="quick-start__shortcut">⌘ + O</div>
           <div show.bind="isRunningInElectron && isRunningOnWindows" class="quick-start__shortcut">Strg + O</div>
         </div>
@@ -16,7 +16,7 @@
           <div show.bind="isRunningInElectron && isRunningOnWindows" class="quick-start__shortcut">Strg + Shift + O</div>
         </div>
         <div class="quick-start__item">
-          <div class="quick-start__topic" click.delegate="createNewSingleDiagram()">New Diagram</div>
+          <div class="quick-start__topic" click.delegate="createNewDiagram()">New Diagram</div>
           <div show.bind="isRunningInElectron && isRunningOnMacOS" class="quick-start__shortcut">⌘ + N</div>
           <div show.bind="isRunningInElectron && isRunningOnWindows" class="quick-start__shortcut">Strg + N</div>
         </div>

--- a/src/modules/start-page/start-page.ts
+++ b/src/modules/start-page/start-page.ts
@@ -26,11 +26,11 @@ export class StartPage {
     this._eventAggregator.publish(environment.events.startPage.openLocalSolution);
   }
 
-  public openSingleDiagram(): void {
-    this._eventAggregator.publish(environment.events.startPage.openSingleDiagram);
+  public openDiagram(): void {
+    this._eventAggregator.publish(environment.events.startPage.openDiagram);
   }
 
-  public createNewSingleDiagram(): void {
-    this._eventAggregator.publish(environment.events.startPage.createSingleDiagram);
+  public createNewDiagram(): void {
+    this._eventAggregator.publish(environment.events.startPage.createDiagram);
   }
 }

--- a/src/modules/status-bar/status-bar.ts
+++ b/src/modules/status-bar/status-bar.ts
@@ -232,9 +232,9 @@ export class StatusBar {
     const diagramIsSet: boolean = diagramName !== undefined;
 
     if (solutionIsSet && diagramIsSet) {
-      const activeSolutionIsSingleDiagramSolution: boolean = solutionUriFromNavigation === 'Single Diagrams';
-      if (activeSolutionIsSingleDiagramSolution) {
-        const persistedDiagrams: Array<IDiagram> = this._solutionService.getSingleDiagrams();
+      const activeSolutionIsOpenDiagramSolution: boolean = solutionUriFromNavigation === 'Open Diagrams';
+      if (activeSolutionIsOpenDiagramSolution) {
+        const persistedDiagrams: Array<IDiagram> = this._solutionService.getOpenDiagrams();
 
         this.activeDiagram = persistedDiagrams.find((diagram: IDiagram) => {
           return diagram.name === diagramName;

--- a/src/modules/status-bar/status-bar.ts
+++ b/src/modules/status-bar/status-bar.ts
@@ -232,7 +232,7 @@ export class StatusBar {
     const diagramIsSet: boolean = diagramName !== undefined;
 
     if (solutionIsSet && diagramIsSet) {
-      const activeSolutionIsOpenDiagramSolution: boolean = solutionUriFromNavigation === 'Open Diagrams';
+      const activeSolutionIsOpenDiagramSolution: boolean = solutionUriFromNavigation === 'about:open-diagrams';
       if (activeSolutionIsOpenDiagramSolution) {
         const persistedDiagrams: Array<IDiagram> = this._solutionService.getOpenDiagrams();
 

--- a/src/services/solution-explorer-services/OpenDiagramStateService.ts
+++ b/src/services/solution-explorer-services/OpenDiagramStateService.ts
@@ -2,7 +2,7 @@ import {IShape} from '@process-engine/bpmn-elements_contracts';
 
 import {IDiagramState} from '../../contracts';
 
-export class OpenDiagramsStateService {
+export class OpenDiagramStateService {
 
   public saveDiagramState(uri: string, xml: string, location: any, selectedElements: Array<IShape>): void {
     const diagramState: IDiagramState = {

--- a/src/services/solution-explorer-services/OpenDiagramStateService.ts
+++ b/src/services/solution-explorer-services/OpenDiagramStateService.ts
@@ -4,7 +4,7 @@ import {IDiagramState} from '../../contracts';
 
 export class OpenDiagramStateService {
 
-  public saveDiagramState(uri: string, xml: string, location: any, selectedElements: Array<IShape>): void {
+  public saveDiagramState(uri: string, xml: string, location: any, selectedElements: Array<IShape>, isChanged: boolean): void {
     const diagramState: IDiagramState = {
       data: {
         xml: xml,
@@ -12,6 +12,7 @@ export class OpenDiagramStateService {
       metaData: {
         location: location,
         selectedElements: selectedElements,
+        isChanged: isChanged,
       },
     };
 

--- a/src/services/solution-explorer-services/OpenDiagramsSolutionExplorerService.ts
+++ b/src/services/solution-explorer-services/OpenDiagramsSolutionExplorerService.ts
@@ -5,37 +5,37 @@ import {ISolutionExplorerService} from '@process-engine/solutionexplorer.service
 import {IDiagramValidationService, ISolutionService} from '../../contracts';
 
 /**
- * This service allows to keep all opened single diagrams inside a solution.
+ * This service allows to keep all opened open diagrams inside a solution.
  *
  * This is needed because the default solution explorer does not keep state
- * about single diagrams.
+ * about open diagrams.
  *
- * With this service you can retrieve, all opened single diagrams inside a
+ * With this service you can retrieve, all opened diagrams inside a
  * solution.
  *
- * To remove a diagram from the solution, call use #closeSingleDiagram().
+ * To remove a diagram from the solution, call use #closeDiagram().
  */
 
-export class SingleDiagramsSolutionExplorerService implements ISolutionExplorerService {
+export class OpenDiagramsSolutionExplorerService implements ISolutionExplorerService {
 
   private _validationService: IDiagramValidationService;
   private _solutionExplorerToOpenDiagrams: ISolutionExplorerService;
-  private _uriOfSingleDiagramService: string;
-  private _nameOfSingleDiagramService: string;
+  private _uriOfOpenDiagramService: string;
+  private _nameOfOpenDiagramService: string;
   private _openedDiagrams: Array<IDiagram> = [];
   private _solutionService: ISolutionService;
 
   constructor(
     validationService: IDiagramValidationService,
     solutionExplorerToOpenDiagrams: ISolutionExplorerService,
-    uriOfSingleDiagramService: string,
-    nameOfSingleDiagramService: string,
+    uriOfOpenDiagramService: string,
+    nameOfOpenDiagramService: string,
     solutionService: ISolutionService,
   ) {
     this._validationService = validationService;
     this._solutionExplorerToOpenDiagrams = solutionExplorerToOpenDiagrams;
-    this._uriOfSingleDiagramService = uriOfSingleDiagramService;
-    this._nameOfSingleDiagramService = nameOfSingleDiagramService;
+    this._uriOfOpenDiagramService = uriOfOpenDiagramService;
+    this._nameOfOpenDiagramService = nameOfOpenDiagramService;
     this._solutionService = solutionService;
   }
 
@@ -44,7 +44,7 @@ export class SingleDiagramsSolutionExplorerService implements ISolutionExplorerS
   }
 
   /**
-   * Gets the single diagram with the given uri, if the diagram was opened
+   * Gets the open diagram with the given uri, if the diagram was opened
    * before.
    */
   public getOpenedDiagramByURI(uri: string): IDiagram | null {
@@ -67,13 +67,13 @@ export class SingleDiagramsSolutionExplorerService implements ISolutionExplorerS
   public loadSolution(): Promise<ISolution> {
     const solution: ISolution = {
       diagrams: this._openedDiagrams,
-      name: this._uriOfSingleDiagramService,
-      uri: this._nameOfSingleDiagramService,
+      name: this._uriOfOpenDiagramService,
+      uri: this._nameOfOpenDiagramService,
     };
     return Promise.resolve(solution);
   }
 
-  public async openSingleDiagram(uri: string, identity: IIdentity): Promise<IDiagram> {
+  public async openDiagram(uri: string, identity: IIdentity): Promise<IDiagram> {
 
     const uriIsNoBpmnFile: boolean = !uri.endsWith('.bpmn');
 
@@ -111,7 +111,7 @@ export class SingleDiagramsSolutionExplorerService implements ISolutionExplorerS
     return diagram;
   }
 
-  public closeSingleDiagram(diagram: IDiagram): Promise<void> {
+  public closeDiagram(diagram: IDiagram): Promise<void> {
     const index: number = this._findOfDiagramWithURI(diagram.uri);
 
     this._openedDiagrams.splice(index, 1);
@@ -141,7 +141,7 @@ export class SingleDiagramsSolutionExplorerService implements ISolutionExplorerS
   }
 
   public saveDiagram(diagram: IDiagram): Promise<void> {
-    this._solutionService.addSingleDiagram(diagram);
+    this._solutionService.addOpenDiagram(diagram);
 
     return this._solutionExplorerToOpenDiagrams.saveDiagram(diagram);
   }

--- a/src/services/solution-explorer-services/OpenDiagramsSolutionExplorerService.ts
+++ b/src/services/solution-explorer-services/OpenDiagramsSolutionExplorerService.ts
@@ -146,6 +146,14 @@ export class OpenDiagramsSolutionExplorerService implements ISolutionExplorerSer
     return this._solutionExplorerToOpenDiagrams.saveDiagram(diagram);
   }
 
+  public async openDiagramFromSolution(diagramUri: string, identity: IIdentity): Promise<IDiagram> {
+    const openedDiagram: IDiagram = await this.openDiagram(diagramUri, identity);
+
+    this._solutionService.addOpenDiagram(openedDiagram);
+
+    return openedDiagram;
+  }
+
   private _findOfDiagramWithURI(uri: string): number {
     const index: number = this._openedDiagrams
       .findIndex((diagram: IDiagram): boolean => {

--- a/src/services/solution-explorer-services/OpenDiagramsSolutionExplorerService.ts
+++ b/src/services/solution-explorer-services/OpenDiagramsSolutionExplorerService.ts
@@ -67,8 +67,8 @@ export class OpenDiagramsSolutionExplorerService implements ISolutionExplorerSer
   public loadSolution(): Promise<ISolution> {
     const solution: ISolution = {
       diagrams: this._openedDiagrams,
-      name: this._uriOfOpenDiagramService,
-      uri: this._nameOfOpenDiagramService,
+      name: this._nameOfOpenDiagramService,
+      uri: this._uriOfOpenDiagramService,
     };
     return Promise.resolve(solution);
   }

--- a/src/services/solution-explorer-services/OpenDiagramsStateService.ts
+++ b/src/services/solution-explorer-services/OpenDiagramsStateService.ts
@@ -1,0 +1,48 @@
+import {IShape} from '@process-engine/bpmn-elements_contracts';
+
+import {IDiagramState} from '../../contracts';
+
+export class OpenDiagramsStateService {
+
+  public saveDiagramState(uri: string, xml: string, location: any, selectedElements: Array<IShape>): void {
+    const diagramState: IDiagramState = {
+      data: {
+        xml: xml,
+      },
+      metaData: {
+        location: location,
+        selectedElements: selectedElements,
+      },
+    };
+
+    const key: string = this._getLocalStorageKeyByUri(uri);
+    const value: string = JSON.stringify(diagramState);
+
+    window.localStorage.setItem(key, value);
+  }
+
+  public loadDiagramState(uri: string): IDiagramState | null {
+    const key: string = this._getLocalStorageKeyByUri(uri);
+
+    const dataFromLocalStorage: string = window.localStorage.getItem(key);
+
+    const noDataFound: boolean = dataFromLocalStorage === null;
+    if (noDataFound) {
+      return null;
+    }
+
+    const diagramState: IDiagramState = JSON.parse(dataFromLocalStorage);
+
+    return diagramState;
+  }
+
+  public deleteDiagramState(uri: string): void {
+    const key: string = this._getLocalStorageKeyByUri(uri);
+
+    window.localStorage.removeItem(key);
+  }
+
+  private _getLocalStorageKeyByUri(uri: string): string {
+    return `Open Diagram: ${uri}`;
+  }
+}

--- a/src/services/solution-explorer-services/index.ts
+++ b/src/services/solution-explorer-services/index.ts
@@ -6,6 +6,7 @@ import {SolutionExplorerManagementApiRepository} from '@process-engine/solutione
 import {SolutionExplorerService} from '@process-engine/solutionexplorer.service';
 
 import {DiagramTrashFolderService} from './DiagramTrashFolderService';
+import {OpenDiagramsStateService} from './OpenDiagramsStateService';
 import {SolutionExplorerServiceFactory} from './SolutionExplorerServiceFactory';
 
 export async function configure(config: FrameworkConfiguration): Promise<void> {
@@ -18,6 +19,7 @@ export async function configure(config: FrameworkConfiguration): Promise<void> {
 
   config.container.registerSingleton('SolutionExplorerServiceFactory', SolutionExplorerServiceFactory);
   config.container.registerSingleton('DiagramTrashFolderService', DiagramTrashFolderService);
+  config.container.registerSingleton('OpenDiagramsStateService', OpenDiagramsStateService);
 }
 
 function registerFileSystem(container: Container): void {

--- a/src/services/solution-explorer-services/index.ts
+++ b/src/services/solution-explorer-services/index.ts
@@ -6,7 +6,7 @@ import {SolutionExplorerManagementApiRepository} from '@process-engine/solutione
 import {SolutionExplorerService} from '@process-engine/solutionexplorer.service';
 
 import {DiagramTrashFolderService} from './DiagramTrashFolderService';
-import {OpenDiagramsStateService} from './OpenDiagramsStateService';
+import {OpenDiagramStateService} from './OpenDiagramStateService';
 import {SolutionExplorerServiceFactory} from './SolutionExplorerServiceFactory';
 
 export async function configure(config: FrameworkConfiguration): Promise<void> {
@@ -19,7 +19,7 @@ export async function configure(config: FrameworkConfiguration): Promise<void> {
 
   config.container.registerSingleton('SolutionExplorerServiceFactory', SolutionExplorerServiceFactory);
   config.container.registerSingleton('DiagramTrashFolderService', DiagramTrashFolderService);
-  config.container.registerSingleton('OpenDiagramsStateService', OpenDiagramsStateService);
+  config.container.registerSingleton('OpenDiagramStateService', OpenDiagramStateService);
 }
 
 function registerFileSystem(container: Container): void {

--- a/src/services/solution-service/SolutionService.ts
+++ b/src/services/solution-service/SolutionService.ts
@@ -130,7 +130,7 @@ export class SolutionService implements ISolutionService {
      * Right now the open diagram solution entry doesn't get persisted.
      */
     const entriesToPersist: Array<ISolutionEntry> = this._allSolutionEntries.filter((entry: ISolutionEntry) => {
-      const entryIsNotOpenDiagramSolution: boolean = entry.uri !== 'Open Diagrams';
+      const entryIsNotOpenDiagramSolution: boolean = entry.uri !== 'about:open-diagrams';
 
       return entryIsNotOpenDiagramSolution;
     });

--- a/src/services/solution-service/SolutionService.ts
+++ b/src/services/solution-service/SolutionService.ts
@@ -127,7 +127,7 @@ export class SolutionService implements ISolutionService {
 
   public persistSolutionsInLocalStorage(): void {
     /**
-     * Right now the oopen diagram solution entry doesn't get persisted.
+     * Right now the open diagram solution entry doesn't get persisted.
      */
     const entriesToPersist: Array<ISolutionEntry> = this._allSolutionEntries.filter((entry: ISolutionEntry) => {
       const entryIsNotOpenDiagramSolution: boolean = entry.uri !== 'Open Diagrams';

--- a/src/services/solution-service/SolutionService.ts
+++ b/src/services/solution-service/SolutionService.ts
@@ -10,13 +10,13 @@ export class SolutionService implements ISolutionService {
   private _allSolutionEntries: Array<ISolutionEntry> = [];
   private _serviceFactory: SolutionExplorerServiceFactory;
   private _persistedEntries: Array<ISolutionEntry> = [];
-  private _persistedSingleDiagrams: Array<IDiagram> = [];
+  private _persistedOpenDiagrams: Array<IDiagram> = [];
 
   constructor(serviceFactory: SolutionExplorerServiceFactory) {
     this._serviceFactory = serviceFactory;
 
     const openedSolutions: Array<ISolutionEntry> = this._getSolutionFromLocalStorage();
-    this._persistedSingleDiagrams = this._getSingleDiagramsFromLocalStorage();
+    this._persistedOpenDiagrams = this._getOpenDiagramsFromLocalStorage();
 
     const openedSolutionsAreNotSet: boolean = openedSolutions === null;
     if (openedSolutionsAreNotSet) {
@@ -96,43 +96,43 @@ export class SolutionService implements ISolutionService {
   }
 
   /**
-   * SINGLE DIAGRAMS
+   * OPEN DIAGRAMS
    */
 
-  public addSingleDiagram(diagramToAdd: IDiagram): void {
-    const indexOfDiagram: number = this._persistedSingleDiagrams.findIndex((diagram: IDiagram) => diagram.uri === diagramToAdd.uri);
+  public addOpenDiagram(diagramToAdd: IDiagram): void {
+    const indexOfDiagram: number = this._persistedOpenDiagrams.findIndex((diagram: IDiagram) => diagram.uri === diagramToAdd.uri);
     const diagramIsPersisted: boolean = indexOfDiagram >= 0;
 
     if (diagramIsPersisted) {
-      this._persistedSingleDiagrams[indexOfDiagram] = diagramToAdd;
+      this._persistedOpenDiagrams[indexOfDiagram] = diagramToAdd;
     } else {
-      this._persistedSingleDiagrams.push(diagramToAdd);
+      this._persistedOpenDiagrams.push(diagramToAdd);
     }
 
-    this._persistSingleDiagramsInLocalStorage();
+    this._persistOpenDiagramsInLocalStorage();
   }
 
-  public removeSingleDiagramByUri(diagramUri: string): void {
-    const indexOfDiagramToRemove: number = this._persistedSingleDiagrams.findIndex((diagram: IDiagram) => {
+  public removeOpenDiagramByUri(diagramUri: string): void {
+    const indexOfDiagramToRemove: number = this._persistedOpenDiagrams.findIndex((diagram: IDiagram) => {
       return diagram.uri === diagramUri;
     });
 
-    this._persistedSingleDiagrams.splice(indexOfDiagramToRemove, 1);
-    this._persistSingleDiagramsInLocalStorage();
+    this._persistedOpenDiagrams.splice(indexOfDiagramToRemove, 1);
+    this._persistOpenDiagramsInLocalStorage();
   }
 
-  public getSingleDiagrams(): Array<IDiagram> {
-    return this._persistedSingleDiagrams;
+  public getOpenDiagrams(): Array<IDiagram> {
+    return this._persistedOpenDiagrams;
   }
 
   public persistSolutionsInLocalStorage(): void {
     /**
-     * Right now the single diagram solution entry doesn't get persisted.
+     * Right now the oopen diagram solution entry doesn't get persisted.
      */
     const entriesToPersist: Array<ISolutionEntry> = this._allSolutionEntries.filter((entry: ISolutionEntry) => {
-      const entryIsNotSingleDiagramSolution: boolean = entry.uri !== 'Single Diagrams';
+      const entryIsNotOpenDiagramSolution: boolean = entry.uri !== 'Open Diagrams';
 
-      return entryIsNotSingleDiagramSolution;
+      return entryIsNotOpenDiagramSolution;
     });
 
     window.localStorage.setItem('openedSolutions', JSON.stringify(entriesToPersist));
@@ -145,15 +145,15 @@ export class SolutionService implements ISolutionService {
     return openedSolutions;
   }
 
-  private _getSingleDiagramsFromLocalStorage(): Array<IDiagram> {
-    const singleDiagrams: Array<IDiagram> = JSON.parse(window.localStorage.getItem('SingleDiagrams'));
-    const singleDigramsPersisted: boolean = singleDiagrams !== null;
+  private _getOpenDiagramsFromLocalStorage(): Array<IDiagram> {
+    const openDiagrams: Array<IDiagram> = JSON.parse(window.localStorage.getItem('OpenDiagrams'));
+    const openDiagramsWerePersisted: boolean = openDiagrams !== null;
 
-    return singleDigramsPersisted ? singleDiagrams : [];
+    return openDiagramsWerePersisted ? openDiagrams : [];
   }
 
-  private _persistSingleDiagramsInLocalStorage(): void {
+  private _persistOpenDiagramsInLocalStorage(): void {
 
-    window.localStorage.setItem('SingleDiagrams', JSON.stringify(this._persistedSingleDiagrams));
+    window.localStorage.setItem('OpenDiagrams', JSON.stringify(this._persistedOpenDiagrams));
   }
 }


### PR DESCRIPTION
## Changes

1. Add Open Diagrams Functionality
  1.1 Save diagrams in local storage (diagrams don't have to be saved anymore when changing the diagram)
  1.2 Remove "Quit"- and "Leave"-modal
  1.3 Save viewbox of open diagrams
  1.4. Save selected element
2. Move Remote Solutions to the Bottom of the SolutionExplorer
3. Remove "Single Diagrams"

## Issues

Closes #374 

PR: #1516

## How to test the changes

- Open Diagram from Filesystem
- **Notice that they will be opened as "Open Diagrams"**
- Make some changes
- Change the diagram
- **Notice that the diagram will be marked with a circle in the solution explorer**
<img width="247" src="https://user-images.githubusercontent.com/20394992/59766297-2aae4f00-92a0-11e9-829b-f21f4c4b4d3e.png">

- Close the unsaved diagram
- **Notice that a modal will appear**
- Click Save
- **Notice that the diagram will be saved.**
- Click Don't Save
- **Notice that the diagram wont be saved**
- Click Cancel

- Open a diagram
- Make some changes
- Change the diagram
- Close the diagram with the changes
- **Notice that the diagram with the saves will be displayed with a modal asking if one wants to save**
- Confirm the Modal
- **Notice that the previous diagram will be displayed again**
