### PR TITLE
🐛Fix empty modal and updating tasks when using the pagination

### DIFF
--- a/src/modules/inspect/task-list/task-list.html
+++ b/src/modules/inspect/task-list/task-list.html
@@ -32,7 +32,7 @@
       </table>
       <div class="col-md-12 col-xs-12 pagination">
         <aubs-pagination page-size.bind="pageSize" total-items.bind="totalItems" current-page.bind="currentPage"
-          boundary-links.bind="true" click.delegate="_updateTasks()" pagination-size.bind="paginationSize">
+          boundary-links.bind="true" pagination-size.bind="paginationSize">
         </aubs-pagination>
       </div>
     </div>

--- a/src/modules/task-dynamic-ui/task-dynamic-ui.ts
+++ b/src/modules/task-dynamic-ui/task-dynamic-ui.ts
@@ -34,8 +34,8 @@ export class TaskDynamicUi {
   @bindable() public taskId: string;
   @bindable() public isModal: boolean;
   @bindable() public activeSolutionEntry: ISolutionEntry;
-  public userTask: DataModels.UserTasks.UserTask;
-  public manualTask: DataModels.ManualTasks.ManualTask;
+  @bindable public userTask: DataModels.UserTasks.UserTask;
+  @bindable public manualTask: DataModels.ManualTasks.ManualTask;
 
   private activeDiagramName: string;
   private activeSolutionUri: string;


### PR DESCRIPTION
## Changes

1. Fix the empty modal when working off tasks
2. Fix _updateTasks is not a function bug when using the task-list pagination

## Issues

Closes #1613 
Closes #1614 

PR: #1615 

## How to test the changes

- look at #1614 
