### PR TITLE
🐛 Prevent Saving Diagram State of Remote Diagrams

### DIFF
--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -426,7 +426,7 @@ export class BpmnIo {
     }
 
     const oldValueExists: boolean = oldValue !== undefined;
-    if (!this.diagramHasChanged && oldValueExists) {
+    if (!this.diagramHasChanged && oldValueExists && !this.solutionIsRemote) {
       await this._saveDiagramState(this.diagramUri);
     }
 


### PR DESCRIPTION
## Changes

1. Prevent Saving Diagram State of Remote Diagrams

PR: #1533 

## How to test the changes

- Open some remote diagrams
- Have a look at the localStorage
- **Notice that remote diagrams will no longer be saved in localStorage**
