### PR TITLE
🐛 Fix Target Process Selection for Call Activities

### DIFF
--- a/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.html
@@ -13,7 +13,7 @@
                 <option model.bind="undefined">-Choose called process-</option>
                 <option repeat.for="diagram of allDiagrams" model.bind="diagram.name" value="${diagram.name}">${diagram.name}</option>
               </select>
-              <input class="called-process-selection__input" value.bind="selectedDiagramName" change.delegate="updateCalledDiagram()"/>
+              <input class="called-process-selection__input" value.bind="selectedDiagramName" change.delegate="updateCalledDiagram()" disabled.bind="!isEditable"/>
             </div>
           </td>
         </tr>

--- a/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.html
@@ -8,15 +8,17 @@
         <tr>
           <th>Process</th>
           <td>
-            <select class="props-input props-select" value.bind="selectedDiagramId" change.delegate="updateCalledDiagram()" disabled.bind="!isEditable">
-              <option model.bind="null">-Choose called process-</option>
-              <option repeat.for="diagram of allDiagrams"
-                      model.bind="diagram.name" value="${diagram.name}">${diagram.name}</option>
-            </select>
+            <div class="called-process-selection">
+              <select class="called-process-selection__select" value.bind="selectValue" change.delegate="updateCalledDiagram()"  disabled.bind="!isEditable"}>
+                <option model.bind="undefined">-Choose called process-</option>
+                <option repeat.for="diagram of allDiagrams" model.bind="diagram.name" value="${diagram.name}">${diagram.name}</option>
+              </select>
+              <input class="called-process-selection__input" value.bind="selectedDiagramName" change.delegate="updateCalledDiagram()"/>
+            </div>
           </td>
         </tr>
       </table>
-      <button class="navigation-button" disabled.bind="!selectedDiagramId || !isEditable" click.delegate="navigateToCalledDiagram()">Navigate to called process</button>
+      <button class="navigation-button" disabled.bind="!selectedDiagramName || !isEditable || !isPartOfAllDiagrams(selectedDiagramName)" click.delegate="navigateToCalledDiagram()">Navigate to called process</button>
     </div>
   </div>
 </template>

--- a/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.scss
+++ b/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.scss
@@ -10,7 +10,7 @@
 
 .called-process-selection {
   position: relative;
-  width: 200px;
+  width: 100%;
   height: 25px;
   padding: 0;
   margin: 0;
@@ -21,7 +21,7 @@
   position: absolute;
   top: 0px;
   left: 0px;
-  width: 200px;
+  width: 100%;
   height: 25px;
   padding: 0;
   margin: 0;
@@ -32,7 +32,7 @@
   position: absolute;
   top: 2px;
   left: 3px;
-  width: 180px;
+  width: calc(100% - 17px);
   height: 21px;
   border: 1px solid #A9A9A9;
 }

--- a/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.scss
+++ b/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.scss
@@ -7,3 +7,32 @@
   pointer-events: none;
   opacity: 0.5;
 }
+
+.called-process-selection {
+  position: relative;
+  width: 200px;
+  height: 25px;
+  padding: 0;
+  margin: 0;
+  border: 0;
+}
+
+.called-process-selection__select {
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  width: 200px;
+  height: 25px;
+  padding: 0;
+  margin: 0;
+  line-height: 20px;
+}
+
+.called-process-selection__input {
+  position: absolute;
+  top: 2px;
+  left: 3px;
+  width: 180px;
+  height: 21px;
+  border: 1px solid #A9A9A9;
+}

--- a/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.ts
@@ -14,7 +14,10 @@ export class CallActivitySection implements ISection {
   public path: string = '/sections/call-activity/call-activity';
   public canHandleElement: boolean = false;
   public allDiagrams: Array<IDiagram>;
-  public selectedDiagramId: string;
+  public selectValue: string;
+  public selectedDiagramName: string;
+
+  public previouslySelectedDiagram: string;
 
   private businessObjInPanel: ICallActivityElement;
   private generalService: GeneralService;
@@ -34,7 +37,8 @@ export class CallActivitySection implements ISection {
 
     await this.getAllDiagrams();
 
-    this.selectedDiagramId = this.businessObjInPanel.calledElement;
+    this.previouslySelectedDiagram = this.businessObjInPanel.calledElement;
+    this.selectedDiagramName = this.businessObjInPanel.calledElement;
   }
 
   public isSuitableForElement(element: IShape): boolean {
@@ -48,14 +52,26 @@ export class CallActivitySection implements ISection {
 
   public navigateToCalledDiagram(): void {
     this.router.navigateToRoute('design', {
-      diagramName: this.selectedDiagramId,
+      diagramName: this.selectedDiagramName,
       solutionUri: this.activeSolutionUri,
       view: 'detail',
     });
   }
 
+  public isPartOfAllDiagrams(diagramName: string): boolean {
+    return this.allDiagrams.some((diagram: IDiagram): boolean => {
+      return diagram.name === diagramName;
+    });
+  }
+
   public updateCalledDiagram(): void {
-    this.businessObjInPanel.calledElement = this.selectedDiagramId;
+    const diagramSelectedViaSelect: boolean = this.selectValue !== undefined;
+    if (diagramSelectedViaSelect) {
+      this.selectedDiagramName = this.selectValue;
+      this.selectValue = undefined;
+    }
+
+    this.businessObjInPanel.calledElement = this.selectedDiagramName;
 
     this.publishDiagramChange();
   }


### PR DESCRIPTION
## Changes

1. Fix target process selection for call activities
2. Add an input field to select a process from another solution

## Issues

Closes #1588

PR: #1606

## How to test the changes

- Add a call activity to a diagram
- Select a process from the current solution
- Change the solution and open the same process
- **Notice that the correct process will be displayed in the 'Call Activity' section of the property panel.**


> This fix could be improved by using a [datalist](https://developer.mozilla.org/de/docs/Web/HTML/Element/datalist), which is not working in the electron version that we are using, or by using a [input group](https://getbootstrap.com/docs/4.3/components/input-group/#buttons-with-dropdowns), which leads to style issues when used in the property panel.
