### PR TITLE
✨Use events on process list

### DIFF
--- a/src/modules/inspect/dashboard/dashboard.ts
+++ b/src/modules/inspect/dashboard/dashboard.ts
@@ -10,7 +10,6 @@ import {NotificationService} from '../../../services/notification-service/notifi
 
 const versionRegex: RegExp = /(\d+)\.(\d+).(\d+)/;
 
-// tslint:disable: no-magic-numbers
 @inject('ManagementApiClientService', 'NotificationService', Router)
 export class Dashboard {
   @bindable() public activeSolutionEntry: ISolutionEntry;

--- a/src/modules/inspect/process-list/process-list.html
+++ b/src/modules/inspect/process-list/process-list.html
@@ -21,7 +21,7 @@
             <td class="process-list__last-table-cell">
               <a if.bind="processInstanceWithCorrelation.processInstance.state !== 'error'" route-href="route: task-list-processinstance; params.bind: { processInstanceId: processInstanceWithCorrelation.processInstance.processInstanceId, solutionUri: activeSolutionEntry.uri }" class="process-list-item-user-tasks btn btn-default">Tasks</a>
               <a if.bind="processInstanceWithCorrelation.processInstance.state !== 'error'" route-href="route: live-execution-tracker; params.bind: { diagramName: processInstanceWithCorrelation.processInstance.processModelId, solutionUri: activeSolutionEntry.uri, correlationId: processInstanceWithCorrelation.correlation.id, processInstanceId: processInstanceWithCorrelation.processInstance.processInstanceId }" class="btn btn-default">Live Execution Tracking</a>
-              <button if.bind="processInstanceWithCorrelation.processInstance.state !== 'error'" class="btn btn-default" click.delegate="stopProcessInstance(processInstanceWithCorrelation.processInstance.processInstanceId, correlation)">Stop</button>
+              <button if.bind="processInstanceWithCorrelation.processInstance.state !== 'error'" class="btn btn-default" click.delegate="stopProcessInstance(processInstanceWithCorrelation.processInstance, processInstanceWithCorrelation.correlation)">Stop</button>
             </td>
           </tr>
         </table>

--- a/src/modules/inspect/process-list/process-list.ts
+++ b/src/modules/inspect/process-list/process-list.ts
@@ -233,7 +233,23 @@ export class ProcessList {
     const lastProcessInstanceIndex: number = this.pageSize * this.currentPage;
 
     this.processInstancesToDisplay = this.processInstancesWithCorrelation;
-    this.processInstancesToDisplay.push(...this.stoppedProcessInstancesWithCorrelation);
+
+    this.stoppedProcessInstancesWithCorrelation.forEach(
+      (stoppedProcessInstanceWithCorrelation: ProcessInstanceWithCorrelation) => {
+        const processInstanceExistInDisplayArray: boolean = this.processInstancesToDisplay.some(
+          (processInstanceWithCorrelation: ProcessInstanceWithCorrelation) => {
+            return (
+              stoppedProcessInstanceWithCorrelation.processInstance === processInstanceWithCorrelation.processInstance
+            );
+          },
+        );
+
+        if (!processInstanceExistInDisplayArray) {
+          this.processInstancesToDisplay.push(stoppedProcessInstanceWithCorrelation);
+        }
+      },
+    );
+
     this.processInstancesToDisplay.sort(this.sortProcessInstancesWithCorrelation);
     this.processInstancesToDisplay = this.processInstancesToDisplay.slice(
       firstProcessInstanceIndex,

--- a/src/modules/inspect/process-list/process-list.ts
+++ b/src/modules/inspect/process-list/process-list.ts
@@ -164,25 +164,22 @@ export class ProcessList {
     correlation: DataModels.Correlations.Correlation,
   ): Promise<void> {
     try {
+      this.managementApiService.onProcessError(this.activeSolutionEntry.identity, () => {
+        processInstance.state = DataModels.Correlations.CorrelationState.error;
+      });
+
       await this.managementApiService.terminateProcessInstance(
         this.activeSolutionEntry.identity,
         processInstance.processInstanceId,
       );
 
-      const getStoppedCorrelation: Function = (): void => {
-        this.managementApiService.onProcessError(this.activeSolutionEntry.identity, () => {
-          processInstance.state = DataModels.Correlations.CorrelationState.error;
-        });
-
-        const processInstanceWithCorrelation: ProcessInstanceWithCorrelation = {
-          processInstance: processInstance,
-          correlation: correlation,
-        };
-
-        this.stoppedProcessInstancesWithCorrelation.push(processInstanceWithCorrelation);
+      const processInstanceWithCorrelation: ProcessInstanceWithCorrelation = {
+        processInstance: processInstance,
+        correlation: correlation,
       };
 
-      getStoppedCorrelation();
+      this.stoppedProcessInstancesWithCorrelation.push(processInstanceWithCorrelation);
+
       await this.updateCorrelationList();
     } catch (error) {
       this.notificationService.showNotification(NotificationType.ERROR, `Error while stopping Process! ${error}`);

--- a/src/modules/inspect/process-list/process-list.ts
+++ b/src/modules/inspect/process-list/process-list.ts
@@ -36,7 +36,6 @@ export class ProcessList {
   private subscriptions: Array<Subscription>;
   private correlations: Array<DataModels.Correlations.Correlation> = [];
   private processInstancesWithCorrelation: Array<ProcessInstanceWithCorrelation> = [];
-  private stoppedCorrelations: Array<DataModels.Correlations.Correlation> = [];
   private stoppedProcessInstancesWithCorrelation: Array<ProcessInstanceWithCorrelation> = [];
   private isAttached: boolean = false;
 
@@ -55,7 +54,6 @@ export class ProcessList {
   }
 
   public activeSolutionEntryChanged(): void {
-    this.stoppedCorrelations = [];
     this.stoppedProcessInstancesWithCorrelation = [];
   }
 
@@ -174,7 +172,6 @@ export class ProcessList {
             return;
           }
 
-          this.stoppedCorrelations.push(stoppedCorrelation);
 
           const processInstancesWithCorrelation: Array<
             ProcessInstanceWithCorrelation

--- a/src/modules/inspect/process-list/process-list.ts
+++ b/src/modules/inspect/process-list/process-list.ts
@@ -154,7 +154,7 @@ export class ProcessList {
   }
 
   public async stopProcessInstance(
-    processInstanceId: string,
+    processInstance: DataModels.Correlations.CorrelationProcessInstance,
     correlation: DataModels.Correlations.Correlation,
   ): Promise<void> {
     try {

--- a/src/modules/inspect/process-list/process-list.ts
+++ b/src/modules/inspect/process-list/process-list.ts
@@ -6,7 +6,6 @@ import {IIdentity} from '@essential-projects/iam_contracts';
 import {DataModels, IManagementApi} from '@process-engine/management_api_contracts';
 
 import {AuthenticationStateEvent, ISolutionEntry, ISolutionService, NotificationType} from '../../../contracts/index';
-import environment from '../../../environment';
 import {getBeautifiedDate} from '../../../services/date-service/date.service';
 import {NotificationService} from '../../../services/notification-service/notification.service';
 

--- a/src/modules/inspect/process-list/process-list.ts
+++ b/src/modules/inspect/process-list/process-list.ts
@@ -88,6 +88,22 @@ export class ProcessList {
         this.updateCorrelationList();
       }),
     ];
+
+    this.managementApiService.onProcessStarted(this.activeSolutionEntry.identity, async () => {
+      await this.updateCorrelationList();
+    });
+
+    this.managementApiService.onProcessEnded(this.activeSolutionEntry.identity, async () => {
+      await this.updateCorrelationList();
+    });
+
+    /**
+     * This notification gets also triggered when the processinstance has been terminated.
+     * Currently the onProcessTerminated notification does not work.
+     */
+    this.managementApiService.onProcessError(this.activeSolutionEntry.identity, async () => {
+      await this.updateCorrelationList();
+    });
   }
 
   public detached(): void {

--- a/src/modules/inspect/process-list/process-list.ts
+++ b/src/modules/inspect/process-list/process-list.ts
@@ -31,12 +31,10 @@ export class ProcessList {
   private activeSolutionUri: string;
   private router: Router;
 
-  private pollingTimeout: NodeJS.Timer | number;
   private subscriptions: Array<Subscription>;
   private correlations: Array<DataModels.Correlations.Correlation> = [];
   private processInstancesWithCorrelation: Array<ProcessInstanceWithCorrelation> = [];
   private stoppedProcessInstancesWithCorrelation: Array<ProcessInstanceWithCorrelation> = [];
-  private isAttached: boolean = false;
 
   constructor(
     managementApiService: IManagementApi,
@@ -65,7 +63,6 @@ export class ProcessList {
   }
 
   public async attached(): Promise<void> {
-    this.isAttached = true;
     this.activeSolutionUri = this.router.currentInstruction.queryParams.solutionUri;
 
     const activeSolutionUriIsNotSet: boolean = this.activeSolutionUri === undefined;
@@ -94,9 +91,6 @@ export class ProcessList {
   }
 
   public detached(): void {
-    this.isAttached = false;
-    clearTimeout(this.pollingTimeout as NodeJS.Timer);
-
     for (const subscription of this.subscriptions) {
       subscription.dispose();
     }

--- a/src/modules/inspect/process-list/process-list.ts
+++ b/src/modules/inspect/process-list/process-list.ts
@@ -8,6 +8,7 @@ import {DataModels, IManagementApi} from '@process-engine/management_api_contrac
 import {AuthenticationStateEvent, ISolutionEntry, ISolutionService, NotificationType} from '../../../contracts/index';
 import {getBeautifiedDate} from '../../../services/date-service/date.service';
 import {NotificationService} from '../../../services/notification-service/notification.service';
+import environment from '../../../environment';
 
 type ProcessInstanceWithCorrelation = {
   processInstance: DataModels.Correlations.CorrelationProcessInstance;
@@ -50,8 +51,15 @@ export class ProcessList {
     this.router = router;
   }
 
-  public activeSolutionEntryChanged(): void {
+  public async activeSolutionEntryChanged(newValue): Promise<void> {
+    this.correlations = [];
+    this.processInstancesWithCorrelation = [];
+    this.processInstancesToDisplay = [];
     this.stoppedProcessInstancesWithCorrelation = [];
+    this.requestSuccessful = false;
+
+    this.eventAggregator.publish(environment.events.configPanel.solutionEntryChanged, newValue);
+    await this.updateCorrelationList();
   }
 
   public async currentPageChanged(newValue: number, oldValue: number): Promise<void> {

--- a/src/modules/inspect/process-list/process-list.ts
+++ b/src/modules/inspect/process-list/process-list.ts
@@ -83,7 +83,6 @@ export class ProcessList {
     this.activeSolutionEntry = this.solutionService.getSolutionEntryForUri(this.activeSolutionUri);
 
     await this.updateCorrelationList();
-    this.startPolling();
 
     this.subscriptions = [
       this.eventAggregator.subscribe(AuthenticationStateEvent.LOGIN, () => {
@@ -203,16 +202,6 @@ export class ProcessList {
     const identity: IIdentity = this.activeSolutionEntry.identity;
 
     return this.managementApiService.getActiveCorrelations(identity);
-  }
-
-  private startPolling(): void {
-    this.pollingTimeout = setTimeout(async () => {
-      await this.updateCorrelationList();
-
-      if (this.isAttached) {
-        this.startPolling();
-      }
-    }, environment.processengine.dashboardPollingIntervalInMs);
   }
 
   private sortCorrelations(


### PR DESCRIPTION
## Changes

1. Use process instance instead of processInstanceId as parameter
2. Add event listener to update the processlist
3. Use onProcessError event listener to handle stopped correlation/processinstance
4. Fix bug where stopped entries get increased when using the pagination

## Issues

Part two of #1594
Closes #1620

PR: #1621 

## How to test the changes

- try to reproduce the #1620 
- open the inspect view
- switch between some remote solutions
- see that the process-list gets updated
