### PR TITLE
✨Add empty activities to task list

### DIFF
--- a/src/modules/inspect/task-list/task-list.html
+++ b/src/modules/inspect/task-list/task-list.html
@@ -10,16 +10,16 @@
           <th>Task ID</th>
           <th></th>
         </tr>
-        <tr repeat.for="entry of shownTasks" class="task-list-item" id="taskList-${entry.userTask ? entry.userTask.processModelId : entry.manualTask.processModelId}">
+        <tr repeat.for="entry of shownTasks" class="task-list-item" id="taskList-${entry.processModelId}">
           <td>
-            <a>${entry.userTask ? entry.userTask.correlationId : entry.manualTask.correlationId}</a>
+            <a>${entry.correlationId}</a>
           </td>
           <td>
-            <a route-href="route: design; params.bind: { diagramName: entry.userTask ? entry.userTask.processModelId : entry.manualTask.processModelId,
+            <a route-href="route: design; params.bind: { diagramName: entry.processModelId,
                                           solutionUri: activeSolutionEntry.uri, view: 'detail' }"
-               class="task-list-item-modelname">${entry.userTask ? entry.userTask.processModelId : entry.manualTask.processModelId}</a>
+               class="task-list-item-modelname">${entry.processModelId}</a>
           </td>
-          <td>${entry.userTask.id ? entry.userTask.id : entry.manualTask.id}</td>
+          <td>${entry.id}</td>
           <td class="task-list__last-table-cell">
             <button class="btn btn-default task-list-continue-button" click.delegate="continueTask(entry)">Continue</button>
           </td>

--- a/src/modules/inspect/task-list/task-list.ts
+++ b/src/modules/inspect/task-list/task-list.ts
@@ -20,18 +20,10 @@ interface ITaskListRouteParameters {
   correlationId?: string;
 }
 
