### PR TITLE
🐛 Fix bug where diagram is marked as edited when clicking on cond…

### DIFF
--- a/src/modules/design/property-panel/indextabs/general/sections/flow/flow.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/flow/flow.html
@@ -8,7 +8,7 @@
         <tr>
           <th>Condition</th>
           <td>
-            <input type="text" class="props-input" value.bind="condition" disabled.bind="!isEditable">
+            <input type="text" class="props-input" value.bind="condition" change.delegate="updateCondition()" disabled.bind="!isEditable">
           </td>
         </tr>
       </table>

--- a/src/modules/design/property-panel/indextabs/general/sections/flow/flow.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/flow/flow.ts
@@ -1,6 +1,6 @@
 
 import {EventAggregator} from 'aurelia-event-aggregator';
-import {inject, observable} from 'aurelia-framework';
+import {inject} from 'aurelia-framework';
 
 import {IConditionExpression, IFlowElement, IShape} from '@process-engine/bpmn-elements_contracts';
 
@@ -16,7 +16,7 @@ export class FlowSection implements ISection {
 
   public path: string = '/sections/flow/flow';
   public canHandleElement: boolean = false;
-  @observable public condition: string;
+  public condition: string;
 
   private _businessObjInPanel: IFlowElement;
   private _moddle: IBpmnModdle;
@@ -55,7 +55,7 @@ export class FlowSection implements ISection {
     }
   }
 
-  public conditionChanged(newValue: string, oldValue: string): void {
+  public updateCondition(): void {
     const objectHasNoConditionExpression: boolean = this._businessObjInPanel.conditionExpression === undefined
                                                  || this._businessObjInPanel.conditionExpression === null;
 
@@ -63,7 +63,7 @@ export class FlowSection implements ISection {
       this._createConditionExpression();
     }
 
-    this._businessObjInPanel.conditionExpression.body = newValue;
+    this._businessObjInPanel.conditionExpression.body = this.condition;
     this._publishDiagramChange();
   }
 


### PR DESCRIPTION
## Changes

1. Fix bug where the diagram is marked as edited when clicking on conditional flows

## Issues

Closes #1520 

PR: #1528 

## How to test the changes

> Describe how others can test your changes (not required when fixing typos, linter errors and such)
