### PR TITLE
✨Collapse open diagrams

### DIFF
--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.html
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.html
@@ -7,7 +7,7 @@
     <div class="solution-list">
       <div repeat.for="solutionEntry of openedSolutionsToDisplay" class="solution-entry">
 
-        <div class.bind="solutionEntry.uri === 'about:open-diagrams' ? 'solution-entry__open-diagrams-header' : 'solution-entry__header'" title.bind="solutionEntry.processEngineVersion ? `${solutionEntry.uri} | Version: ${solutionEntry.processEngineVersion}` : solutionEntry.uri">
+        <div class="solution-entry__header" title.bind="solutionEntry.processEngineVersion ? `${solutionEntry.uri} | Version: ${solutionEntry.processEngineVersion}` : solutionEntry.uri">
              
         <div class="solution-entry__collapse-header" click.delegate="toggleSolution(solutionEntry)">
 

--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.html
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.html
@@ -13,8 +13,8 @@
 
           <div class="solution-entry__left-icon_and_name">
 
-            <i if.bind="solutionEntry.hidden && solutionEntry.uri !== 'about:open-diagrams'" class="fas fa-angle-right collapse__icon"></i>
-            <i if.bind="!solutionEntry.hidden && solutionEntry.uri !== 'about:open-diagrams'" class="fas fa-angle-down collapse__icon"></i>
+            <i if.bind="solutionEntry.hidden" class="fas fa-angle-right collapse__icon"></i>
+            <i if.bind="!solutionEntry.hidden" class="fas fa-angle-down collapse__icon"></i>
   
             <i class="fa ${solutionEntry.fontAwesomeIconClass} solution-entry__solution-icon" title.bind="solutionEntry.fontAwesomeIconClass === 'fa-bolt' ? 'ProcessEngine Disconnected!' : ''"></i>
     

--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.scss
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.scss
@@ -29,15 +29,6 @@
   background-color: rgba(230, 230, 230, 0.6);
 }
 
-.solution-entry__open-diagrams-header {
-  display: flex;
-  max-height: 26px;
-  padding: 2.5px 5px;
-  padding-bottom: 2px;
-  color: darkgray;
-  cursor: default;
-}
-
 .solution-entry__header button {
   padding: 0 2px;
   background: transparent;

--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
@@ -99,10 +99,6 @@ export class SolutionExplorerList {
   }
 
   public toggleSolution(solutionEntry: ISolutionEntry): void {
-    if (solutionEntry.isOpenDiagramService) {
-      return;
-    }
-
     solutionEntry.hidden = !solutionEntry.hidden;
     this.solutionService.persistSolutionsInLocalStorage();
   }

--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
@@ -538,6 +538,15 @@ export class SolutionExplorerList {
   }
 
   private getHiddenStateForSolutionUri(uri: string): boolean {
+    const solutionIsOpenDiagrams: boolean = uri === 'about:open-diagrams';
+    if (solutionIsOpenDiagrams) {
+      const solutionCollapseState: boolean = JSON.parse(
+        window.localStorage.getItem('openDiagramSolutionCollapseState'),
+      );
+
+      return solutionCollapseState ? solutionCollapseState : false;
+    }
+
     const persistedSolutions: Array<ISolutionEntry> = this.solutionService.getPersistedEntries();
     const solutionToLoad: ISolutionEntry = persistedSolutions.find((solution: ISolutionEntry) => solution.uri === uri);
 

--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
@@ -544,7 +544,7 @@ export class SolutionExplorerList {
         window.localStorage.getItem('openDiagramSolutionCollapseState'),
       );
 
-      return solutionCollapseState ? solutionCollapseState : false;
+      return solutionCollapseState || false;
     }
 
     const persistedSolutions: Array<ISolutionEntry> = this.solutionService.getPersistedEntries();

--- a/src/services/solution-service/SolutionService.ts
+++ b/src/services/solution-service/SolutionService.ts
@@ -136,6 +136,11 @@ export class SolutionService implements ISolutionService {
       return entryIsNotOpenDiagramSolution;
     });
 
+    const openDiagramSolution: ISolutionEntry = this.allSolutionEntries.find((entry: ISolutionEntry) => {
+      return entry.uri === 'about:open-diagrams';
+    });
+
+    window.localStorage.setItem('openDiagramSolutionCollapseState', JSON.stringify(openDiagramSolution.hidden));
     window.localStorage.setItem('openedSolutions', JSON.stringify(entriesToPersist));
     this.persistedEntries = entriesToPersist;
   }


### PR DESCRIPTION
## Changes

1. Remove unused CSS class
2. Use solution-entry__header class for open-diagram solution too
4. Show collapse icon also on open-diagrams solution
5. Persist the open-diagram solution collapse state on local storage
6. Allow to click on open-diagrams header
7. Get the hidden/collapse state for open-diagrams solution while open it

## Issues

Closes #1616 

PR: #1617 

## How to test the changes

- try to collapse the open-diagrams solution 
- also have a look whether the solution has the same state after reload/reopen the studio
