### PR TITLE
🐛 Fix Diagram Creation

### DIFF
--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.html
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.html
@@ -31,7 +31,7 @@
         click.delegate="openDiagram(diagram)"
         id="diagramList-${diagram.name}">
 
-        <div show.bind="currentlyRenamingDiagramUri === diagram.uri" class="diagram-rename-container">
+        <div if.bind="currentlyRenamingDiagramUri === diagram.uri" class="diagram-rename-container">
           <div class="input-holder">
             <input ref="renameDiagramInput" class.bind="hasValidationErrors ? 'input-holder__input input-holder__input--error' : 'input-holder__input'" type="text" value.bind="diagramRenamingState.currentDiagramInputValue & validateOnChange">
           </div>

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -429,7 +429,6 @@ export class SolutionExplorerSolution {
     }
 
     this.diagramCreationState.isCreateDiagramInputShown = true;
-    this.validationController.validate();
 
     // The templating update must happen before we can set the focus.
     window.setTimeout(() => {

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -55,7 +55,7 @@ interface IDiagramCreationState extends IDiagramNameInputState {
 export class SolutionExplorerSolution {
   public activeDiagram: IDiagram;
   public showCloseModal: boolean = false;
-  public renameDiagramInput: HTMLInputElement;
+  @bindable public renameDiagramInput: HTMLInputElement;
 
   // Fields below are bound from the html view.
   @bindable public solutionService: ISolutionExplorerService;

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -204,7 +204,7 @@ export class SolutionExplorerSolution {
 
     this.disposeSubscriptions();
 
-    if (this.isCreateDiagramInputShown()) {
+    if (this.diagramCreationState.isCreateDiagramInputShown) {
       this.resetDiagramCreation();
     }
 
@@ -341,7 +341,7 @@ export class SolutionExplorerSolution {
     }
 
     // Dont allow renaming diagram, if already creating another.
-    if (this.isCreateDiagramInputShown()) {
+    if (this.diagramCreationState.isCreateDiagramInputShown) {
       return;
     }
 
@@ -413,7 +413,7 @@ export class SolutionExplorerSolution {
    * diagram.
    */
   public async startCreationOfNewDiagram(): Promise<void> {
-    if (this.isCreateDiagramInputShown()) {
+    if (this.diagramCreationState.isCreateDiagramInputShown) {
       return;
     }
 
@@ -438,10 +438,6 @@ export class SolutionExplorerSolution {
 
     document.addEventListener('click', this.onCreateNewDiagramClickEvent);
     document.addEventListener('keyup', this.onCreateNewDiagramKeyupEvent);
-  }
-
-  public isCreateDiagramInputShown(): boolean {
-    return this.diagramCreationState.isCreateDiagramInputShown;
   }
 
   @computedFrom('validationController.errors.length')

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -352,6 +352,7 @@ export class SolutionExplorerSolution {
     window.setTimeout(() => {
       this.renameDiagramInput.focus();
       this.diagramRenamingState.currentDiagramInputValue = diagram.name;
+      this.setValidationRules();
       this.validationController.validate();
     }, 0);
 

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -434,6 +434,7 @@ export class SolutionExplorerSolution {
     // The templating update must happen before we can set the focus.
     window.setTimeout(() => {
       this.createNewDiagramInput.focus();
+      this.setValidationRules();
     }, 0);
 
     document.addEventListener('click', this.onCreateNewDiagramClickEvent);


### PR DESCRIPTION
## Changes

1. Fix diagram creation
2. Fix focus on 'renameDiagramInput'
3. Stop validating when create diagram input gets displayed
4. Fix validating 'createDiagramInput' after one diagram was created
5. Fix validating 'renameDiagramInput' after one diagram was renamed

## Issues

Closes #1631 

PR: #1633

## How to test the changes

- Create new diagram
- **Notice that the diagram creation works.**

- Rename a diagram
- **Notice that the rename input is directly focused.**

- Create a second diagram
- **Notice that the diagram creation still works.**

- Rename a second diagram
- **Notice that the renaming of diagrams still works.**