-interface IUserTaskWithProcessModel {
-  userTask: DataModels.UserTasks.UserTask;
-  processModel: DataModels.ProcessModels.ProcessModel;
-}
-
-interface IManualTaskWithProcessModel {
-  manualTask: DataModels.ManualTasks.ManualTask;
-  processModel: DataModels.ProcessModels.ProcessModel;
-}
-
-type UserAndManualTasksWithProcessModels = Array<IUserTaskWithProcessModel & IManualTaskWithProcessModel>;
-type PromisesForUserAndManualTasks = Promise<UserAndManualTasksWithProcessModels>;
+type Task = DataModels.ManualTasks.ManualTask
+          & DataModels.UserTasks.UserTask
+          & DataModels.EmptyActivities.EmptyActivity
+          & {processModel: DataModels.ProcessModels.ProcessModel};
 
 @inject(EventAggregator, 'ManagementApiClientService', Router, 'NotificationService', 'SolutionService')
 export class TaskList {
@@ -53,9 +45,9 @@ export class TaskList {
   private _solutionService: ISolutionService;
 
   private _subscriptions: Array<Subscription>;
-  private _userTasks: Array<IUserTaskWithProcessModel>;
+  private _tasks: Array<Task>;
   private _pollingTimeout: NodeJS.Timer | number;
-  private _getTasks: () => Promise<Array<IUserTaskWithProcessModel>>;
+  private _getTasks: () => Promise<Array<Task>>;
   private _isAttached: boolean = false;
 
   constructor(eventAggregator: EventAggregator,
@@ -81,15 +73,15 @@ export class TaskList {
     const hasProcessInstanceId: boolean = processInstanceId !== undefined;
 
     if (hasDiagramName) {
-      this._getTasks = (): Promise<Array<IUserTaskWithProcessModel>> => {
+      this._getTasks = (): Promise<Array<Task>> => {
         return this._getTasksForProcessModel(diagramName);
       };
     } else if (hasCorrelationId) {
-      this._getTasks = (): Promise<Array<IUserTaskWithProcessModel>> => {
+      this._getTasks = (): Promise<Array<Task>> => {
         return this._getTasksForCorrelation(correlationId);
       };
     } else if (hasProcessInstanceId) {
-      this._getTasks = (): Promise<Array<IUserTaskWithProcessModel>> => {
+      this._getTasks = (): Promise<Array<Task>> => {
         return this._getTasksForProcessInstanceId(processInstanceId);
       };
     } else {
@@ -152,15 +144,10 @@ export class TaskList {
     this._router.navigateBack();
   }
 
-  public continueTask(taskWithProcessModel: IUserTaskWithProcessModel & IManualTaskWithProcessModel): void {
-    const taskIsAnUserTask: boolean = taskWithProcessModel.userTask !== undefined;
-    const taskToProcess: DataModels.UserTasks.UserTask | DataModels.ManualTasks.ManualTask = taskIsAnUserTask
-                                                                                           ? taskWithProcessModel.userTask
-                                                                                           : taskWithProcessModel.manualTask;
+  public continueTask(taskWithProcessModel: Task): void {
+    const {correlationId, id, processInstanceId} = taskWithProcessModel;
 
-    const {correlationId, id, processInstanceId} = taskToProcess;
-
-    const tasksProcessModelId: string = taskToProcess.processModelId;
+    const tasksProcessModelId: string = taskWithProcessModel.processModelId;
 
     const taskIsFromCallActivity: boolean = taskWithProcessModel.processModel.id !== tasksProcessModelId;
 
@@ -177,60 +164,60 @@ export class TaskList {
     });
   }
 
-  public get shownTasks(): Array<IUserTaskWithProcessModel> {
+  public get shownTasks(): Array<Task> {
     return this.tasks.slice((this.currentPage - 1) * this.pageSize, this.pageSize * this.currentPage);
   }
 
-  public get tasks(): Array<IUserTaskWithProcessModel> {
-    const noTasksExisitng: boolean = this._userTasks === undefined;
+  public get tasks(): Array<Task> {
+    const noTasksExisitng: boolean = this._tasks === undefined;
     if (noTasksExisitng) {
       return [];
     }
 
-    return this._userTasks;
+    return this._tasks;
   }
 
-  private async _getAllTasks(): Promise<Array<IUserTaskWithProcessModel & IManualTaskWithProcessModel>> {
+  private async _getAllTasks(): Promise<Array<Task>> {
 
     const allProcessModels: DataModels.ProcessModels.ProcessModelList = await this._managementApiService
       .getProcessModels(this.activeSolutionEntry.identity);
 
     // TODO (ph): This will create 1 + n http reqeusts, where n is the number of process models in the processengine.
-    const promisesForAllUserTasks: Array<Promise<Array<IUserTaskWithProcessModel>>> = allProcessModels.processModels
-      .map(async(processModel: DataModels.ProcessModels.ProcessModel): Promise<Array<IUserTaskWithProcessModel>> => {
+    const promisesForAllUserTasks: Array<Promise<Array<Task>>> = allProcessModels.processModels
+      .map(async(processModel: DataModels.ProcessModels.ProcessModel): Promise<Array<Task>> => {
         const userTaskList: DataModels.UserTasks.UserTaskList = await this._managementApiService
           .getUserTasksForProcessModel(this.activeSolutionEntry.identity, processModel.id);
 
-        const userTasksAndProcessModels: Array<IUserTaskWithProcessModel> = this._addProcessModelToUserTasks(userTaskList, processModel);
+        const userTasksAndProcessModels: Array<Task> = this._addProcessModelToUserTasks(userTaskList, processModel);
 
         return userTasksAndProcessModels;
       });
 
-    const promisesForAllManualTasks: Array<Promise<Array<IManualTaskWithProcessModel>>> = allProcessModels.processModels
-      .map(async(processModel: DataModels.ProcessModels.ProcessModel): Promise<Array<IManualTaskWithProcessModel>> => {
+    const promisesForAllManualTasks: Array<Promise<Array<Task>>> = allProcessModels.processModels
+      .map(async(processModel: DataModels.ProcessModels.ProcessModel): Promise<Array<Task>> => {
         const manualTaskList: DataModels.ManualTasks.ManualTaskList =
           await this._managementApiService.getManualTasksForProcessModel(this.activeSolutionEntry.identity, processModel.id);
 
-        const manualTasksAndProcessModels: Array<IManualTaskWithProcessModel> = this._addProcessModelToManualTasks(manualTaskList, processModel);
+        const manualTasksAndProcessModels: Array<Task> = this._addProcessModelToManualTasks(manualTaskList, processModel);
 
         return manualTasksAndProcessModels;
       });
 
     // Concatenate the Promises for requesting UserTasks and requesting ManualTasks.
-    const promisesForAllTasksForAllProcessModels: Array<PromisesForUserAndManualTasks> = []
       .concat(promisesForAllUserTasks, promisesForAllManualTasks);
+    const promisesForAllTasksForAllProcessModels: Array<Task> = []
 
     // Await all promises.
-    const allTasksForAllProcessModels: Array<UserAndManualTasksWithProcessModels> =
+    const allTasksForAllProcessModels: Array<Task> =
       await Promise.all(promisesForAllTasksForAllProcessModels);
 
     // Flatten all results.
-    const allTasks: UserAndManualTasksWithProcessModels = [].concat(...allTasksForAllProcessModels);
+    const allTasks: Array<Task> = [].concat(...allTasksForAllProcessModels);
 
     return allTasks;
   }
 
-  private async _getTasksForProcessModel(processModelId: string): Promise<Array<IUserTaskWithProcessModel & IManualTaskWithProcessModel>> {
+  private async _getTasksForProcessModel(processModelId: string): Promise<Array<Task>> {
 
     const processModel: DataModels.ProcessModels.ProcessModel = await
       this
@@ -243,13 +230,13 @@ export class TaskList {
     const manualTaskList: DataModels.ManualTasks.ManualTaskList =
       await this._managementApiService.getManualTasksForProcessModel(this.activeSolutionEntry.identity, processModelId);
 
-    const userTasksAndProcessModels: Array<IUserTaskWithProcessModel> = this._addProcessModelToUserTasks(userTaskList, processModel);
-    const manualTasksAndProcessModels: Array<IManualTaskWithProcessModel> = this._addProcessModelToManualTasks(manualTaskList, processModel);
 
     return [].concat(userTasksAndProcessModels, manualTasksAndProcessModels);
+    const userTasksAndProcessModels: Array<Task> = this._addProcessModelToUserTasks(userTaskList, processModel);
+    const manualTasksAndProcessModels: Array<Task> = this._addProcessModelToManualTasks(manualTaskList, processModel);
   }
 
-  private async _getTasksForCorrelation(correlationId: string): Promise<Array<IUserTaskWithProcessModel & IManualTaskWithProcessModel>> {
+  private async _getTasksForCorrelation(correlationId: string): Promise<Array<Task>> {
 
     const runningCorrelations: Array<DataModels.Correlations.Correlation> =
       await this._managementApiService.getActiveCorrelations(this.activeSolutionEntry.identity);
@@ -274,16 +261,16 @@ export class TaskList {
     const processModelOfCorrelation: DataModels.ProcessModels.ProcessModel =
       await this._managementApiService.getProcessModelById(this.activeSolutionEntry.identity, correlationProcessInstanceId);
 
-    const userTasksAndProcessModels: Array<IUserTaskWithProcessModel> =
+    const userTasksAndProcessModels: Array<Task> =
       this._addProcessModelToUserTasks(userTaskList, processModelOfCorrelation);
 
-    const manualTasksAndProcessModels: Array<IManualTaskWithProcessModel> =
+    const manualTasksAndProcessModels: Array<Task> =
       this._addProcessModelToManualTasks(manualTaskList, processModelOfCorrelation);
 
     return [].concat(userTasksAndProcessModels, manualTasksAndProcessModels);
   }
 
-  private async _getTasksForProcessInstanceId(processInstanceId: string): Promise<Array<IUserTaskWithProcessModel & IManualTaskWithProcessModel>> {
+  private async _getTasksForProcessInstanceId(processInstanceId: string): Promise<Array<Task>> {
 
     const userTaskList: DataModels.UserTasks.UserTaskList =
       await this._managementApiService.getUserTasksForProcessInstance(this.activeSolutionEntry.identity, processInstanceId);
@@ -296,8 +283,8 @@ export class TaskList {
         ._managementApiService
         .getProcessModelByProcessInstanceId(this.activeSolutionEntry.identity, processInstanceId);
 
-    const userTasksAndProcessModels: Array<IUserTaskWithProcessModel> = this._addProcessModelToUserTasks(userTaskList, processModel);
-    const manualTasksAndProcessModels: Array<IManualTaskWithProcessModel> = this._addProcessModelToManualTasks(manualTaskList, processModel);
+    const userTasksAndProcessModels: Array<Task> = this._addProcessModelToUserTasks(userTaskList, processModel);
+    const manualTasksAndProcessModels: Array<Task> = this._addProcessModelToManualTasks(manualTaskList, processModel);
 
     return [].concat(userTasksAndProcessModels, manualTasksAndProcessModels);
   }
@@ -305,12 +292,19 @@ export class TaskList {
   private _addProcessModelToUserTasks(
     userTaskList: DataModels.UserTasks.UserTaskList,
     processModel: DataModels.ProcessModels.ProcessModel,
-  ): Array<IUserTaskWithProcessModel> {
+  ): Array<Task> {
 
-    const userTasksAndProcessModels: Array<IUserTaskWithProcessModel> = userTaskList.userTasks
-      .map((userTask: DataModels.UserTasks.UserTask): IUserTaskWithProcessModel => ({
+    const userTasksAndProcessModels: Array<Task> = userTaskList.userTasks
+      .map((userTask: DataModels.UserTasks.UserTask): Task => ({
         processModel: processModel,
-        userTask: userTask,
+        correlationId: userTask.correlationId,
+        id: userTask.id,
+        flowNodeInstanceId: userTask.flowNodeInstanceId,
+        processInstanceId: userTask.processInstanceId,
+        processModelId: userTask.processModelId,
+        name: userTask.name,
+        tokenPayload: userTask.tokenPayload,
+        data: userTask.data,
       }));
 
     return userTasksAndProcessModels;
@@ -319,12 +313,19 @@ export class TaskList {
   private _addProcessModelToManualTasks(
     manualTaskList: DataModels.ManualTasks.ManualTaskList,
     processModel: DataModels.ProcessModels.ProcessModel,
-  ): Array<IManualTaskWithProcessModel> {
+  ): Array<Task> {
 
-    const manualTasksAndProcessModels: Array<IManualTaskWithProcessModel> = manualTaskList.manualTasks
-      .map((manualTask: DataModels.ManualTasks.ManualTask): IManualTaskWithProcessModel => ({
+    const manualTasksAndProcessModels: Array<Task> = manualTaskList.manualTasks
+      .map((manualTask: DataModels.ManualTasks.ManualTask): Task => ({
         processModel: processModel,
-        manualTask: manualTask,
+        correlationId: manualTask.correlationId,
+        id: manualTask.id,
+        flowNodeInstanceId: manualTask.flowNodeInstanceId,
+        processInstanceId: manualTask.processInstanceId,
+        processModelId: manualTask.processModelId,
+        name: manualTask.name,
+        tokenPayload: manualTask.tokenPayload,
+        data: undefined,
       }));
 
     return manualTasksAndProcessModels;
@@ -332,7 +333,7 @@ export class TaskList {
 
   public async updateTasks(): Promise<void> {
     try {
-      this._userTasks = await this._getTasks();
+      this._tasks = await this._getTasks();
       this.requestSuccessful = true;
     } catch (error) {
 
@@ -343,7 +344,7 @@ export class TaskList {
         this._router.navigateToRoute('start-page');
       } else {
         this._notificationService.showNotification(NotificationType.ERROR, `Error receiving task list: ${error.message}`);
-        this._userTasks = undefined;
+        this._tasks = undefined;
       }
     }
 

--- a/src/modules/inspect/task-list/task-list.ts
+++ b/src/modules/inspect/task-list/task-list.ts
@@ -20,10 +20,14 @@ interface ITaskListRouteParameters {
   correlationId?: string;
 }
 
-type Task = DataModels.ManualTasks.ManualTask
-          & DataModels.UserTasks.UserTask
-          & DataModels.EmptyActivities.EmptyActivity
-          & {processModel: DataModels.ProcessModels.ProcessModel};
+type ProcessModelAnnotation = {processModel: DataModels.ProcessModels.ProcessModel};
+type ManualTaskWithProcessModel = DataModels.ManualTasks.ManualTask & ProcessModelAnnotation;
+type UserTaskWithProcessModel = DataModels.UserTasks.UserTask & ProcessModelAnnotation;
+type EmptyActivityWithProcessModel = DataModels.EmptyActivities.EmptyActivity & ProcessModelAnnotation;
+
+type Task = ManualTaskWithProcessModel
+          | UserTaskWithProcessModel
+          | EmptyActivityWithProcessModel;
 
 @inject(EventAggregator, 'ManagementApiClientService', Router, 'NotificationService', 'SolutionService')
 export class TaskList {
@@ -349,7 +353,6 @@ export class TaskList {
         processModelId: manualTask.processModelId,
         name: manualTask.name,
         tokenPayload: manualTask.tokenPayload,
-        data: undefined,
       }));
 
     return manualTasksAndProcessModels;
@@ -370,7 +373,6 @@ export class TaskList {
         processModelId: emptyActivity.processModelId,
         name: emptyActivity.name,
         tokenPayload: emptyActivity.tokenPayload,
-        data: undefined,
       }));
 
     return emptyActivitiesAndProcessModels;

--- a/src/modules/live-execution-tracker/live-execution-tracker.ts
+++ b/src/modules/live-execution-tracker/live-execution-tracker.ts
@@ -120,7 +120,20 @@ export class LiveExecutionTracker {
       const routeParameterContainsTaskId: boolean = routeParameters.taskId !== undefined;
       if (routeParameterContainsTaskId) {
         this.taskId = routeParameters.taskId;
-        this.showDynamicUiModal = true;
+
+        const emptyActivitiesInProcessInstance: DataModels.EmptyActivities.EmptyActivityList =
+          await this._liveExecutionTrackerService.getEmptyActivitiesForProcessInstance(this.processInstanceId);
+
+        const emptyActivity: DataModels.EmptyActivities.EmptyActivity =
+          emptyActivitiesInProcessInstance.emptyActivities.find((activity: DataModels.EmptyActivities.EmptyActivity) => {
+            return activity.id === this.taskId;
+        });
+
+        if (emptyActivity) {
+          this._liveExecutionTrackerService.finishEmptyActivity(this.processInstanceId, this.correlationId, emptyActivity);
+        } else {
+          this.showDynamicUiModal = true;
+        }
       }
     }, 0);
   }


### PR DESCRIPTION
## Changes

1. Refactor types and interfaces and rename _userTasks to _tasks
2. Add emptyActivities to task-list
3. Fix bug where the LET tries to open a dynamicUiModal after navigate to it with an empty activity

## Issues

Closes #YourIssueNumber

PR: #1581 

## How to test the changes

- start some processes containing empty activities
- switch to the inspect view and see that they are on the task-list
