### PR TITLE
Avoid update error on double click

### DIFF
--- a/src/modules/status-bar/status-bar.html
+++ b/src/modules/status-bar/status-bar.html
@@ -27,10 +27,10 @@
           </div>
           <span class="update-dropdown-text">${(updateProgressData.bytesPerSecond/1000).toFixed(2)} KB/s - ${(updateProgressData.transferred/1000/1000).toFixed(2)} MB of ${(updateProgressData.total/1000/1000).toFixed(2)} MB</span>
           <div class="update-dropdown-progress-container">
-            <div class="update-dropdown-cancel-download-button" title="Cancel download." click.delegate="cancelUpdate()"><i class="fas fa-times"></i></div>
             <div class="progress update-dropdown-progressbar">
               <div class="progress-bar progress-bar-striped progress-bar-animated update-dropdown-progressbar-progress" role="progressbar" css="width: ${updateProgressData.percent}%;">${updateProgressData.percent.toFixed(1)}%</div>
             </div>
+            <button class="btn btn-default update-dropdown-cancel-download-button" title="Abort download." click.delegate="cancelUpdate()">Abort Download</button>
           </div>
         </template>
         <template if.bind="updateDownloadFinished">

--- a/src/modules/status-bar/status-bar.html
+++ b/src/modules/status-bar/status-bar.html
@@ -17,8 +17,8 @@
             Click here for release notes
           </a>
           <div class="update-dropdown-button-container">
-            <button class="btn btn-default update-dropdown-cancel-button" click.delegate="hideDropdown()">Cancel</button>
-            <button class="btn btn-primary update-dropdown-update-button" click.delegate="startUpdate()">Update</button>
+            <button class="btn btn-default update-dropdown-cancel-button" click.delegate="hideDropdown()" disabled.bind="updateStarted">Cancel</button>
+            <button class="btn btn-primary update-dropdown-update-button" click.delegate="startUpdate()" disabled.bind="updateStarted">Update</button>
           </div>
         </template>
         <template if.bind="isDownloading && !updateDownloadFinished">

--- a/src/modules/status-bar/status-bar.scss
+++ b/src/modules/status-bar/status-bar.scss
@@ -126,7 +126,7 @@
 
 .update-dropdown-progressbar {
   height: 16px;
-  margin: 0 25px 0 10px;
+  margin: 0 10px 0 10px;
 }
 
 .update-dropdown-progressbar-progress {
@@ -140,12 +140,7 @@
 }
 
 .update-dropdown-cancel-download-button {
-  float: right;
-  width: 15px;
-  height: 15px;
-  margin-right: 5px;
-  line-height: 16px;
-  cursor: pointer;
+  margin-top: 5px;
 }
 
 .update-dropdown-button-container {

--- a/src/modules/status-bar/status-bar.ts
+++ b/src/modules/status-bar/status-bar.ts
@@ -208,6 +208,7 @@ export class StatusBar {
     this._ipcRenderer.send('cancel_update');
 
     this.updateProgressData = undefined;
+    this.updateStarted = false;
   }
 
   private _refreshRightButtons(): void {

--- a/src/modules/status-bar/status-bar.ts
+++ b/src/modules/status-bar/status-bar.ts
@@ -36,6 +36,7 @@ export class StatusBar {
   public updateAvailable: boolean = false;
   public updateDropdown: HTMLElement;
   public updateDownloadFinished: boolean = false;
+  public updateStarted: boolean = false;
 
   public DiffMode: typeof DiffMode = DiffMode;
 
@@ -183,11 +184,20 @@ export class StatusBar {
   }
 
   public hideDropdown(): void {
+    if (this.updateStarted) {
+      return;
+    }
+
     this.updateDropdown.classList.remove('show');
   }
 
   public startUpdate(): void {
+    if (this.updateStarted) {
+      return;
+    }
+
     this._ipcRenderer.send('download_update');
+    this.updateStarted = true;
   }
 
   public installUpdate(): void {


### PR DESCRIPTION
## Changes

1. Disable buttons if the update has been started
2. Improve the `Abort Download` button

![Jul-11-2019 13-18-28](https://user-images.githubusercontent.com/17065920/61046854-6e4b3300-a3de-11e9-8382-d1a4e8136752.gif)


## Issues

Closes #YourIssueNumber

PR: #1578 

## How to test the changes

- download and install the studio version from [here](https://ci.process-engine.io/blue/organizations/jenkins/process-engine_node-lts%2Fbpmn-studio/detail/feature%2Favoid_update-error_on_double-click/4/artifacts)
- If you have already installed version 5.6.0, you must first delete it from the updater cache
```
macOS: ~/Library/Application Support/Caches/bpmn-studio-updater/pending
Windows: C:\Users\<user>\AppData\Local\bpmn-studio-updater\pending
```
- start the studio and update it