### PR TITLE
✨ Persist Selected Remote Solution for 'Multiple Connected Process Engines Found' Modal

### DIFF
--- a/src/modules/design/design.html
+++ b/src/modules/design/design.html
@@ -46,7 +46,7 @@
       </template>
     </modal>
 
-    <modal show.bind="showRemoteSolutionOnDeployModal"
+    <modal if.bind="showRemoteSolutionOnDeployModal"
           header-text="Multiple Connected ProcessEngines Found">
       <template replace-part="modal-body">
         Choose a remote ProcessEngines; the diagram will be deployed to your selection.

--- a/src/modules/design/diagram-detail/diagram-detail.ts
+++ b/src/modules/design/diagram-detail/diagram-detail.ts
@@ -12,7 +12,7 @@ import {
 } from '@process-engine/bpmn-elements_contracts';
 
 import {DataModels, IManagementApi} from '@process-engine/management_api_contracts';
-import {IDiagram} from '@process-engine/solutionexplorer.contracts';
+import {IDiagram, ISolution} from '@process-engine/solutionexplorer.contracts';
 
 import {
   IElementRegistry,
@@ -55,7 +55,7 @@ export class DiagramDetail {
   public diagramIsInvalid: boolean = false;
   public showRemoteSolutionOnDeployModal: boolean = false;
   public remoteSolutions: Array<ISolutionEntry> = [];
-  public selectedRemoteSolution: ISolutionEntry;
+  @observable public selectedRemoteSolution: ISolutionEntry;
   public showDiagramExistingModal: boolean = false;
 
   private notificationService: NotificationService;
@@ -104,6 +104,8 @@ export class DiagramDetail {
   public attached(): void {
     this.diagramHasChanged = false;
 
+    this.selectedRemoteSolution = this.getPreviouslySelectedRemoteSolution();
+
     const isRunningInElectron: boolean = Boolean((window as any).nodeRequire);
     if (isRunningInElectron) {
       this.ipcRenderer = (window as any).nodeRequire('electron').ipcRenderer;
@@ -143,6 +145,12 @@ export class DiagramDetail {
         this.electronOnSaveDiagramAs();
       }),
     ];
+  }
+
+  public selectedRemoteSolutionChanged(): void {
+    const selectedRemoteSolutionAsString: string = JSON.stringify(this.selectedRemoteSolution);
+
+    localStorage.setItem('selectedRemoteSolution', selectedRemoteSolutionAsString);
   }
 
   public correlationChanged(newValue: string): void {
@@ -522,6 +530,16 @@ export class DiagramDetail {
   public showCustomStartModal(): void {
     this.getTokenFromStartEventAnnotation();
     this.showStartWithOptionsModal = true;
+  }
+
+  private getPreviouslySelectedRemoteSolution(): ISolutionEntry {
+    const selectedRemoteSolutionFromLocalStorage: string = localStorage.getItem('selectedRemoteSolution');
+
+    if (selectedRemoteSolutionFromLocalStorage === null) {
+      return undefined;
+    }
+
+    return JSON.parse(selectedRemoteSolutionFromLocalStorage);
   }
 
   private getInitialTokenValues(token: any): any {

--- a/src/modules/design/diagram-detail/diagram-detail.ts
+++ b/src/modules/design/diagram-detail/diagram-detail.ts
@@ -12,7 +12,7 @@ import {
 } from '@process-engine/bpmn-elements_contracts';
 
 import {DataModels, IManagementApi} from '@process-engine/management_api_contracts';
-import {IDiagram, ISolution} from '@process-engine/solutionexplorer.contracts';
+import {IDiagram} from '@process-engine/solutionexplorer.contracts';
 
 import {
   IElementRegistry,


### PR DESCRIPTION
## Changes

1. Persist Selected Remote Solution for 'Multiple Connected Process Engines Found' modal

## Issues

Closes #1608 

PR: #1609

## How to test the changes

- Connect multiple ProcessEngines
- Deploy a process to a ProcessEngine
- Deploy another process
- **Notice that the previously selected ProcessEngine will already be selected**
