### PR TITLE
♻️🐛 Do not Generate a New Camunda Property Objects 

### DIFF
--- a/src/modules/design/property-panel/indextabs/extensions/sections/basics/basics.ts
+++ b/src/modules/design/property-panel/indextabs/extensions/sections/basics/basics.ts
@@ -195,7 +195,9 @@ export class BasicsSection implements ISection {
   private _getPropertiesElement(): IPropertiesElement {
 
     const propertiesElement: IPropertiesElement  = this._businessObjInPanel.extensionElements.values.find((extensionValue: IExtensionElement) => {
-      const extensionIsPropertiesElement: boolean = extensionValue.$type === 'camunda:Properties' && extensionValue.values !== undefined;
+      const extensionIsPropertiesElement: boolean = extensionValue.$type === 'camunda:Properties'
+                                                 && extensionValue.values !== undefined
+                                                 && extensionValue.values !== null;
 
       return extensionIsPropertiesElement;
     });

--- a/src/modules/design/property-panel/indextabs/extensions/sections/basics/basics.ts
+++ b/src/modules/design/property-panel/indextabs/extensions/sections/basics/basics.ts
@@ -203,16 +203,9 @@ export class BasicsSection implements ISection {
   }
 
   private _createExtensionElement(): void {
-    const bpmnExecutionListenerProperties: Object = {
-      class: '',
-      event: '',
-    };
-    const bpmnExecutionListener: IModdleElement = this._moddle.create('camunda:ExecutionListener', bpmnExecutionListenerProperties);
-
     const extensionValues: Array<IModdleElement> = [];
     const properties: Array<IProperty> = [];
     const propertiesElement: IPropertiesElement = this._moddle.create('camunda:Properties', {values: properties});
-    extensionValues.push(bpmnExecutionListener);
     extensionValues.push(propertiesElement);
 
     const extensionElements: IModdleElement = this._moddle.create('bpmn:ExtensionElements', {values: extensionValues});

--- a/src/modules/design/property-panel/indextabs/extensions/sections/basics/basics.ts
+++ b/src/modules/design/property-panel/indextabs/extensions/sections/basics/basics.ts
@@ -104,6 +104,11 @@ export class BasicsSection implements ISection {
         .values
         .splice(index, 1);
 
+    const emptyProperties: boolean = this._propertiesElement.values.length === 0;
+    if (emptyProperties) {
+      this._deletePropertiesElementAndExtensionElements();
+    }
+
     this._reloadProperties();
     this._publishDiagramChange();
   }
@@ -120,6 +125,20 @@ export class BasicsSection implements ISection {
     this._checkAndRemoveEmptyProperties(index);
 
     this._publishDiagramChange();
+  }
+
+  private _deletePropertiesElementAndExtensionElements(): void {
+    const indexOfPropertiesElement: number = this._businessObjInPanel.extensionElements.values.findIndex((element: IPropertiesElement) => {
+      return element.$type === 'camunda:Properties';
+    });
+
+    delete this._businessObjInPanel.extensionElements.values[indexOfPropertiesElement];
+
+    // tslint:disable-next-line: no-magic-numbers
+    const emptyExtensionElements: boolean = this._businessObjInPanel.extensionElements.values.length < 2;
+    if (emptyExtensionElements) {
+      delete this._businessObjInPanel.extensionElements;
+    }
   }
 
   private _checkAndRemoveEmptyProperties(index: number): void {

--- a/src/modules/design/property-panel/indextabs/extensions/sections/basics/basics.ts
+++ b/src/modules/design/property-panel/indextabs/extensions/sections/basics/basics.ts
@@ -52,6 +52,8 @@ export class BasicsSection implements ISection {
   }
 
   public addProperty(): void {
+    this._reloadProperties();
+
     const bpmnPropertyProperties: Object = {
       name: '',
       value: '',
@@ -132,6 +134,9 @@ export class BasicsSection implements ISection {
 
   private _deletePropertiesElementAndExtensionElements(): void {
     const indexOfPropertiesElement: number = this._businessObjInPanel.extensionElements.values.findIndex((element: IPropertiesElement) => {
+      if (!element) {
+        return;
+      }
       return element.$type === 'camunda:Properties';
     });
 
@@ -146,6 +151,10 @@ export class BasicsSection implements ISection {
 
   private _checkAndRemoveEmptyProperties(index: number): void {
     const propertyElement: IProperty = this._propertiesElement.values[index];
+    if (!propertyElement) {
+      return;
+    }
+
     const propertyIsEmpty: boolean = propertyElement.value === '' && propertyElement.name === '';
     if (propertyIsEmpty) {
       this.removeProperty(index);
@@ -167,11 +176,13 @@ export class BasicsSection implements ISection {
       return;
     }
 
-    this._propertiesElement = this._getPropertiesElement();
-
     const extensionsPropertiesElement: IPropertiesElement  =
       this._businessObjInPanel.extensionElements.values
         .find((extensionValue: IExtensionElement) => {
+          if (!extensionValue) {
+            return undefined;
+          }
+
           const extensionIsPropertyElement: boolean = extensionValue.$type === 'camunda:Properties'
                                                    && extensionValue.values !== undefined
                                                    && extensionValue.values !== null
@@ -185,6 +196,8 @@ export class BasicsSection implements ISection {
     if (extensionElementHasNoPropertyElement) {
       return;
     }
+
+    this._propertiesElement = extensionsPropertiesElement;
 
     const properties: Array<IProperty> = extensionsPropertiesElement.values;
     for (const property of properties) {
@@ -209,6 +222,10 @@ export class BasicsSection implements ISection {
     }
 
     const propertiesElement: IPropertiesElement  = this._businessObjInPanel.extensionElements.values.find((extensionValue: IExtensionElement) => {
+      if (!extensionValue) {
+        return undefined;
+      }
+
       const extensionIsPropertiesElement: boolean = extensionValue.$type === 'camunda:Properties'
                                                  && extensionValue.values !== undefined
                                                  && extensionValue.values !== null;

--- a/src/modules/design/property-panel/indextabs/extensions/sections/basics/basics.ts
+++ b/src/modules/design/property-panel/indextabs/extensions/sections/basics/basics.ts
@@ -62,7 +62,10 @@ export class BasicsSection implements ISection {
     this.newValues.push('');
 
     const businessObjectHasNoExtensionElements: boolean = this._businessObjInPanel.extensionElements === undefined
-                                                       || this._businessObjInPanel.extensionElements === null;
+                                                       || this._businessObjInPanel.extensionElements === null
+                                                       || this._businessObjInPanel.extensionElements.values === undefined
+                                                       || this._businessObjInPanel.extensionElements.values.length === 0;
+
     if (businessObjectHasNoExtensionElements) {
       this._createExtensionElement();
     }
@@ -156,7 +159,9 @@ export class BasicsSection implements ISection {
     this.shouldFocus = false;
 
     const businessObjectHasNoExtensionElements: boolean = this._businessObjInPanel.extensionElements === undefined
-                                                       || this._businessObjInPanel.extensionElements === null;
+                                                       || this._businessObjInPanel.extensionElements === null
+                                                       || this._businessObjInPanel.extensionElements.values === undefined
+                                                       || this._businessObjInPanel.extensionElements.values.length === 0;
 
     if (businessObjectHasNoExtensionElements) {
       return;
@@ -192,7 +197,16 @@ export class BasicsSection implements ISection {
     }
   }
 
-  private _getPropertiesElement(): IPropertiesElement {
+  private _getPropertiesElement(): IPropertiesElement | undefined {
+
+    const businessObjectHasNoExtensionElements: boolean = this._businessObjInPanel.extensionElements === undefined
+                                                       || this._businessObjInPanel.extensionElements === null
+                                                       || this._businessObjInPanel.extensionElements.values === undefined
+                                                       || this._businessObjInPanel.extensionElements.values.length === 0;
+
+    if (businessObjectHasNoExtensionElements) {
+      return undefined;
+    }
 
     const propertiesElement: IPropertiesElement  = this._businessObjInPanel.extensionElements.values.find((extensionValue: IExtensionElement) => {
       const extensionIsPropertiesElement: boolean = extensionValue.$type === 'camunda:Properties'
@@ -201,6 +215,7 @@ export class BasicsSection implements ISection {
 
       return extensionIsPropertiesElement;
     });
+
     return propertiesElement;
   }
 

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.ts
@@ -21,13 +21,6 @@ export class ExternalTask {
     this._eventAggregator = eventAggregator;
   }
 
-  public attached(): void {
-    this.businessObjInPanel = this.model.elementInPanel.businessObject;
-    this._moddle = this.model.modeler.get('moddle');
-    this.selectedTopic = this.businessObjInPanel.topic;
-    this.selectedPayload = this._getPayloadFromModel();
-  }
-
   public modelChanged(): void {
     this.businessObjInPanel = this.model.elementInPanel.businessObject;
     this._moddle = this.model.modeler.get('moddle');

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.ts
@@ -1,7 +1,13 @@
 import {EventAggregator} from 'aurelia-event-aggregator';
-import {bindable, inject, observable} from 'aurelia-framework';
+import {bindable, inject} from 'aurelia-framework';
 
-import {IPropertiesElement, IProperty, IServiceTaskElement} from '@process-engine/bpmn-elements_contracts';
+import {
+  IExtensionElement,
+  IModdleElement,
+  IPropertiesElement,
+  IProperty,
+  IServiceTaskElement,
+} from '@process-engine/bpmn-elements_contracts';
 
 import {IBpmnModdle, IPageModel} from '../../../../../../../../../contracts';
 import environment from '../../../../../../../../../environment';

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.ts
@@ -2,15 +2,13 @@ import {EventAggregator} from 'aurelia-event-aggregator';
 import {bindable, inject} from 'aurelia-framework';
 
 import {
-  IExtensionElement,
-  IModdleElement,
-  IPropertiesElement,
   IProperty,
   IServiceTaskElement,
 } from '@process-engine/bpmn-elements_contracts';
 
 import {IBpmnModdle, IPageModel} from '../../../../../../../../../contracts';
 import environment from '../../../../../../../../../environment';
+import {ServiceTaskService} from '../service-task-service/service-task-service';
 
 @inject(EventAggregator)
 export class ExternalTask {
@@ -21,15 +19,16 @@ export class ExternalTask {
   public selectedPayload: string;
 
   private _eventAggregator: EventAggregator;
-  private _moddle: IBpmnModdle;
+  private _serviceTaskService: ServiceTaskService;
 
   constructor(eventAggregator?: EventAggregator) {
     this._eventAggregator = eventAggregator;
   }
 
   public modelChanged(): void {
+    this._serviceTaskService = new ServiceTaskService(this.model);
     this.businessObjInPanel = this.model.elementInPanel.businessObject;
-    this._moddle = this.model.modeler.get('moddle');
+
     this.selectedTopic = this.businessObjInPanel.topic;
     this.selectedPayload = this._getPayloadFromModel();
   }
@@ -47,7 +46,7 @@ export class ExternalTask {
   }
 
   private _getPayloadFromModel(): string | undefined {
-    const payloadProperty: IProperty = this._getProperty('payload');
+    const payloadProperty: IProperty = this._serviceTaskService.getProperty('payload');
 
     const payloadPropertyExists: boolean = payloadProperty !== undefined;
     if (payloadPropertyExists) {
@@ -58,12 +57,12 @@ export class ExternalTask {
   }
 
   private _setPayloadToModel(value: string): void {
-    let payloadProperty: IProperty = this._getProperty('payload');
+    let payloadProperty: IProperty = this._serviceTaskService.getProperty('payload');
 
     const payloadPropertyNotExists: boolean = payloadProperty === undefined;
 
     if (payloadPropertyNotExists) {
-      payloadProperty = this._createProperty('payload');
+      payloadProperty = this._serviceTaskService.createProperty('payload');
     }
 
     payloadProperty.value = value;
@@ -71,41 +70,5 @@ export class ExternalTask {
 
   private _publishDiagramChange(): void {
     this._eventAggregator.publish(environment.events.diagramChange);
-  }
-
-  private _createProperty(propertyName: string): IProperty {
-    const propertiesElement: IPropertiesElement = this._getPropertiesElement();
-
-    const propertyObject: any = {
-      name: propertyName,
-      value: '',
-    };
-
-    const property: IProperty = this._moddle.create('camunda:Property', propertyObject);
-
-    propertiesElement.values.push(property);
-
-    return property;
-  }
-
-  private _getPropertiesElement(): IPropertiesElement {
-    const propertiesElement: IPropertiesElement = this.businessObjInPanel.extensionElements.values.find((element: IPropertiesElement) => {
-      const elementIsCamundaProperties: boolean = element.$type === 'camunda:Properties';
-      const elementContainsValues: boolean = element.values !== undefined;
-
-      return elementIsCamundaProperties && elementContainsValues;
-    });
-
-    return propertiesElement;
-  }
-
-  private _getProperty(propertyName: string): IProperty {
-    const propertiesElement: IPropertiesElement = this._getPropertiesElement();
-
-    const property: IProperty = propertiesElement.values.find((element: IProperty) => {
-      return element.name === propertyName;
-    });
-
-    return property;
   }
 }

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/components/http-service-task/http-service-task.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/components/http-service-task/http-service-task.ts
@@ -30,13 +30,6 @@ export class HttpServiceTask {
     this._eventAggregator = eventAggregator;
   }
 
-  public attached(): void {
-    this.businessObjInPanel = this.model.elementInPanel.businessObject;
-    this._moddle = this.model.modeler.get('moddle');
-
-    this._initHttpServiceTask();
-  }
-
   public modelChanged(): void {
     this.businessObjInPanel = this.model.elementInPanel.businessObject;
     this._moddle = this.model.modeler.get('moddle');

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/components/http-service-task/http-service-task.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/components/http-service-task/http-service-task.ts
@@ -73,6 +73,19 @@ export class HttpServiceTask {
   }
 
   private _createProperty(propertyName: string): void {
+    const noExtensionElements: boolean = this.businessObjInPanel.extensionElements === undefined
+                                      || this.businessObjInPanel.extensionElements === null;
+
+    if (noExtensionElements) {
+      this._createExtensionElement();
+    }
+
+    const noPropertiesElement: boolean = this._getPropertiesElement() === undefined;
+
+    if (noPropertiesElement) {
+      this._createPropertiesElement();
+    }
+
     const propertiesElement: IPropertiesElement = this._getPropertiesElement();
 
     const propertyObject: Object = {
@@ -85,16 +98,46 @@ export class HttpServiceTask {
     propertiesElement.values.push(property);
   }
 
-  private _getPropertiesElement(): IPropertiesElement {
-    const propertiesElement: IPropertiesElement = this.businessObjInPanel.extensionElements.values.find((element: IPropertiesElement) => {
-      return element.$type === 'camunda:Properties' && element.values !== undefined;
-    });
+  private _createExtensionElement(): void {
+    const extensionValues: Array<IModdleElement> = [];
+
+    const extensionElements: IModdleElement = this._moddle.create('bpmn:ExtensionElements', {values: extensionValues});
+    this.businessObjInPanel.extensionElements = extensionElements;
+  }
+
+  private _createPropertiesElement(): void {
+    const extensionElement: IExtensionElement = this.businessObjInPanel.extensionElements;
+
+    const properties: Array<IProperty> = [];
+    const propertiesElement: IPropertiesElement = this._moddle.create('camunda:Properties', {values: properties});
+
+    extensionElement.values.push(propertiesElement);
+  }
+
+  private _getPropertiesElement(): IPropertiesElement | undefined {
+    const noExtensionElements: boolean = this.businessObjInPanel.extensionElements === undefined
+                                      || this.businessObjInPanel.extensionElements === null;
+
+    if (noExtensionElements) {
+      return undefined;
+    }
+
+    const propertiesElement: IPropertiesElement = this.businessObjInPanel
+      .extensionElements
+      .values
+      .find((element: IPropertiesElement) => {
+        return element.$type === 'camunda:Properties' && element.values !== undefined;
+      });
 
     return propertiesElement;
   }
 
-  private _getProperty(propertyName: string): IProperty {
+  private _getProperty(propertyName: string): IProperty | undefined {
     const propertiesElement: IPropertiesElement = this._getPropertiesElement();
+
+    if (!propertiesElement) {
+      return undefined;
+    }
 
     const property: IProperty = propertiesElement.values.find((element: IProperty) => {
       return element.name === propertyName;

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/components/http-service-task/http-service-task.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/components/http-service-task/http-service-task.ts
@@ -2,15 +2,13 @@ import {EventAggregator} from 'aurelia-event-aggregator';
 import {bindable, inject} from 'aurelia-framework';
 
 import {
-  IExtensionElement,
-  IModdleElement,
-  IPropertiesElement,
   IProperty,
   IServiceTaskElement,
 } from '@process-engine/bpmn-elements_contracts';
 
-import {IBpmnModdle, IPageModel} from '../../../../../../../../../contracts';
+import {IPageModel} from '../../../../../../../../../contracts';
 import environment from '../../../../../../../../../environment';
+import {ServiceTaskService} from '../service-task-service/service-task-service';
 
 interface IAuthParameters {
   headers: {
@@ -31,15 +29,15 @@ export class HttpServiceTask {
   public selectedHttpContentType: string;
 
   private _eventAggregator: EventAggregator;
-  private _moddle: IBpmnModdle;
+  private _serviceTaskService: ServiceTaskService;
 
   constructor(eventAggregator?: EventAggregator) {
     this._eventAggregator = eventAggregator;
   }
 
   public modelChanged(): void {
+    this._serviceTaskService = new ServiceTaskService(this.model);
     this.businessObjInPanel = this.model.elementInPanel.businessObject;
-    this._moddle = this.model.modeler.get('moddle');
 
     this._initHttpServiceTask();
   }
@@ -60,106 +58,32 @@ export class HttpServiceTask {
       this.selectedHttpContentType = undefined;
     }
 
-    this._getProperty('params').value = this._getParamsFromInput();
+    this._serviceTaskService.getProperty('params').value = this._getParamsFromInput();
     this._publishDiagramChange();
   }
 
   public httpMethodChanged(): void {
-    const property: IProperty = this._getProperty('method');
+    const property: IProperty = this._serviceTaskService.getProperty('method');
     property.value = this.selectedHttpMethod;
 
     this._getParamsFromInput();
     this._publishDiagramChange();
   }
 
-  private _createProperty(propertyName: string): void {
-    const noExtensionElements: boolean = this.businessObjInPanel.extensionElements === undefined
-                                      || this.businessObjInPanel.extensionElements === null;
-
-    if (noExtensionElements) {
-      this._createExtensionElement();
-    }
-
-    const noPropertiesElement: boolean = this._getPropertiesElement() === undefined;
-
-    if (noPropertiesElement) {
-      this._createPropertiesElement();
-    }
-
-    const propertiesElement: IPropertiesElement = this._getPropertiesElement();
-
-    const propertyObject: Object = {
-      name: propertyName,
-      value: '',
-    };
-
-    const property: IProperty = this._moddle.create('camunda:Property', propertyObject);
-
-    propertiesElement.values.push(property);
-  }
-
-  private _createExtensionElement(): void {
-    const extensionValues: Array<IModdleElement> = [];
-
-    const extensionElements: IModdleElement = this._moddle.create('bpmn:ExtensionElements', {values: extensionValues});
-    this.businessObjInPanel.extensionElements = extensionElements;
-  }
-
-  private _createPropertiesElement(): void {
-    const extensionElement: IExtensionElement = this.businessObjInPanel.extensionElements;
-
-    const properties: Array<IProperty> = [];
-    const propertiesElement: IPropertiesElement = this._moddle.create('camunda:Properties', {values: properties});
-
-    extensionElement.values.push(propertiesElement);
-  }
-
-  private _getPropertiesElement(): IPropertiesElement | undefined {
-    const noExtensionElements: boolean = this.businessObjInPanel.extensionElements === undefined
-                                      || this.businessObjInPanel.extensionElements === null;
-
-    if (noExtensionElements) {
-      return undefined;
-    }
-
-    const propertiesElement: IPropertiesElement = this.businessObjInPanel
-      .extensionElements
-      .values
-      .find((element: IPropertiesElement) => {
-        return element.$type === 'camunda:Properties' && element.values !== undefined;
-      });
-
-    return propertiesElement;
-  }
-
-  private _getProperty(propertyName: string): IProperty | undefined {
-    const propertiesElement: IPropertiesElement = this._getPropertiesElement();
-
-    if (!propertiesElement) {
-      return undefined;
-    }
-
-    const property: IProperty = propertiesElement.values.find((element: IProperty) => {
-      return element.name === propertyName;
-    });
-
-    return property;
-  }
-
   private _initHttpServiceTask(): void {
-    const methodPropertyExists: boolean = this._getProperty('method') !== undefined;
-    const paramPropertyExists: boolean = this._getProperty('params') !== undefined;
+    const methodPropertyExists: boolean = this._serviceTaskService.getProperty('method') !== undefined;
+    const paramPropertyExists: boolean = this._serviceTaskService.getProperty('params') !== undefined;
 
     if (methodPropertyExists) {
-      this.selectedHttpMethod = this._getProperty('method').value;
+      this.selectedHttpMethod = this._serviceTaskService.getProperty('method').value;
     } else {
-      this._createProperty('method');
+      this._serviceTaskService.createProperty('method');
     }
 
     if (paramPropertyExists) {
-      this._fillVariablesFromParam(this._getProperty('params').value);
+      this._fillVariablesFromParam(this._serviceTaskService.getProperty('params').value);
     } else {
-      this._createProperty('params');
+      this._serviceTaskService.createProperty('params');
     }
   }
 

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/components/http-service-task/http-service-task.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/components/http-service-task/http-service-task.ts
@@ -1,7 +1,13 @@
 import {EventAggregator} from 'aurelia-event-aggregator';
-import {bindable, inject, observable} from 'aurelia-framework';
+import {bindable, inject} from 'aurelia-framework';
 
-import {IPropertiesElement, IProperty, IServiceTaskElement} from '@process-engine/bpmn-elements_contracts';
+import {
+  IExtensionElement,
+  IModdleElement,
+  IPropertiesElement,
+  IProperty,
+  IServiceTaskElement,
+} from '@process-engine/bpmn-elements_contracts';
 
 import {IBpmnModdle, IPageModel} from '../../../../../../../../../contracts';
 import environment from '../../../../../../../../../environment';
@@ -12,6 +18,7 @@ interface IAuthParameters {
     Authorization?: string,
   };
 }
+
 @inject(EventAggregator)
 export class HttpServiceTask {
 

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/components/service-task-service/service-task-service.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/components/service-task-service/service-task-service.ts
@@ -1,0 +1,98 @@
+import {IExtensionElement, IModdleElement, IPropertiesElement, IProperty} from '@process-engine/bpmn-elements_contracts';
+import {IBpmnModdle, IPageModel} from '../../../../../../../../../contracts';
+
+export class ServiceTaskService {
+
+  private _model: IPageModel;
+  private _businessObjInPanel: IModdleElement;
+
+  private _moddle: IBpmnModdle;
+
+  constructor(model: IPageModel) {
+    this._model = model;
+    this._businessObjInPanel = model.elementInPanel.businessObject;
+    this._moddle = this._model.modeler.get('moddle');
+  }
+
+  public createExtensionElement(): void {
+    const extensionValues: Array<IModdleElement> = [];
+
+    const extensionElements: IModdleElement = this._moddle.create('bpmn:ExtensionElements', {values: extensionValues});
+    this._businessObjInPanel.extensionElements = extensionElements;
+  }
+
+  public createPropertiesElement(): void {
+    const extensionElement: IExtensionElement = this._businessObjInPanel.extensionElements;
+
+    const properties: Array<IProperty> = [];
+    const propertiesElement: IPropertiesElement = this._moddle.create('camunda:Properties', {values: properties});
+
+    extensionElement.values.push(propertiesElement);
+  }
+
+  public createProperty(propertyName: string): IProperty {
+    if (this.extensionElementDoesNotExist) {
+      this.createExtensionElement();
+    }
+
+    const noPropertiesElement: boolean = this.getPropertiesElement() === undefined;
+
+    if (noPropertiesElement) {
+      this.createPropertiesElement();
+    }
+
+    const propertiesElement: IPropertiesElement = this.getPropertiesElement();
+
+    const propertyObject: Object = {
+      name: propertyName,
+      value: '',
+    };
+
+    const property: IProperty = this._moddle.create('camunda:Property', propertyObject);
+
+    propertiesElement.values.push(property);
+
+    return property;
+  }
+
+  public getProperty(propertyName: string): IProperty | undefined {
+    const propertiesElement: IPropertiesElement = this.getPropertiesElement();
+
+    if (!propertiesElement) {
+      return undefined;
+    }
+
+    const property: IProperty = propertiesElement.values.find((element: IProperty) => {
+      return element.name === propertyName;
+    });
+
+    return property;
+  }
+
+  public getPropertiesElement(): IPropertiesElement | undefined {
+    if (this.extensionElementDoesNotExist) {
+      return undefined;
+    }
+
+    const propertiesElement: IPropertiesElement = this._businessObjInPanel.extensionElements.values.find((element: IPropertiesElement) => {
+      return element.$type === 'camunda:Properties';
+    });
+
+    const noPropertyElementFound: boolean = propertiesElement === undefined;
+    if (noPropertyElementFound) {
+      return undefined;
+    }
+
+    const noValuesDefined: boolean = propertiesElement.values === undefined;
+    if (noValuesDefined) {
+      propertiesElement.values = [];
+    }
+
+    return propertiesElement;
+  }
+
+  public get extensionElementDoesNotExist(): boolean {
+    return this._businessObjInPanel.extensionElements === undefined
+        || this._businessObjInPanel.extensionElements.values === undefined;
+  }
+}

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/components/service-task-service/service-task-service.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/components/service-task-service/service-task-service.ts
@@ -75,6 +75,9 @@ export class ServiceTaskService {
     }
 
     const propertiesElement: IPropertiesElement = this._businessObjInPanel.extensionElements.values.find((element: IPropertiesElement) => {
+      if (!element) {
+        return;
+      }
       return element.$type === 'camunda:Properties';
     });
 

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/service-task.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/service-task.ts
@@ -83,7 +83,7 @@ export class ServiceTaskSection implements ISection {
 
     const noPropertyElementFound: boolean = propertiesElement === undefined;
     if (noPropertyElementFound) {
-      return undefined
+      return undefined;
     }
 
     const noValuesDefined: boolean = propertiesElement.values === undefined;

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/service-task.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/service-task.ts
@@ -1,7 +1,14 @@
 import {EventAggregator} from 'aurelia-event-aggregator';
 import {inject} from 'aurelia-framework';
 
-import {IExtensionElement, IModdleElement, IPropertiesElement, IProperty, IServiceTaskElement, IShape} from '@process-engine/bpmn-elements_contracts';
+import {
+  IExtensionElement,
+  IModdleElement,
+  IPropertiesElement,
+  IProperty,
+  IServiceTaskElement,
+  IShape,
+} from '@process-engine/bpmn-elements_contracts';
 
 import {IBpmnModdle, IPageModel, ISection} from '../../../../../../../contracts';
 import environment from '../../../../../../../environment';
@@ -120,19 +127,6 @@ export class ServiceTaskSection implements ISection {
   }
 
   private _initServiceTask(): void {
-    const extensionElementDoesNotExist: boolean = this.businessObjInPanel.extensionElements === undefined
-                                         || this.businessObjInPanel.extensionElements.values === undefined;
-
-    if (extensionElementDoesNotExist) {
-      this._createExtensionElement();
-    }
-
-    const propertyElementDoesNotExists: boolean = this._getPropertiesElement() === undefined;
-
-    if (propertyElementDoesNotExists) {
-      this._createPropertiesElement();
-    }
-
     const taskIsExternalTask: boolean = this.businessObjInPanel.type === 'external';
 
     if (taskIsExternalTask) {
@@ -145,6 +139,8 @@ export class ServiceTaskSection implements ISection {
       this.selectedKind = ServiceKind[this._getProperty('module').value];
 
       return;
+    } else {
+      this.selectedKind = ServiceKind.None;
     }
 
   }

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/service-task.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/service-task.ts
@@ -166,6 +166,10 @@ export class ServiceTaskSection implements ISection {
 
   private _deletePropertiesElementAndExtensionElements(): void {
     const indexOfPropertiesElement: number = this.businessObjInPanel.extensionElements.values.findIndex((element: IPropertiesElement) => {
+      if (!element) {
+        return;
+      }
+
       return element.$type === 'camunda:Properties';
     });
 

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/service-task.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/service-task.ts
@@ -76,10 +76,20 @@ export class ServiceTaskSection implements ISection {
     this._eventAggregator.publish(environment.events.diagramChange);
   }
 
-  private _getPropertiesElement(): IPropertiesElement {
+  private _getPropertiesElement(): IPropertiesElement | undefined {
     const propertiesElement: IPropertiesElement = this.businessObjInPanel.extensionElements.values.find((element: IPropertiesElement) => {
-      return element.$type === 'camunda:Properties' && element.values !== undefined;
+      return element.$type === 'camunda:Properties';
     });
+
+    const noPropertyElementFound: boolean = propertiesElement === undefined;
+    if (noPropertyElementFound) {
+      return undefined
+    }
+
+    const noValuesDefined: boolean = propertiesElement.values === undefined;
+    if (noValuesDefined) {
+      propertiesElement.values = [];
+    }
 
     return propertiesElement;
   }


### PR DESCRIPTION
## Changes

1. Fix the new generation of a `<camunda:Properties>` element, if a ServiceTask already has an empty PropertiesElement.
2. Remove empty ExtensionElements and PropertieElements when last Property gets deleted.
3. Fix generating an empty Property when initializing a ServiceTask.
4. Refactor ExternalTask, HTTP-Service-Task and ServiceTask component and add ServiceTaskService.

## Issues

Closes #1525 
Closes #1553 

PR: #1534

## How can others test the changes?

- Add a ServiceTask
- Configure a HTTP ServiceTask and run the process
- be sure that all works as expected
- repeat these steps with an ExternalTask
- Check that the XML does not contain empty Properties/PropertiesElement or ExtensionElements, only if a HTTP ServiceTask or ExternalTask is configured.