### PR TITLE
🐛Fix initial loading of solutions

### DIFF
--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
@@ -175,6 +175,16 @@ export class SolutionExplorerList {
 
       const errorIsFailedToFetch: boolean = error.message === 'Failed to fetch';
       if (errorIsFailedToFetch) {
+
+         /**
+         * If opening the solution has failed with a 'Failed to fetch' the solution has not been added yet
+         * so we must open it again when it is started. The version indicates when that has been done.
+         */
+        if (!uriIsNotInternalProcessEngine) {
+          const processEngineHasStarted: string = await this._getProcessEngineVersionFromInternalPE(uri);
+          this.openSolution(uri, insertAtBeginning, identity);
+          return;
+        }
         /**
          * TODO: The error message only contains 'Failed to fetch' if the connection
          * failed. A more detailed cause (such as Connection Refused) would

--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
@@ -394,7 +394,7 @@ export class SolutionExplorerList {
             makeRequest();
           }
           // tslint:disable-next-line: no-magic-numbers
-        }, 10);
+        }, 100);
       });
 
       makeRequest();

--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
@@ -146,8 +146,11 @@ export class SolutionExplorerList {
     }
 
     let processEngineVersion: string;
+    const internalProcessEngineRoute: string = window.localStorage.getItem('InternalProcessEngineRoute');
+    const uriIsNotInternalProcessEngine: boolean = internalProcessEngineRoute !== uri;
+
     try {
-      if (uriIsRemote) {
+      if (uriIsRemote && uriIsNotInternalProcessEngine) {
         const response: Response = await fetch(uri);
 
         const responseJSON: object & {version: string} = await response.json();
@@ -190,6 +193,10 @@ export class SolutionExplorerList {
 
     if (arrayAlreadyContainedURI) {
       throw new Error('Solution is already opened.');
+    }
+
+    if (!processEngineVersion && !uriIsNotInternalProcessEngine) {
+      processEngineVersion = await this._getProcessEngineVersionFromInternalPE(uri);
     }
 
     this._addSolutionEntry(uri, solutionExplorer, identity, insertAtBeginning, processEngineVersion);
@@ -362,6 +369,26 @@ export class SolutionExplorerList {
     });
 
     return sortedEntries;
+  }
+
+  private _getProcessEngineVersionFromInternalPE(uri: string): Promise<string> {
+    return new Promise((resolve: Function): void => {
+      const makeRequest: Function = ((): void => {
+        setTimeout(async() => {
+          try {
+            const response: Response = await fetch(uri);
+            const responseJSON: object & {version: string} = await response.json();
+
+            resolve(responseJSON.version);
+          } catch (error) {
+            makeRequest();
+          }
+          // tslint:disable-next-line: no-magic-numbers
+        }, 10);
+      });
+
+      makeRequest();
+    });
   }
 
   private _cleanupSolution(uri: string): void {

--- a/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.ts
+++ b/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.ts
@@ -70,10 +70,10 @@ export class SolutionExplorerPanel {
     try {
       if (internalSolutionWasPersisted) {
         // Only open the internal solution with the persisted identity when it as persisted.
-        await this.solutionExplorerList.openSolution(uriOfProcessEngine, true, persistedInternalSolution.identity);
+        this.solutionExplorerList.openSolution(uriOfProcessEngine, true, persistedInternalSolution.identity);
       } else {
         // Otherwise just open it without an identity.
-        await this.solutionExplorerList.openSolution(uriOfProcessEngine);
+        this.solutionExplorerList.openSolution(uriOfProcessEngine);
       }
     } catch {
       return;

--- a/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.ts
+++ b/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.ts
@@ -66,12 +66,17 @@ export class SolutionExplorerPanel {
 
     const persistedInternalSolution: ISolutionEntry = this._solutionService.getSolutionEntryForUri(uriOfProcessEngine);
     const internalSolutionWasPersisted: boolean = persistedInternalSolution !== undefined;
-    if (internalSolutionWasPersisted) {
-      // Only open the internal solution with the persisted identity when it as persisted.
-      await this.solutionExplorerList.openSolution(uriOfProcessEngine, true, persistedInternalSolution.identity);
-    } else {
-      // Otherwise just open it without an identity.
-      await this.solutionExplorerList.openSolution(uriOfProcessEngine);
+
+    try {
+      if (internalSolutionWasPersisted) {
+        // Only open the internal solution with the persisted identity when it as persisted.
+        await this.solutionExplorerList.openSolution(uriOfProcessEngine, true, persistedInternalSolution.identity);
+      } else {
+        // Otherwise just open it without an identity.
+        await this.solutionExplorerList.openSolution(uriOfProcessEngine);
+      }
+    } catch {
+      return;
     }
 
     // Open the previously opened solutions.

--- a/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.ts
+++ b/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.ts
@@ -81,7 +81,7 @@ export class SolutionExplorerPanel {
 
     // Open the previously opened solutions.
     const previouslyOpenedSolutions: Array<ISolutionEntry> = this._solutionService.getPersistedEntries();
-    previouslyOpenedSolutions.forEach(async(entry: ISolutionEntry) => {
+    previouslyOpenedSolutions.forEach((entry: ISolutionEntry) => {
       // We are not adding the solution of the connect PE here again since that happened above.
       const entryIsNotConnectedProcessEngine: boolean = entry.uri !== uriOfProcessEngine;
       if (entryIsNotConnectedProcessEngine) {
@@ -91,7 +91,7 @@ export class SolutionExplorerPanel {
          * produced by the openSolution method.
          */
         try {
-          await this.solutionExplorerList.openSolution(entry.uri, false, entry.identity);
+          this.solutionExplorerList.openSolution(entry.uri, false, entry.identity);
         } catch (error) {
 
           return;
@@ -100,9 +100,9 @@ export class SolutionExplorerPanel {
     });
 
     const persistedOpenDiagrams: Array<IDiagram> = this._solutionService.getOpenDiagrams();
-    persistedOpenDiagrams.forEach(async(diagram: IDiagram) => {
+    persistedOpenDiagrams.forEach((diagram: IDiagram) => {
       try {
-        await this.solutionExplorerList.openDiagram(diagram.uri);
+        this.solutionExplorerList.openDiagram(diagram.uri);
       } catch {
         return;
       }


### PR DESCRIPTION
## Changes

1. Add try/catch while loading the internal process engine
2. Fix bug where the internal solution does not get added to the solution explorer if its HTTP server isn't ready

## Issues

Closes #1566 

PR: #1567 

## How to test the changes

- generate a DB with more than 500 running process instances
- build the electron app of the studio
- start it
- see that all solutions get opened
