### PR TITLE
Reverse port list order

### DIFF
--- a/electron_app/electron.js
+++ b/electron_app/electron.js
@@ -664,16 +664,16 @@ function getPortList(defaultPort) {
 
 function getDefaultPorts() {
   if (isDev) {
-    return getPortList(56000);
+    return getPortList(56300);
   }
   if (isAlpha) {
-    return getPortList(56100);
-  }
-  if (isBeta) {
     return getPortList(56200);
   }
+  if (isBeta) {
+    return getPortList(56100);
+  }
   if (isStable) {
-    return getPortList(56300);
+    return getPortList(56000);
   }
   throw new Error('Could not get default port for internal process engine');
 }


### PR DESCRIPTION
Dreht die Port-Listen so um, dass die Produktiv-Version den Basisport nutzt, die Beta-Version den Basisport + 100, usw.

Ich denke, dass wird den Support und die menschliche Kommunikation einfacher machen, wenn man nicht kopfrechnen muss, welchen Port die Stable-Version hat.