### PR TITLE
🐛 Fix bug where the delete diagram modal is still open after deletion

### DIFF
--- a/src/modules/solution-explorer/solution-explorer-solution/delete-diagram-modal/delete-diagram-modal.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/delete-diagram-modal/delete-diagram-modal.ts
@@ -91,15 +91,19 @@ export class DeleteDiagramModal {
       this._notificationService.showNotification(NotificationType.ERROR, message);
     }
 
-    const diagramIndex: number = this._openDiagramService
-      .getOpenedDiagrams()
-      .findIndex((diagram: IDiagram) => diagram.uri === this.diagram.uri);
+    const diagramIndex: number = this._isRunningInElectron
+                               ? this._openDiagramService
+                                  .getOpenedDiagrams()
+                                  .findIndex((diagram: IDiagram) => diagram.uri === this.diagram.uri)
+                               : undefined;
 
     const previousOrNextDiagramIndex: number = diagramIndex === 0 ? diagramIndex + 1 : diagramIndex - 1;
 
-    const diagramToNavigateTo: IDiagram = this._openDiagramService
-      .getOpenedDiagrams()
-      .find((diagram: IDiagram, index: number) => index === previousOrNextDiagramIndex);
+    const diagramToNavigateTo: IDiagram = this._isRunningInElectron
+                                        ? this._openDiagramService
+                                            .getOpenedDiagrams()
+                                            .find((diagram: IDiagram, index: number) => index === previousOrNextDiagramIndex)
+                                        : undefined;
 
     const diagramIsDeployed: boolean = this.diagram.uri.startsWith('http');
 
@@ -119,13 +123,19 @@ export class DeleteDiagramModal {
       });
     }
 
-    this._openDiagramService.closeDiagram(this.diagram);
-    this._solutionService.removeOpenDiagramByUri(this.diagram.uri);
-    this._openDiagramStateService.deleteDiagramState(this.diagram.uri);
+    if (this._isRunningInElectron) {
+      this._openDiagramService.closeDiagram(this.diagram);
+      this._solutionService.removeOpenDiagramByUri(this.diagram.uri);
+      this._openDiagramStateService.deleteDiagramState(this.diagram.uri);
+    }
 
     this.diagram = undefined;
     this._solutionExplorerService = undefined;
 
     this.showModal = false;
+  }
+
+  private get _isRunningInElectron(): boolean {
+    return (window as any).nodeRequire;
   }
 }

--- a/src/modules/solution-explorer/solution-explorer-solution/delete-diagram-modal/delete-diagram-modal.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/delete-diagram-modal/delete-diagram-modal.ts
@@ -91,7 +91,9 @@ export class DeleteDiagramModal {
       this._notificationService.showNotification(NotificationType.ERROR, message);
     }
 
-    const diagramIndex: number = this._isRunningInElectron
+    const openDiagramServiceIsAvailable: boolean = typeof this._openDiagramService !== 'string';
+
+    const diagramIndex: number = openDiagramServiceIsAvailable
                                ? this._openDiagramService
                                   .getOpenedDiagrams()
                                   .findIndex((diagram: IDiagram) => diagram.uri === this.diagram.uri)
@@ -99,7 +101,7 @@ export class DeleteDiagramModal {
 
     const previousOrNextDiagramIndex: number = diagramIndex === 0 ? diagramIndex + 1 : diagramIndex - 1;
 
-    const diagramToNavigateTo: IDiagram = this._isRunningInElectron
+    const diagramToNavigateTo: IDiagram = openDiagramServiceIsAvailable
                                         ? this._openDiagramService
                                             .getOpenedDiagrams()
                                             .find((diagram: IDiagram, index: number) => index === previousOrNextDiagramIndex)
@@ -123,7 +125,7 @@ export class DeleteDiagramModal {
       });
     }
 
-    if (this._isRunningInElectron) {
+    if (openDiagramServiceIsAvailable) {
       this._openDiagramService.closeDiagram(this.diagram);
       this._solutionService.removeOpenDiagramByUri(this.diagram.uri);
       this._openDiagramStateService.deleteDiagramState(this.diagram.uri);
@@ -133,9 +135,5 @@ export class DeleteDiagramModal {
     this._solutionExplorerService = undefined;
 
     this.showModal = false;
-  }
-
-  private get _isRunningInElectron(): boolean {
-    return (window as any).nodeRequire;
   }
 }


### PR DESCRIPTION
## Changes

1. Fix still open delete-diagram modal on web version

## Issues

Closes #1579 

PR: #1580 

## How to test the changes

- look at #1579 
