### PR TITLE
✨ Add Enlarge Button to External Task Payload

### DIFF
--- a/src/modules/design/property-panel/indextabs/general/sections/basics/basics.scss
+++ b/src/modules/design/property-panel/indextabs/general/sections/basics/basics.scss
@@ -53,10 +53,6 @@
   color: #007bff !important;
 }
 
-.docs-enlarge-link {
-  color: #0056b3;
-}
-
 .docs-enlarge-text:hover {
   text-decoration: underline;
 }

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.html
@@ -1,4 +1,5 @@
 <template>
+  <require from="./external-task.css"></require>
   <require from="../../../../../../styles/sections.css"></require>
   <div class="section-panel panel--grow">
     <div class="panel__heading">External Task</div>
@@ -11,12 +12,23 @@
           </td>
         </tr>
         <tr>
-          <th>Payload</th>
+          <th>Payload<a class="payload-enlarge-link" click.delegate="showModal = true"><small class="payload-enlarge-text">Enlarge</small></a></th>
           <td>
             <textarea class="props-textarea name-input" value.bind="selectedPayload" change.delegate="payloadChanged()" disabled.bind="!model.isEditable"></textarea>
           </td>
         </tr>
-      </table>
+    </div>
+  </div>
+
+  <modal show.bind="showModal"
+         header-text="Editing: Payload">
+    <template replace-part="modal-body" autofocus>
+      <textarea class="form-control payload" value.bind="selectedPayload" change.delegate="payloadChanged()" rows="10" aria-multiline="true" autofocus wrap="soft" disabled.bind="!model.isEditable"></textarea>
+    </template>
+    <template replace-part="modal-footer">
+      <button type="button" class="btn btn-primary" data-dismiss="modal" click.delegate="showModal = false">Okay</button>
+    </template>
+  </modal>
     </div>
   </div>
 </template>

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.scss
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.scss
@@ -1,0 +1,9 @@
+.payload-enlarge-link {
+  display: block;
+  cursor: pointer;
+  color: #007bff !important;
+}
+
+.payload-enlarge-text:hover {
+  text-decoration: underline;
+}

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.scss
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.scss
@@ -7,3 +7,8 @@
 .payload-enlarge-text:hover {
   text-decoration: underline;
 }
+
+.payload {
+  min-height: 55px;
+  max-height: 400px;
+}

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.ts
@@ -13,6 +13,7 @@ export class ExternalTask {
   public businessObjInPanel: IServiceTaskElement;
   public selectedTopic: string;
   public selectedPayload: string;
+  public showModal: boolean = false;
 
   private eventAggregator: EventAggregator;
   private serviceTaskService: ServiceTaskService;


### PR DESCRIPTION
## Changes

1. Add enlarge button to external task payload
2. Remove unneeded CSS

## Issues

Closes #1592 

PR: #1603

## How to test the changes

- Click on an External Task
- **Notice that there is a enlarge button under 'Payload' which opens a modal in which one can change the payload of the external task.**


<img width="881" src="https://user-images.githubusercontent.com/20394992/62119993-0beca080-b2c1-11e9-96d1-a9e845d7ead8.png">
