### PR TITLE
🐛 Fix Displaying Diagram Location for Untitled Diagrams

### DIFF
--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -520,10 +520,10 @@ export class SolutionExplorerSolution {
   }
 
   public getDiagramFolder(diagramUri: string): string {
-    if(diagramUri.includes('about:open-diagrams')) {
+    if (diagramUri.includes('about:open-diagrams')) {
       return '';
     }
-    
+
     const diagramLocation: string = this.getDiagramLocation(diagramUri);
 
     const lastIndexOfSlash: number = diagramLocation.lastIndexOf('/');

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -520,15 +520,16 @@ export class SolutionExplorerSolution {
   }
 
   public getDiagramFolder(diagramUri: string): string {
-    if (diagramUri.includes('about:open-diagrams')) {
-      return '';
-    }
-
     const diagramLocation: string = this.getDiagramLocation(diagramUri);
 
     const lastIndexOfSlash: number = diagramLocation.lastIndexOf('/');
     const lastIndexOfBackSlash: number = diagramLocation.lastIndexOf('\\');
     const indexBeforeFoldername: number = Math.max(lastIndexOfSlash, lastIndexOfBackSlash);
+
+    const indexIsInvalid: boolean = indexBeforeFoldername < 0;
+    if (indexIsInvalid) {
+      return '';
+    }
 
     const diagramFolder: string = diagramLocation.slice(indexBeforeFoldername, diagramLocation.length);
 

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -520,6 +520,10 @@ export class SolutionExplorerSolution {
   }
 
   public getDiagramFolder(diagramUri: string): string {
+    if(diagramUri.includes('about:open-diagrams')) {
+      return '';
+    }
+    
     const diagramLocation: string = this.getDiagramLocation(diagramUri);
 
     const lastIndexOfSlash: number = diagramLocation.lastIndexOf('/');


### PR DESCRIPTION
## Changes

1. Fix Displaying Diagram Location for Untitled Diagrams

PR: #1550 

## How to test the changes

- Hit CMD+N
- **Notice that the diagram location will be empty instead of 's'**
