### PR TITLE
💄Unify font size

### DIFF
--- a/src/modules/design/bpmn-io/bpmn-io.scss
+++ b/src/modules/design/bpmn-io/bpmn-io.scss
@@ -134,7 +134,7 @@
     height: 32px;
     margin-left: 1px;
     cursor: default;
-    font-size: 18px;
+    font-size: 20px;
     line-height: 24px;
   }
 

--- a/src/modules/design/bpmn-xml-view/bpmn-xml-view.scss
+++ b/src/modules/design/bpmn-xml-view/bpmn-xml-view.scss
@@ -4,9 +4,9 @@
   height: 100%;
   background-color: unset;
   border: none;
-  font-size: 13px;
+  font-size: 14px;
   font-family: monospace;
-  line-height: 13px;
+  line-height: 14px;
   word-break: unset;
   word-wrap: unset;
 }

--- a/src/modules/design/property-panel/indextabs/general/sections/basics/basics.scss
+++ b/src/modules/design/property-panel/indextabs/general/sections/basics/basics.scss
@@ -6,7 +6,7 @@
   z-index: 0;	
   opacity: 1;	  
   color: red;
-  font-size: 15px;
+  font-size: 16px;
 }
 
 .panel--general {

--- a/src/modules/design/property-panel/property-panel.scss
+++ b/src/modules/design/property-panel/property-panel.scss
@@ -10,11 +10,6 @@
   margin: 15px 0 20px 0;
 }
 
-.element-id-label {
-  margin-left: 10px;
-  font-size: 15px;
-}
-
 .indextab-dropdown__button {
   width: 100%;
 }

--- a/src/modules/inspect/heatmap/heatmap.html
+++ b/src/modules/inspect/heatmap/heatmap.html
@@ -2,7 +2,7 @@
   <require from="./heatmap.css"></require>
   <div class="heatmap">
     <div ref="viewerContainer" class="heatmap__viewer-container">
-      <span if.bind="!activeDiagram" class="heatmap__empty-message">No diagram selected.</span>
+      <h3 if.bind="!activeDiagram" class="heatmap__empty-message">No diagram selected.</h3>
     </div>
     <div class="heatmap__legend">
       <span class="heatmap__legend-entry heatmap__legend-entry-first">Median runtime:</span>

--- a/src/modules/inspect/heatmap/heatmap.scss
+++ b/src/modules/inspect/heatmap/heatmap.scss
@@ -20,13 +20,13 @@
 .heatmap__legend-entry {
   display: block;
   margin: 0 10px;
-  font-size: 13px;
+  font-size: 14px;
 }
 
 .heatmap__legend-entry-first {
   margin-top: 10px;
   margin-bottom: 2px;
-  font-size: 13px;
+  font-size: 14px;
   font-weight: bold;
 }
 
@@ -38,11 +38,11 @@
   width: 35px;
   height: 35px;
   min-height: 16px;
-  padding: 9px;
+  padding: 7px;
   background-color: black;
   border-radius: 50%;
   font-family: Arial;
-  font-size: 12px;
+  font-size: 14px;
   color: white;
   text-align: center;
 }
@@ -60,7 +60,6 @@
 }
 
 .heatmap__empty-message {
+  margin: 20px;
   user-select: none;
-  font-size: 24px;
-  font-weight: 900;
 }

--- a/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.html
+++ b/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.html
@@ -1,6 +1,6 @@
 <template>
   <require from="./diagram-viewer.css"></require>
   <div ref="canvasModel" class="diagram-viewer__body">
-    <span if.bind="xmlIsNotSelected" class="diagram-viewer__empty-message">No correlation selected.</span>
+    <h3 if.bind="xmlIsNotSelected" class="diagram-viewer__empty-message">No correlation selected.</h3>
   </div>
 </template>

--- a/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.scss
+++ b/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.scss
@@ -19,6 +19,4 @@
   white-space: nowrap;
   transform: translate(-50%, -50%);
   user-select: none;
-  font-size: 24px;
-  font-weight: 900;
 }

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/components/correlation-list/correlation-list.html
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/components/correlation-list/correlation-list.html
@@ -1,7 +1,7 @@
 <template>
   <require from="./correlation-list.css"></require>
   <div class="correlation-container">
-    <span if.bind="correlations.length === 0" class="correlation-table__empty-message">No correlations found.</span>
+    <h3 if.bind="correlations.length === 0" class="correlation-table__empty-message">No correlations found.</h3>
     <table else class="table table-striped table-hover correlation-table">
       <thead>
         <tr class="correlation-table__headlines">

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/components/correlation-list/correlation-list.scss
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/components/correlation-list/correlation-list.scss
@@ -22,7 +22,7 @@
   padding: 8px;
   overflow: hidden;
   border-bottom: 2px solid #ccc !important;
-  font-size: 18px;
+  font-size: 16px;
   font-weight: 900;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -33,7 +33,7 @@
   padding: 8px;
   overflow: hidden;
   border-bottom: 2px solid #ccc !important;
-  font-size: 18px;
+  font-size: 16px;
   font-weight: 900;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -79,6 +79,4 @@
   left: 50%;
   transform: translate(-50%, -50%);
   user-select: none;
-  font-size: 24px;
-  font-weight: 900;
 }

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/components/log-viewer/log-viewer.html
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/components/log-viewer/log-viewer.html
@@ -1,7 +1,7 @@
 <template>
   <require from="./log-viewer.css"></require>
   <div class="log-viewer">
