### PR TITLE
✨ Update the task-list only if a task is waiting or has been finished

### DIFF
--- a/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.html
+++ b/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.html
@@ -2,8 +2,8 @@
   <require from="./diagram-viewer.css"></require>
   <div ref="canvasModel" class="diagram-viewer__body">
     <div if.bind="xmlIsNotSelected && !noCorrelationsFound">
-      <img src="src/resources/images/gears.svg" class="loading-spinner">
-      <h3 class="diagram-viewer__empty-message">Loading correlations...</h3>
+      <img src="src/resources/images/gears.svg" class="diagram-viewer__loading-spinner">
+      <h3 class="diagram-viewer__empty-message">Loading Correlations...</h3>
     </div>
     <h3 if.bind="noCorrelationsFound" class="diagram-viewer__empty-message">No correlations found.</h3>
   </div>

--- a/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.scss
+++ b/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.scss
@@ -21,7 +21,7 @@
   user-select: none;
 }
 
-.loading-spinner {
+.diagram-viewer__loading-spinner {
   display: inline-block;
   position: absolute;
   left: 50%;

--- a/src/modules/inspect/task-list/task-list.ts
+++ b/src/modules/inspect/task-list/task-list.ts
@@ -102,8 +102,11 @@ export class TaskList {
     }
   }
 
-  public async attached(): Promise<void> {
+  public async activeSolutionEntryChanged(): Promise<void> {
+    await this.updateTasks();
+  }
 
+  public async attached(): Promise<void> {
     const getTasksIsUndefined: boolean = this.getTasks === undefined;
 
     this.activeSolutionUri = this.router.currentInstruction.queryParams.solutionUri;

--- a/src/modules/inspect/task-list/task-list.ts
+++ b/src/modules/inspect/task-list/task-list.ts
@@ -6,7 +6,6 @@ import {NotFoundError, UnauthorizedError, isError} from '@essential-projects/err
 import {DataModels, IManagementApi} from '@process-engine/management_api_contracts';
 
 import {AuthenticationStateEvent, ISolutionEntry, ISolutionService, NotificationType} from '../../../contracts/index';
-import environment from '../../../environment';
 import {NotificationService} from '../../../services/notification-service/notification.service';
 
 interface ITaskListRouteParameters {
@@ -133,7 +132,30 @@ export class TaskList {
     ];
 
     await this.updateTasks();
-    this.startPolling();
+
+    this.managementApiService.onEmptyActivityFinished(this.activeSolutionEntry.identity, async () => {
+      await this.updateTasks();
+    });
+
+    this.managementApiService.onEmptyActivityWaiting(this.activeSolutionEntry.identity, async () => {
+      await this.updateTasks();
+    });
+
+    this.managementApiService.onUserTaskFinished(this.activeSolutionEntry.identity, async () => {
+      await this.updateTasks();
+    });
+
+    this.managementApiService.onUserTaskWaiting(this.activeSolutionEntry.identity, async () => {
+      await this.updateTasks();
+    });
+
+    this.managementApiService.onManualTaskFinished(this.activeSolutionEntry.identity, async () => {
+      await this.updateTasks();
+    });
+
+    this.managementApiService.onManualTaskWaiting(this.activeSolutionEntry.identity, async () => {
+      await this.updateTasks();
+    });
   }
 
   public detached(): void {
@@ -159,16 +181,6 @@ export class TaskList {
       processInstanceId: processInstanceId,
       taskId: id,
     });
-  }
-
-  private startPolling(): void {
-    this.pollingTimeout = setTimeout(async () => {
-      await this.updateTasks();
-
-      if (this.isAttached) {
-        this.startPolling();
-      }
-    }, environment.processengine.dashboardPollingIntervalInMs);
   }
 
   private async getAllTasks(): Promise<Array<TaskListEntry>> {

--- a/src/modules/inspect/task-list/task-list.ts
+++ b/src/modules/inspect/task-list/task-list.ts
@@ -57,7 +57,6 @@ export class TaskList {
   private tasks: Array<TaskListEntry> = [];
   private pollingTimeout: NodeJS.Timer | number;
   private getTasks: () => Promise<Array<TaskListEntry>>;
-  private isAttached: boolean = false;
 
   constructor(
     eventAggregator: EventAggregator,
@@ -104,7 +103,6 @@ export class TaskList {
   }
 
   public async attached(): Promise<void> {
-    this.isAttached = true;
 
     const getTasksIsUndefined: boolean = this.getTasks === undefined;
 
@@ -159,7 +157,6 @@ export class TaskList {
   }
 
   public detached(): void {
-    this.isAttached = false;
     clearTimeout(this.pollingTimeout as NodeJS.Timer);
 
     for (const subscription of this.subscriptions) {


### PR DESCRIPTION
## Changes

1. Update the task-list only if a task is waiting or has been finished

## Issues

First part of #1594 

PR: #1619 

## How to test the changes

- open the studio and navigate to the inspect view
- see that the task-list gets updated when switching to another remote solution
- open up the studio for a second time (e.g. web version) and connect to the same remote solution
- start a process with user/manual task or empty activity
- see that the task-list gets updated on the first studio instance
- it should get updated also when finishing a task.
