### PR TITLE
🔥Remove file associations for alpha and beta

### DIFF
--- a/electron-builder/alpha/electron-builder.yml
+++ b/electron-builder/alpha/electron-builder.yml
@@ -16,18 +16,9 @@ nsis:
   runAfterFinish: false
 win:
   target: nsis
-  fileAssociations:
-    - ext:
-        - bpmn
-      name: BPMN
-      description: BPMN diagram extension
   artifactName: 'bpmn-studio-setup-${version}.${ext}'
 mac:
   target:
     - dmg
     - zip
-  fileAssociations:
-    - ext:
-        - bpmn
-      name: BPMN
   artifactName: 'bpmn-studio-setup-${version}.${ext}'

--- a/electron-builder/beta/electron-builder.yml
+++ b/electron-builder/beta/electron-builder.yml
@@ -16,18 +16,9 @@ nsis:
   runAfterFinish: false
 win:
   target: nsis
-  fileAssociations:
-    - ext:
-        - bpmn
-      name: BPMN
-      description: BPMN diagram extension
   artifactName: 'bpmn-studio-setup-${version}.${ext}'
 mac:
   target:
     - dmg
     - zip
-  fileAssociations:
-    - ext:
-        - bpmn
-      name: BPMN
   artifactName: 'bpmn-studio-setup-${version}.${ext}'


### PR DESCRIPTION
## Changes

1. Remove file associations for alpha releases
2. Remove file associations for beta releases

## Issues

PR: #1635 

## How to test the changes

- build the app for macOS or Windows
- install the app and recognize whether the file association is still set to the stable studio version