-    <span if.bind="log.length === 0" class="log-table__empty-message">No logs for this correlation available.</span>
+    <h3 if.bind="log.length === 0" class="log-table__empty-message">No logs for this correlation available.</h3>
     <table else class="table table-striped table-hover log-table">
       <thead>
         <tr class="log-table__headlines">

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/components/log-viewer/log-viewer.scss
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/components/log-viewer/log-viewer.scss
@@ -22,7 +22,7 @@
   padding: 8px;
   overflow: hidden;
   border-bottom: 2px solid #ccc !important;
-  font-size: 18px;
+  font-size: 16px;
   font-weight: 900;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -77,6 +77,4 @@
   top: 50%;
   transform: translate(-50%, -50%);
   user-select: none;
-  font-size: 24px;
-  font-weight: 900;
 }

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/inspect-panel.scss
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/inspect-panel.scss
@@ -26,9 +26,10 @@
   border-left: 1px solid #ccc;
   cursor: default;
 }
+
 .inspect-panel__fullscreen-button > i {
   margin: auto;
-  font-size: 19px;
+  font-size: 20px;
 }
 
 .inspect-panel__tab {

--- a/src/modules/inspect/token-viewer/token-viewer.scss
+++ b/src/modules/inspect/token-viewer/token-viewer.scss
@@ -10,7 +10,7 @@
   padding-top: 10px;
   padding-left: 10px;
   border-bottom: 1px solid #ccc;
-  font-size: 18px;
+  font-size: 20px;
   font-weight: 900;
 }
 

--- a/src/modules/inspect/token-viewer/token-viewer.scss
+++ b/src/modules/inspect/token-viewer/token-viewer.scss
@@ -10,12 +10,11 @@
   padding-top: 10px;
   padding-left: 10px;
   border-bottom: 1px solid #ccc;
-  font-size: 20px;
-  font-weight: 900;
+  font-size: 14px;
 }
 
 .headline__node-id {
-  font-size: 16px;
+  font-size: 14px;
   font-weight: normal;
 }
 

--- a/src/modules/inspect/token-viewer/token-viewer.scss
+++ b/src/modules/inspect/token-viewer/token-viewer.scss
@@ -19,11 +19,6 @@
   font-weight: normal;
 }
 
-.token-viewer__token {
-  border: none;
-  font-size: 12px;
-}
-
 .token-viewer__empty-message {
   position: absolute;
   top: 50%;

--- a/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.scss
+++ b/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.scss
@@ -22,7 +22,7 @@
 }
 
 .solution-explorer-panel__header-name {
-  font-size: 16px;
+  font-size: 14px;
   flex: 1;
 }
 

--- a/src/modules/start-page/start-page.html
+++ b/src/modules/start-page/start-page.html
@@ -2,7 +2,7 @@
   <require from ='./start-page.css'></require>
   <div class="start-page__container">
     <div class="start-page__content">
-      <p class="start-page__title">Welcome to BPMN-Studio!</p>
+      <h3 class="start-page__title">Welcome to BPMN-Studio!</h3>
       <img class="start-page__icon" src="src/resources/images/icon.png">
       <div class="start-page__quick-start" show.bind="isRunningInElectron">
         <div class="quick-start__item">

--- a/src/modules/start-page/start-page.scss
+++ b/src/modules/start-page/start-page.scss
@@ -16,7 +16,6 @@
   position: relative;
   top: 150px;
   margin: 0;
-  font-size: 25px;
 }
 
 .start-page__icon {
@@ -44,7 +43,7 @@
 .quick-start__topic {
   width: 50%;
   margin-right: 20px;
-  font-size: 15px;
+  font-size: 14px;
   font-weight: bold;
   color: #555555;
   text-align: right;
@@ -58,7 +57,7 @@
 .quick-start__shortcut {
   width: 50%;
   margin-left: 20px;
-  font-size: 15px;
+  font-size: 14px;
   font-weight: bold;
   color: #555555;
   text-align: left;

--- a/src/modules/status-bar/status-bar.scss
+++ b/src/modules/status-bar/status-bar.scss
@@ -17,7 +17,7 @@
   border-top: 2px solid #e9e9e9;
   user-select: none;
   color: #fff;
-  font-size: 11px;
+  font-size: 12px;
   flex-direction: row;
   justify-content: space-evenly;
   align-items: stretch;
@@ -50,7 +50,9 @@
 .status-bar__element {
   display: inline-block;
   min-width: 50px;
-  padding: 2px 10px;
+  padding-right: 10px;
+  padding-left: 10px;
+  padding-bottom: 2px;
   color: white;
   text-align: center;
   white-space: nowrap;

--- a/src/modules/status-bar/status-bar.scss
+++ b/src/modules/status-bar/status-bar.scss
@@ -68,10 +68,6 @@
   text-decoration: none;
 }
 
-.baseroute__lock-icon {
-  font-size: 14px;
-}
-
 .center-bar__diff-view-buttons {
   display: inline-flex;
   float: left;


### PR DESCRIPTION
## Changes

Now we have the following font-sizes:

12px: for the PropertyPanel content, diagram/solution path at the SE, status-bar
14px: normal
16px: middle
20px: large

1. Unify font-size
2. Remove unused CSS classes
3. Use h3 as HTML element for empty_messages on the views and for the start-page title

## Issues

Closes #1072 

PR: #1582 

## How to test the changes

- start the studio and look at it
