### PR TITLE
Save tokenviewer collapse state

### DIFF
--- a/src/modules/inspect/inspect-correlation/inspect-correlation.ts
+++ b/src/modules/inspect/inspect-correlation/inspect-correlation.ts
@@ -102,6 +102,9 @@ export class InspectCorrelation {
     });
 
     this.viewIsAttached = true;
+
+    const previousTokenViewerState: boolean = JSON.parse(window.localStorage.getItem('tokenViewerCollapseState'));
+    this.showTokenViewer = previousTokenViewerState || false;
   }
 
   public detached(): void {

--- a/src/modules/inspect/inspect-correlation/inspect-correlation.ts
+++ b/src/modules/inspect/inspect-correlation/inspect-correlation.ts
@@ -103,7 +103,9 @@ export class InspectCorrelation {
 
     this.viewIsAttached = true;
 
-    const previousTokenViewerState: boolean = JSON.parse(window.localStorage.getItem('tokenViewerCollapseState'));
+    const previousTokenViewerState: boolean = JSON.parse(
+      window.localStorage.getItem('tokenViewerInspectCollapseState'),
+    );
     this.showTokenViewer = previousTokenViewerState || false;
   }
 

--- a/src/modules/inspect/inspect.ts
+++ b/src/modules/inspect/inspect.ts
@@ -134,7 +134,9 @@ export class Inspect {
       ),
     ];
 
-    const previousTokenViewerState: boolean = JSON.parse(window.localStorage.getItem('tokenViewerCollapseState'));
+    const previousTokenViewerState: boolean = JSON.parse(
+      window.localStorage.getItem('tokenViewerInspectCollapseState'),
+    );
     this.showTokenViewer = previousTokenViewerState || false;
   }
 
@@ -154,7 +156,7 @@ export class Inspect {
     this.showTokenViewer = !this.showTokenViewer;
 
     this.eventAggregator.publish(environment.events.inspectCorrelation.showTokenViewer, this.showTokenViewer);
-    window.localStorage.setItem('tokenViewerCollapseState', JSON.stringify(this.showTokenViewer));
+    window.localStorage.setItem('tokenViewerInspectCollapseState', JSON.stringify(this.showTokenViewer));
   }
 
   private async updateInspectView(diagramName: string, solutionUri?: string): Promise<void> {

--- a/src/modules/inspect/inspect.ts
+++ b/src/modules/inspect/inspect.ts
@@ -151,6 +151,7 @@ export class Inspect {
     this.showTokenViewer = !this.showTokenViewer;
 
     this.eventAggregator.publish(environment.events.inspectCorrelation.showTokenViewer, this.showTokenViewer);
+    window.localStorage.setItem('tokenViewerCollapseState', JSON.stringify(this.showTokenViewer));
   }
 
   private async updateInspectView(diagramName: string, solutionUri?: string): Promise<void> {

--- a/src/modules/inspect/inspect.ts
+++ b/src/modules/inspect/inspect.ts
@@ -133,6 +133,9 @@ export class Inspect {
         },
       ),
     ];
+
+    const previousTokenViewerState: boolean = JSON.parse(window.localStorage.getItem('tokenViewerCollapseState'));
+    this.showTokenViewer = previousTokenViewerState || false;
   }
 
   public detached(): void {

--- a/src/modules/live-execution-tracker/live-execution-tracker.ts
+++ b/src/modules/live-execution-tracker/live-execution-tracker.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import {computedFrom, inject, observable} from 'aurelia-framework';
 import {Router} from 'aurelia-router';
 

--- a/src/modules/live-execution-tracker/live-execution-tracker.ts
+++ b/src/modules/live-execution-tracker/live-execution-tracker.ts
@@ -228,7 +228,7 @@ export class LiveExecutionTracker {
       document.addEventListener('mouseup', mouseUpFunction);
     });
 
-    const previousTokenViewerState: boolean = JSON.parse(window.localStorage.getItem('tokenViewerCollapseState'));
+    const previousTokenViewerState: boolean = JSON.parse(window.localStorage.getItem('tokenViewerLETCollapseState'));
     this.showTokenViewer = previousTokenViewerState || false;
   }
 
@@ -296,7 +296,7 @@ export class LiveExecutionTracker {
 
   public toggleShowTokenViewer(): void {
     this.showTokenViewer = !this.showTokenViewer;
-    window.localStorage.setItem('tokenViewerCollapseState', JSON.stringify(this.showTokenViewer));
+    window.localStorage.setItem('tokenViewerLETCollapseState', JSON.stringify(this.showTokenViewer));
   }
 
   public async stopProcessInstance(): Promise<void> {

--- a/src/modules/live-execution-tracker/live-execution-tracker.ts
+++ b/src/modules/live-execution-tracker/live-execution-tracker.ts
@@ -293,6 +293,7 @@ export class LiveExecutionTracker {
 
   public toggleShowTokenViewer(): void {
     this.showTokenViewer = !this.showTokenViewer;
+    window.localStorage.setItem('tokenViewerCollapseState', JSON.stringify(this.showTokenViewer));
   }
 
   public async stopProcessInstance(): Promise<void> {

--- a/src/modules/live-execution-tracker/live-execution-tracker.ts
+++ b/src/modules/live-execution-tracker/live-execution-tracker.ts
@@ -227,6 +227,9 @@ export class LiveExecutionTracker {
       document.addEventListener('mousemove', mousemoveFunction);
       document.addEventListener('mouseup', mouseUpFunction);
     });
+
+    const previousTokenViewerState: boolean = JSON.parse(window.localStorage.getItem('tokenViewerCollapseState'));
+    this.showTokenViewer = previousTokenViewerState || false;
   }
 
   public async detached(): Promise<void> {


### PR DESCRIPTION
## Changes

1. Save and load the TokenViewer's collapse state

## Issues

Closes #1647 

PR: #1641 

## How to test the changes

- open the LET or inspect-correlation view
- expand the tokenviewer 
- reload/restart the studio
- see that is is still expanded
