### PR TITLE
✨Allow delete opened diagrams

### DIFF
--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -95,7 +95,7 @@ export class BpmnIo {
     eventAggregator: EventAggregator,
     openDiagramStateService: OpenDiagramStateService,
     solutionService: ISolutionService,
-    ) {
+  ) {
     this._notificationService = notificationService;
     this._eventAggregator = eventAggregator;
     this._openDiagramStateService = openDiagramStateService;
@@ -470,10 +470,10 @@ export class BpmnIo {
           .getOpenDiagrams()
           .some((diagram: IDiagram) => {
             return diagram.uri === previousUri;
-        });
+          });
 
         if (previousDiagramIsNotDeleted) {
-         await this._saveDiagramState(previousUri);
+          await this._saveDiagramState(previousUri);
         }
       }
     }

--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -468,9 +468,7 @@ export class BpmnIo {
 
         const previousDiagramIsNotDeleted: boolean = this._solutionService
           .getOpenDiagrams()
-          .some((diagram: IDiagram) => {
-            return diagram.uri === previousUri;
-          });
+          .some((diagram: IDiagram) => diagram.uri === previousUri);
 
         if (previousDiagramIsNotDeleted) {
           await this._saveDiagramState(previousUri);

--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -6,6 +6,7 @@ import {IModdleElement, IProcessRef, IPropertiesElement, IShape} from '@process-
 import * as bundle from '@process-engine/bpmn-js-custom-bundle';
 import * as bpmnlintConfig from '@process-engine/bpmn-lint_rules';
 
+import {IDiagram} from '@process-engine/solutionexplorer.contracts';
 import {
   IBpmnModeler,
   IBpmnXmlSaveOptions,
@@ -20,6 +21,7 @@ import {
   IInternalEvent,
   IKeyboard,
   ILinting,
+  ISolutionService,
   IValidateIssue,
   IValidateIssueCategory,
   IValidateResult,
@@ -35,7 +37,7 @@ import {DiagramExportService, DiagramPrintService} from './services/index';
 const sideBarRightSize: number = 35;
 const elementRegistryTimeoutMilliseconds: number = 50;
 
-@inject('NotificationService', EventAggregator, 'OpenDiagramStateService')
+@inject('NotificationService', EventAggregator, 'OpenDiagramStateService', 'SolutionService')
 export class BpmnIo {
   @bindable public propertyPanelViewModel: PropertyPanel;
   public modeler: IBpmnModeler;
@@ -72,6 +74,7 @@ export class BpmnIo {
   private _diagramExportService: IDiagramExportService;
   private _diagramPrintService: IDiagramPrintService;
   private _openDiagramStateService: OpenDiagramStateService;
+  private _solutionService: ISolutionService;
 
   private _tempProcess: IProcessRef;
   private _diagramHasChanges: boolean = false;
@@ -87,10 +90,16 @@ export class BpmnIo {
    */
   public paletteContainer: HTMLDivElement;
 
-  constructor(notificationService: NotificationService, eventAggregator: EventAggregator, openDiagramStateService: OpenDiagramStateService) {
+  constructor(
+    notificationService: NotificationService,
+    eventAggregator: EventAggregator,
+    openDiagramStateService: OpenDiagramStateService,
+    solutionService: ISolutionService,
+    ) {
     this._notificationService = notificationService;
     this._eventAggregator = eventAggregator;
     this._openDiagramStateService = openDiagramStateService;
+    this._solutionService = solutionService;
   }
 
   public created(): void {
@@ -456,7 +465,16 @@ export class BpmnIo {
           await this._saveDiagramState(newUri);
         }
       } else {
-        await this._saveDiagramState(previousUri);
+
+        const previousDiagramIsNotDeleted: boolean = this._solutionService
+          .getOpenDiagrams()
+          .some((diagram: IDiagram) => {
+            return diagram.uri === previousUri;
+        });
+
+        if (previousDiagramIsNotDeleted) {
+         await this._saveDiagramState(previousUri);
+        }
       }
     }
 

--- a/src/modules/solution-explorer/solution-explorer-solution/delete-diagram-modal/delete-diagram-modal.html
+++ b/src/modules/solution-explorer/solution-explorer-solution/delete-diagram-modal/delete-diagram-modal.html
@@ -1,12 +1,9 @@
 <template>
   <require from="./delete-diagram-modal.css"></require>
 
-  <modal if.bind="showModal" 
-         header-text.bind="diagramIsUnsaved ? 'You are deleting a file with unsaved changes.' : 'Are you sure you want to delete this diagram?'" 
-         origin.bind="deleteDiagramModal">
+  <modal if.bind="showModal" header-text="Are you sure you want to delete this diagram?" origin.bind="deleteDiagramModal">
     <template replace-part="modal-body">
-        <p if.bind="diagramIsUnsaved">Your changes will be lost if you don't save them.</p>
-        <p>Diagram Name: ${origin.diagram.name}</p>
+      Diagram Name: ${origin.diagram.name}
     </template>
     <template replace-part="modal-footer">
       <button type="button" class="btn btn-default" data-dismiss="modal" id="cancelDeleteDiagramButton">Cancel</button>

--- a/src/modules/solution-explorer/solution-explorer-solution/delete-diagram-modal/delete-diagram-modal.html
+++ b/src/modules/solution-explorer/solution-explorer-solution/delete-diagram-modal/delete-diagram-modal.html
@@ -1,9 +1,12 @@
 <template>
   <require from="./delete-diagram-modal.css"></require>
 
-  <modal if.bind="showModal" header-text="Are you sure you want to delete this diagram?" origin.bind="deleteDiagramModal">
+  <modal if.bind="showModal" 
+         header-text.bind="diagramIsUnsaved ? 'You are deleting a file with unsaved changes.' : 'Are you sure you want to delete this diagram?'" 
+         origin.bind="deleteDiagramModal">
     <template replace-part="modal-body">
-          Diagram Name: ${origin.diagram.name}
+        <p if.bind="diagramIsUnsaved">Your changes will be lost if you don't save them.</p>
+        <p>Diagram Name: ${origin.diagram.name}</p>
     </template>
     <template replace-part="modal-footer">
       <button type="button" class="btn btn-default" data-dismiss="modal" id="cancelDeleteDiagramButton">Cancel</button>

--- a/src/modules/solution-explorer/solution-explorer-solution/delete-diagram-modal/delete-diagram-modal.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/delete-diagram-modal/delete-diagram-modal.ts
@@ -9,7 +9,6 @@ import {Router} from 'aurelia-router';
 import {IDiagram, ISolution} from '@process-engine/solutionexplorer.contracts';
 import {ISolutionExplorerService} from '@process-engine/solutionexplorer.service.contracts';
 
-import {IDiagramState, IEventFunction, NotificationType} from '../../../../contracts/index';
 import {NotificationService} from '../../../../services/notification-service/notification.service';
 import {OpenDiagramsSolutionExplorerService} from '../../../../services/solution-explorer-services/OpenDiagramsSolutionExplorerService';
 import {OpenDiagramStateService} from '../../../../services/solution-explorer-services/OpenDiagramStateService';
@@ -19,7 +18,6 @@ export class DeleteDiagramModal {
   public showModal: boolean = false;
   public diagram: IDiagram;
   public deleteDiagramModal: DeleteDiagramModal = this;
-  public diagramIsUnsaved: boolean = false;
 
   private _solutionService: ISolutionExplorerService;
   private _notificationService: NotificationService;
@@ -43,8 +41,6 @@ export class DeleteDiagramModal {
     this.diagram = diagram;
     this._solutionService = solutionService;
 
-    const diagramState: IDiagramState = this._openDiagramStateService.loadDiagramState(this.diagram.uri);
-    this.diagramIsUnsaved = diagramState ? diagramState.metaData.isChanged : false;
 
     this.showModal = true;
 

--- a/src/modules/solution-explorer/solution-explorer-solution/delete-diagram-modal/delete-diagram-modal.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/delete-diagram-modal/delete-diagram-modal.ts
@@ -33,7 +33,7 @@ export class DeleteDiagramModal {
     router: Router,
     openDiagramService: OpenDiagramsSolutionExplorerService,
     solutionService: ISolutionService,
-    ) {
+  ) {
     this._notificationService = notificationService;
     this._openDiagramStateService = openDiagramStateService;
     this._router = router;

--- a/src/modules/solution-explorer/solution-explorer-solution/delete-diagram-modal/delete-diagram-modal.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/delete-diagram-modal/delete-diagram-modal.ts
@@ -91,8 +91,6 @@ export class DeleteDiagramModal {
       this._notificationService.showNotification(NotificationType.ERROR, message);
     }
 
-    this._openDiagramStateService.deleteDiagramState(this.diagram.uri);
-
     const diagramIndex: number = this._openDiagramService
       .getOpenedDiagrams()
       .findIndex((diagram: IDiagram) => diagram.uri === this.diagram.uri);
@@ -118,7 +116,10 @@ export class DeleteDiagramModal {
         view: this._router.currentInstruction.params.view,
       });
     }
+
     this._openDiagramService.closeDiagram(this.diagram);
+    this._solutionService.removeOpenDiagramByUri(this.diagram.uri);
+    this._openDiagramStateService.deleteDiagramState(this.diagram.uri);
 
     this.diagram = undefined;
     this._solutionExplorerService = undefined;

--- a/src/modules/solution-explorer/solution-explorer-solution/delete-diagram-modal/delete-diagram-modal.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/delete-diagram-modal/delete-diagram-modal.ts
@@ -95,11 +95,11 @@ export class DeleteDiagramModal {
       .getOpenedDiagrams()
       .findIndex((diagram: IDiagram) => diagram.uri === this.diagram.uri);
 
-    const searchIndex: number = diagramIndex === 0 ? diagramIndex + 1 : diagramIndex - 1;
+    const previousOrNextDiagramIndex: number = diagramIndex === 0 ? diagramIndex + 1 : diagramIndex - 1;
 
     const diagramToNavigateTo: IDiagram = this._openDiagramService
       .getOpenedDiagrams()
-      .find((diagram: IDiagram, index: number) => index === searchIndex);
+      .find((diagram: IDiagram, index: number) => index === previousOrNextDiagramIndex);
 
     const lastIndexOfSlash: number = diagramToNavigateTo.uri.lastIndexOf('/');
     const lastIndexOfBackSlash: number = diagramToNavigateTo.uri.lastIndexOf('\\');

--- a/src/modules/solution-explorer/solution-explorer-solution/delete-diagram-modal/delete-diagram-modal.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/delete-diagram-modal/delete-diagram-modal.ts
@@ -99,9 +99,7 @@ export class DeleteDiagramModal {
 
     const diagramToNavigateTo: IDiagram = this._openDiagramService
       .getOpenedDiagrams()
-      .find((diagram: IDiagram, index: number) => {
-        return index === searchIndex;
-      });
+      .find((diagram: IDiagram, index: number) => index === searchIndex);
 
     const activeSolution: ISolution = await this._solutionExplorerService.loadSolution();
     const diagramIsDeployed: boolean = this.diagram.uri.startsWith('http');

--- a/src/modules/solution-explorer/solution-explorer-solution/delete-diagram-modal/delete-diagram-modal.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/delete-diagram-modal/delete-diagram-modal.ts
@@ -9,38 +9,41 @@ import {Router} from 'aurelia-router';
 import {IDiagram, ISolution} from '@process-engine/solutionexplorer.contracts';
 import {ISolutionExplorerService} from '@process-engine/solutionexplorer.service.contracts';
 
+import {IEventFunction, ISolutionService, NotificationType} from '../../../../contracts/index';
 import {NotificationService} from '../../../../services/notification-service/notification.service';
 import {OpenDiagramsSolutionExplorerService} from '../../../../services/solution-explorer-services/OpenDiagramsSolutionExplorerService';
 import {OpenDiagramStateService} from '../../../../services/solution-explorer-services/OpenDiagramStateService';
 
-@inject('NotificationService', 'OpenDiagramStateService', Router, 'OpenDiagramService')
+@inject('NotificationService', 'OpenDiagramStateService', Router, 'OpenDiagramService', 'SolutionService')
 export class DeleteDiagramModal {
   public showModal: boolean = false;
   public diagram: IDiagram;
   public deleteDiagramModal: DeleteDiagramModal = this;
 
-  private _solutionService: ISolutionExplorerService;
+  private _solutionExplorerService: ISolutionExplorerService;
   private _notificationService: NotificationService;
   private _openDiagramStateService: OpenDiagramStateService;
   private _openDiagramService: OpenDiagramsSolutionExplorerService;
   private _router: Router;
+  private _solutionService: ISolutionService;
 
   constructor(
     notificationService: NotificationService,
     openDiagramStateService: OpenDiagramStateService,
     router: Router,
     openDiagramService: OpenDiagramsSolutionExplorerService,
+    solutionService: ISolutionService,
     ) {
     this._notificationService = notificationService;
     this._openDiagramStateService = openDiagramStateService;
     this._router = router;
     this._openDiagramService = openDiagramService;
+    this._solutionService = solutionService;
   }
 
-  public async show(diagram: IDiagram, solutionService: ISolutionExplorerService): Promise<boolean> {
+  public async show(diagram: IDiagram, solutionExplorerService: ISolutionExplorerService): Promise<boolean> {
     this.diagram = diagram;
-    this._solutionService = solutionService;
-
+    this._solutionExplorerService = solutionExplorerService;
 
     this.showModal = true;
 
@@ -74,14 +77,14 @@ export class DeleteDiagramModal {
 
   private _closeModal(): void {
     this.diagram = undefined;
-    this._solutionService = undefined;
+    this._solutionExplorerService = undefined;
 
     this.showModal = false;
   }
 
   private async _deleteDiagram(): Promise<void> {
     try {
-      await this._solutionService.deleteDiagram(this.diagram);
+      await this._solutionExplorerService.deleteDiagram(this.diagram);
     } catch (error) {
       const message: string = `Unable to delete the diagram: ${error.message}`;
 
@@ -102,7 +105,7 @@ export class DeleteDiagramModal {
         return index === searchIndex;
       });
 
-    const activeSolution: ISolution = await this._solutionService.loadSolution();
+    const activeSolution: ISolution = await this._solutionExplorerService.loadSolution();
     const diagramIsDeployed: boolean = this.diagram.uri.startsWith('http');
 
     if (diagramIsDeployed || !diagramToNavigateTo) {
@@ -118,7 +121,7 @@ export class DeleteDiagramModal {
     this._openDiagramService.closeDiagram(this.diagram);
 
     this.diagram = undefined;
-    this._solutionService = undefined;
+    this._solutionExplorerService = undefined;
 
     this.showModal = false;
   }

--- a/src/modules/solution-explorer/solution-explorer-solution/delete-diagram-modal/delete-diagram-modal.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/delete-diagram-modal/delete-diagram-modal.ts
@@ -6,7 +6,7 @@
 import {inject} from 'aurelia-framework';
 import {Router} from 'aurelia-router';
 
-import {IDiagram, ISolution} from '@process-engine/solutionexplorer.contracts';
+import {IDiagram} from '@process-engine/solutionexplorer.contracts';
 import {ISolutionExplorerService} from '@process-engine/solutionexplorer.service.contracts';
 
 import {IEventFunction, ISolutionService, NotificationType} from '../../../../contracts/index';
@@ -101,7 +101,11 @@ export class DeleteDiagramModal {
       .getOpenedDiagrams()
       .find((diagram: IDiagram, index: number) => index === searchIndex);
 
-    const activeSolution: ISolution = await this._solutionExplorerService.loadSolution();
+    const lastIndexOfSlash: number = diagramToNavigateTo.uri.lastIndexOf('/');
+    const lastIndexOfBackSlash: number = diagramToNavigateTo.uri.lastIndexOf('\\');
+    const indexBeforeFilename: number = Math.max(lastIndexOfSlash, lastIndexOfBackSlash);
+    const activeSolutionUri: string = diagramToNavigateTo.uri.substring(0, indexBeforeFilename);
+
     const diagramIsDeployed: boolean = this.diagram.uri.startsWith('http');
 
     if (diagramIsDeployed || !diagramToNavigateTo) {
@@ -110,7 +114,7 @@ export class DeleteDiagramModal {
       this._router.navigateToRoute('design', {
         diagramName: diagramToNavigateTo.name,
         diagramUri: diagramToNavigateTo.uri,
-        solutionUri: activeSolution.uri,
+        solutionUri: activeSolutionUri,
         view: this._router.currentInstruction.params.view,
       });
     }

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.html
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.html
@@ -69,10 +69,10 @@
             </button>
 
             <button
-              class.bind="activeDiagramUri !== diagram.uri ? 'button' : 'button button--disabled'"
+              class="button"
               if.bind="canDeleteDiagram()"
               click.delegate="showDeleteDiagramModal(diagram, $event)"
-              title.bind="activeDiagramUri !== diagram.uri ? 'Delete the diagram' : 'The diagram is currently open, it cant be deleted.'">
+              title="Delete the diagram">
 
               <i class="fa fa-trash"></i>
             </button>

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -229,16 +229,6 @@ export class SolutionExplorerSolution {
      */
     event.stopPropagation();
 
-    if (await this._isDiagramDetailViewOfDiagramOpen(diagram.uri)) {
-      const messageTitle: string = '<h4 class="toast-message__headline">Not supported while opened.</h4>';
-      const messageBody: string = 'Deleting of opened diagrams is currently not supported. Please switch to another diagram and try again.';
-      const message: string = `${messageTitle}\n${messageBody}`;
-
-      this._notificationService.showNotification(NotificationType.INFO, message, {toastClass: 'toast-not-allowed-renaming-or-deleting'});
-
-      return;
-    }
-
     const diagramWasDeleted: boolean = await this.deleteDiagramModal.show(diagram, this.solutionService);
 
     if (diagramWasDeleted) {
@@ -799,8 +789,7 @@ export class SolutionExplorerSolution {
       return false;
     }
 
-    const openedDiagramUri: string = this.activeDiagramUri;
-    const diagramIsOpened: boolean = diagramUriToCheck === openedDiagramUri;
+    const diagramIsOpened: boolean = diagramUriToCheck === this.activeDiagramUri;
 
     return diagramIsOpened;
   }


### PR DESCRIPTION
## Changes

1. Always enable delete diagram button
2. Remove `not supported `notification
3. Add custom modal message if diagram contains changes
4. Handle deleting diagram if it is open

## Issues

Closes #1564 

PR: #1565 

## How to test the changes

- open a diagram
- click on the trash icon which shows up when hovering over the selected diagram entry
- use the modal to delete the diagram
- see that it has been deleted.

If you are on a remote solution you get navigated to the start-page after deletion has finished.
If you are on a file system solution you get navigated to the next diagram which is opened as Open Diagram. When there is no other diagram opened you will get also navigated to the start-page.

You have not the possibility to save a file with unsaved changed while deleting it. The behaviour is inspired by VSCode.

