### PR TITLE
✨ Add Overlays to Elements With Error

### DIFF
--- a/src/contracts/bpmnmodeler/IOverlayManager.ts
+++ b/src/contracts/bpmnmodeler/IOverlayManager.ts
@@ -1,12 +1,12 @@
 import {IShape} from '@process-engine/bpmn-elements_contracts';
 
-import {IOverlay} from './IOverlay';
 import {IOverlayDescriptor} from './IOverlayDescriptor';
+import {IOverlay, IOverlays} from './index';
 
 export interface IOverlayManager {
-  _overlays: Map<string, IOverlay>;
+  _overlays: IOverlays;
 
-  add(elementOrElementId: string | IShape, overlayDescriptor: IOverlayDescriptor): void;
-  remove(elementOrElementId: string | IShape): void;
+  add(elementOrElementId: string | IShape, overlayDescriptor: IOverlayDescriptor | IOverlay): void;
+  remove(overlayId: string | IShape): void;
   clear(): void;
 }

--- a/src/contracts/bpmnmodeler/IOverlays.ts
+++ b/src/contracts/bpmnmodeler/IOverlays.ts
@@ -1,0 +1,5 @@
+import {IOverlay} from './index';
+
+export interface IOverlays {
+  [key: string]: IOverlay;
+}

--- a/src/contracts/bpmnmodeler/index.ts
+++ b/src/contracts/bpmnmodeler/index.ts
@@ -16,6 +16,7 @@ export {IEditorActions} from './IEditorActions';
 export {IEventFunction} from './IEventFunction';
 export {IBpmnXmlSaveOptions} from './IBpmnXmlSaveOptions';
 export {IOverlay} from './IOverlay';
+export {IOverlays} from './IOverlays';
 export {IOverlayManager} from './IOverlayManager';
 export {IOverlayDescriptor} from './IOverlayDescriptor';
 export {IOverlayPosition} from './IOverlayPosition';

--- a/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.ts
+++ b/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.ts
@@ -200,9 +200,11 @@ export class DiagramViewer {
 
     this.xml = this.processInstance.xml;
 
+    const uncoloredXml: string = await this.liveExecutionTrackerService.clearDiagramColors(this.xml);
+
     this.xmlWithColorizedProgress = await this.liveExecutionTrackerService.getColorizedDiagram(
       this.activeSolutionEntry.identity,
-      this.xml,
+      uncoloredXml,
       this.processInstance.processInstanceId,
       true,
     );

--- a/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.ts
+++ b/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.ts
@@ -281,27 +281,6 @@ export class DiagramViewer {
     this.importXml(this.diagramViewer, colorizedXml);
   }
 
-  private clearColors(): void {
-    const elementsWithColor: Array<IShape> = this.elementRegistry.filter((element: IShape): boolean => {
-      const elementHasFillColor: boolean = element.businessObject.di.fill !== undefined;
-      const elementHasBorderColor: boolean = element.businessObject.di.stroke !== undefined;
-
-      const elementHasColor: boolean = elementHasFillColor || elementHasBorderColor;
-
-      return elementHasColor;
-    });
-
-    const noElementsWithColor: boolean = elementsWithColor.length === 0;
-    if (noElementsWithColor) {
-      return;
-    }
-
-    this.modeling.setColor(elementsWithColor, {
-      stroke: defaultBpmnColors.none.border,
-      fill: defaultBpmnColors.none.fill,
-    });
-  }
-
   private colorElement(element: IShape, color: IColorPickerColor): void {
     this.modeling.setColor(element, {
       stroke: color.border,

--- a/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.ts
+++ b/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.ts
@@ -40,7 +40,7 @@ export class DiagramViewer {
   private diagramModeler: IBpmnModeler;
   private diagramViewer: IBpmnModeler;
   private modeling: IModeling;
-  private uncoloredXml: string;
+  private xmlWithColorizedProgress: string;
   private uncoloredSVG: string;
   private subscriptions: Array<Subscription>;
   private diagramExportService: IDiagramExportService;
@@ -83,7 +83,7 @@ export class DiagramViewer {
         try {
           const exportName: string = `${this.activeDiagram.name}.bpmn`;
           await this.diagramExportService
-            .loadXML(this.uncoloredXml)
+            .loadXML(this.xmlWithColorizedProgress)
             .asBpmn()
             .export(exportName);
         } catch (error) {
@@ -200,15 +200,15 @@ export class DiagramViewer {
 
     this.xml = this.processInstance.xml;
 
-    this.uncoloredXml = await this.liveExecutionTrackerService.getColorizedDiagram(
+    this.xmlWithColorizedProgress = await this.liveExecutionTrackerService.getColorizedDiagram(
       this.activeSolutionEntry.identity,
       this.xml,
       this.processInstance.processInstanceId,
       true,
     );
 
-    await this.importXml(this.diagramModeler, this.uncoloredXml);
-    await this.importXml(this.diagramViewer, this.uncoloredXml);
+    await this.importXml(this.diagramModeler, this.xmlWithColorizedProgress);
+    await this.importXml(this.diagramViewer, this.xmlWithColorizedProgress);
     this.uncoloredSVG = await this.getSVG();
 
     const elementSelected: boolean = this.selectedFlowNode !== undefined;
@@ -265,7 +265,7 @@ export class DiagramViewer {
   }
 
   private async colorizeSelection(selectedElement: IShape): Promise<void> {
-    await this.importXml(this.diagramModeler, this.uncoloredXml);
+    await this.importXml(this.diagramModeler, this.xmlWithColorizedProgress);
 
     const elementToColorize: IShape = this.elementRegistry.filter((element: IShape): boolean => {
       const isSelectedElement: boolean = element.id === selectedElement.id;

--- a/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.ts
+++ b/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.ts
@@ -275,7 +275,12 @@ export class DiagramViewer {
       return isSelectedElement;
     })[0];
 
-    this.colorElement(elementToColorize, defaultBpmnColors.grey);
+    const previousColorWithGreyFill: IColorPickerColor = {
+      fill: defaultBpmnColors.grey.fill,
+      border: elementToColorize.businessObject.di.stroke,
+    };
+
+    this.colorElement(elementToColorize, previousColorWithGreyFill);
 
     const colorizedXml: string = await this.getXmlFromModeler();
     this.importXml(this.diagramViewer, colorizedXml);

--- a/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.ts
+++ b/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.ts
@@ -42,6 +42,7 @@ export class DiagramViewer {
   private subscriptions: Array<Subscription>;
   private diagramExportService: IDiagramExportService;
   private eventAggregator: EventAggregator;
+  private flowNodeToSetAfterProcessInstanceIsSet: string;
 
   constructor(notificationService: NotificationService, eventAggregator: EventAggregator) {
     this.notificationService = notificationService;
@@ -138,6 +139,22 @@ export class DiagramViewer {
     ];
   }
 
+  public selectFlowNode(flowNodeId: string): void {
+    if (this.processInstance === undefined) {
+      this.flowNodeToSetAfterProcessInstanceIsSet = flowNodeId;
+
+      return;
+    }
+
+    const elementRegistry: IElementRegistry = this.diagramViewer.get('elementRegistry');
+    const element: IShape = elementRegistry.get(flowNodeId);
+
+    this.diagramViewer.get('selection').select(element);
+
+    this.selectedFlowNode = element;
+    this.colorizeSelection(element);
+  }
+
   public detached(): void {
     const bjsContainer: Element = this.canvasModel.getElementsByClassName('bjs-container')[0];
 
@@ -201,6 +218,13 @@ export class DiagramViewer {
     }
 
     this.fitDiagramToViewport();
+
+    const flowNodeNeedsToBeSelected: boolean = this.flowNodeToSetAfterProcessInstanceIsSet !== undefined;
+    if (flowNodeNeedsToBeSelected) {
+      this.selectFlowNode(this.flowNodeToSetAfterProcessInstanceIsSet);
+
+      this.flowNodeToSetAfterProcessInstanceIsSet = undefined;
+    }
   }
 
   public activeDiagramChanged(): void {

--- a/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.ts
+++ b/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.ts
@@ -219,8 +219,8 @@ export class DiagramViewer {
         return isSelectedElement;
       });
 
-      const correlationHasSameElementASelected: boolean = elementsToColorize.length > 0;
-      if (correlationHasSameElementASelected) {
+      const correlationHasSameElementAsPreviouslySelected: boolean = elementsToColorize.length > 0;
+      if (correlationHasSameElementAsPreviouslySelected) {
         this.colorizeSelection(this.selectedFlowNode);
 
         const colorizedXml: string = await this.getXmlFromModeler();

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/components/correlation-list/correlation-list.ts
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/components/correlation-list/correlation-list.ts
@@ -15,6 +15,7 @@ import {IProcessInstanceWithCorrelation} from '../../../../contracts/index';
 
 @inject(EventAggregator)
 export class CorrelationList {
+  @bindable public processInstanceToSelect: string;
   @bindable public selectedProcessInstance: DataModels.Correlations.CorrelationProcessInstance;
   @bindable public selectedCorrelation: DataModels.Correlations.Correlation;
   @bindable public correlations: Array<DataModels.Correlations.Correlation>;
@@ -91,6 +92,17 @@ export class CorrelationList {
       this.sortSettings.ascending = true;
 
       this.sortList(CorrelationListSortProperty.Number);
+    }
+
+    const processInstanceToSelectExists: boolean = this.processInstanceToSelect !== undefined;
+    if (processInstanceToSelectExists) {
+      const entryToSelect: ICorrelationTableEntry = this.sortedTableData.find((entry: ICorrelationTableEntry) => {
+        return entry.processInstanceId === this.processInstanceToSelect;
+      });
+
+      this.selectCorrelation(entryToSelect);
+
+      this.processInstanceToSelect = undefined;
     }
   }
 

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/components/log-viewer/log-viewer.ts
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/components/log-viewer/log-viewer.ts
@@ -39,6 +39,11 @@ export class LogViewer {
   }
 
   public async processInstanceChanged(): Promise<void> {
+    const noProcessInstanceSet: boolean = this.processInstance === undefined;
+    if (noProcessInstanceSet) {
+      return;
+    }
+
     setTimeout(async () => {
       this.log = await this.inspectCorrelationService.getLogsForProcessInstance(
         this.processInstance.processModelId,

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/inspect-panel.html
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/inspect-panel.html
@@ -24,7 +24,7 @@
       </div>
     </div>
     <div class="inspect-panel__body">
-      <correlation-list if.bind="showCorrelationList" active-diagram.bind="activeDiagram" correlations.to-view="correlations" process-instances.from-view="processInstances" selected-process-instance.from-view="selectedProcessInstance" selected-correlation.from-view="selectedCorrelation"></correlation-list>
+      <correlation-list if.bind="showCorrelationList" active-diagram.bind="activeDiagram" correlations.to-view="correlations" process-instances.from-view="processInstances" selected-process-instance.from-view="selectedProcessInstance" selected-correlation.from-view="selectedCorrelation" process-instance-to-select.to-view="processInstanceToSelect"></correlation-list>
       <log-viewer if.bind="showLogViewer" active-solution-entry.bind="activeSolutionEntry" process-instance.to-view="selectedProcessInstance"></log-viewer>
     </div>
   </div>

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/inspect-panel.ts
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/inspect-panel.ts
@@ -9,6 +9,7 @@ import environment from '../../../../../environment';
 
 @inject(EventAggregator)
 export class InspectPanel {
+  @bindable public processInstanceToSelect: string;
   @bindable public correlations: Array<DataModels.Correlations.Correlation>;
   @bindable public processInstances: Array<DataModels.Correlations.CorrelationProcessInstance>;
   @bindable public selectedProcessInstance: DataModels.Correlations.CorrelationProcessInstance;

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/inspect-panel.ts
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/inspect-panel.ts
@@ -19,7 +19,7 @@ export class InspectPanel {
   @bindable public activeSolutionEntry: ISolutionEntry;
   public inspectPanelTab: typeof InspectPanelTab = InspectPanelTab;
   public showCorrelationList: boolean = true;
-  public showLogViewer: boolean;
+  public showLogViewer: boolean = false;
 
   private eventAggregator: EventAggregator;
   private subscriptions: Array<Subscription>;

--- a/src/modules/inspect/inspect-correlation/inspect-correlation.html
+++ b/src/modules/inspect/inspect-correlation/inspect-correlation.html
@@ -7,7 +7,7 @@
     <div class="inspect-correlation__left-toolbar"></div>
     <div class="inspect-correlation__panels">
       <div class="inspect-correlation__upper-panel" show.bind="!inspectPanelFullscreen" >
-        <diagram-viewer class="inspect-correlation__diagram-viewer" selected-flow-node.two-way="selectedFlowNode" active-diagram.bind="activeDiagram" process-instance.to-view="selectedProcessInstance"></diagram-viewer>
+        <diagram-viewer class="inspect-correlation__diagram-viewer" view-model.ref="diagramViewer" selected-flow-node.two-way="selectedFlowNode" active-diagram.bind="activeDiagram" process-instance.to-view="selectedProcessInstance"></diagram-viewer>
         <div class="inspect-correlation__right-resize-div" ref="rightPanelResizeDiv" show.bind="showTokenViewer"></div>
         <token-viewer class="inspect-correlation__token-viewer" css="width: ${tokenViewerWidth}px;"
           correlation.bind="selectedCorrelation"
@@ -21,7 +21,7 @@
       <div class="inspect-correlation__bottom-panel" css="height: ${bottomPanelHeight}px;"
             class.bind="inspectPanelFullscreen ? 'inspect-correlation__bottom-panel--fullscreen' : ''"
             show.bind="showInspectPanel">
-        <inspect-panel active-solution-entry.bind="activeSolutionEntry" active-diagram.bind="activeDiagram" correlations.bind="correlations" selected-correlation.from-view="selectedCorrelation" selected-process-instance.from-view="selectedProcessInstance" fullscreen.two-way="inspectPanelFullscreen" log.bind="log"></inspect-panel>
+        <inspect-panel view-model.ref="inspectPanel" active-solution-entry.bind="activeSolutionEntry" active-diagram.bind="activeDiagram" correlations.bind="correlations" selected-correlation.from-view="selectedCorrelation" selected-process-instance.from-view="selectedProcessInstance" fullscreen.two-way="inspectPanelFullscreen" log.bind="log" process-instance-to-select.to-view="processInstanceToSelect"></inspect-panel>
       </div>
     </div>
 </template>

--- a/src/modules/inspect/inspect-correlation/inspect-correlation.html
+++ b/src/modules/inspect/inspect-correlation/inspect-correlation.html
@@ -7,7 +7,7 @@
     <div class="inspect-correlation__left-toolbar"></div>
     <div class="inspect-correlation__panels">
       <div class="inspect-correlation__upper-panel" show.bind="!inspectPanelFullscreen" >
-        <diagram-viewer class="inspect-correlation__diagram-viewer" view-model.ref="diagramViewer" selected-flow-node.two-way="selectedFlowNode" active-diagram.bind="activeDiagram" process-instance.to-view="selectedProcessInstance"></diagram-viewer>
+        <diagram-viewer class="inspect-correlation__diagram-viewer" view-model.ref="diagramViewer" active-solution-entry.bind="activeSolutionEntry" selected-flow-node.two-way="selectedFlowNode" active-diagram.bind="activeDiagram" process-instance.to-view="selectedProcessInstance"></diagram-viewer>
         <div class="inspect-correlation__right-resize-div" ref="rightPanelResizeDiv" show.bind="showTokenViewer"></div>
         <token-viewer class="inspect-correlation__token-viewer" css="width: ${tokenViewerWidth}px;"
           correlation.bind="selectedCorrelation"

--- a/src/modules/inspect/inspect-correlation/inspect-correlation.ts
+++ b/src/modules/inspect/inspect-correlation/inspect-correlation.ts
@@ -5,7 +5,7 @@ import {IShape} from '@process-engine/bpmn-elements_contracts';
 import {DataModels} from '@process-engine/management_api_contracts';
 import {IDiagram} from '@process-engine/solutionexplorer.contracts';
 
-import {IEventFunction, ISolutionEntry} from '../../../contracts/index';
+import {IEventFunction, ISolutionEntry, InspectPanelTab} from '../../../contracts/index';
 import environment from '../../../environment';
 import {IInspectCorrelationService} from './contracts';
 import {DiagramViewer} from './components/diagram-viewer/diagram-viewer';
@@ -25,6 +25,7 @@ export class InspectCorrelation {
   @observable public tokenViewerWidth: number = 250;
   @bindable public diagramViewer: DiagramViewer;
   @bindable public inspectPanel: InspectPanel;
+  @bindable public inspectPanelTabToShow: InspectPanelTab;
 
   public correlations: Array<DataModels.Correlations.Correlation>;
   public token: string;
@@ -115,6 +116,11 @@ export class InspectCorrelation {
     this.showTokenViewer = previousTokenViewerState || false;
 
     this.diagramViewer.selectFlowNode(this.flowNodeToSelect);
+
+    const shouldDisplaySpecificInspectPanelTab: boolean = this.inspectPanelTabToShow !== undefined;
+    if (shouldDisplaySpecificInspectPanelTab) {
+      this.inspectPanel.changeTab(this.inspectPanelTabToShow);
+    }
   }
 
   public detached(): void {

--- a/src/modules/inspect/inspect-correlation/inspect-correlation.ts
+++ b/src/modules/inspect/inspect-correlation/inspect-correlation.ts
@@ -115,7 +115,10 @@ export class InspectCorrelation {
     );
     this.showTokenViewer = previousTokenViewerState || false;
 
-    this.diagramViewer.selectFlowNode(this.flowNodeToSelect);
+    const flowNodeToSelectExists: boolean = this.flowNodeToSelect !== undefined;
+    if (flowNodeToSelectExists) {
+      this.diagramViewer.selectFlowNode(this.flowNodeToSelect);
+    }
 
     const shouldDisplaySpecificInspectPanelTab: boolean = this.inspectPanelTabToShow !== undefined;
     if (shouldDisplaySpecificInspectPanelTab) {

--- a/src/modules/inspect/inspect-correlation/inspect-correlation.ts
+++ b/src/modules/inspect/inspect-correlation/inspect-correlation.ts
@@ -8,9 +8,13 @@ import {IDiagram} from '@process-engine/solutionexplorer.contracts';
 import {IEventFunction, ISolutionEntry} from '../../../contracts/index';
 import environment from '../../../environment';
 import {IInspectCorrelationService} from './contracts';
+import {DiagramViewer} from './components/diagram-viewer/diagram-viewer';
+import {InspectPanel} from './components/inspect-panel/inspect-panel';
 
 @inject('InspectCorrelationService', EventAggregator)
 export class InspectCorrelation {
+  @bindable public processInstanceToSelect: string;
+  @bindable public flowNodeToSelect: string;
   @bindable public activeDiagram: IDiagram;
   @bindable public activeSolutionEntry: ISolutionEntry;
   @bindable public selectedProcessInstance: DataModels.Correlations.CorrelationProcessInstance;
@@ -19,6 +23,8 @@ export class InspectCorrelation {
   @bindable public noCorrelationsFound: boolean = false;
   @observable public bottomPanelHeight: number = 250;
   @observable public tokenViewerWidth: number = 250;
+  @bindable public diagramViewer: DiagramViewer;
+  @bindable public inspectPanel: InspectPanel;
 
   public correlations: Array<DataModels.Correlations.Correlation>;
   public token: string;
@@ -107,6 +113,8 @@ export class InspectCorrelation {
       window.localStorage.getItem('tokenViewerInspectCollapseState'),
     );
     this.showTokenViewer = previousTokenViewerState || false;
+
+    this.diagramViewer.selectFlowNode(this.flowNodeToSelect);
   }
 
   public detached(): void {

--- a/src/modules/inspect/inspect.html
+++ b/src/modules/inspect/inspect.html
@@ -12,7 +12,7 @@
       <heatmap active-diagram.bind="activeDiagram" active-solution-entry.bind="activeSolutionEntry"></heatmap>
     </div>
     <div if.bind="showInspectCorrelation" class="inspect__inspect-correlation-container">
-      <inspect-correlation active-diagram.bind="activeDiagram" active-solution-entry.bind="activeSolutionEntry"></inspect-correlation>
+      <inspect-correlation active-diagram.bind="activeDiagram" active-solution-entry.bind="activeSolutionEntry" process-instance-to-select.to-view="processInstanceToSelect" flow-node-to-select.to-view="flowNodeToSelect"></inspect-correlation>
     </div>
 
     <div class="inspect-layout__tools-right">

--- a/src/modules/inspect/inspect.html
+++ b/src/modules/inspect/inspect.html
@@ -12,7 +12,7 @@
       <heatmap active-diagram.bind="activeDiagram" active-solution-entry.bind="activeSolutionEntry"></heatmap>
     </div>
     <div if.bind="showInspectCorrelation" class="inspect__inspect-correlation-container">
-      <inspect-correlation active-diagram.bind="activeDiagram" active-solution-entry.bind="activeSolutionEntry" process-instance-to-select.to-view="processInstanceToSelect" flow-node-to-select.to-view="flowNodeToSelect"></inspect-correlation>
+      <inspect-correlation active-diagram.bind="activeDiagram" active-solution-entry.bind="activeSolutionEntry" process-instance-to-select.to-view="processInstanceToSelect" flow-node-to-select.to-view="flowNodeToSelect" inspect-panel-tab-to-show.to-view="inspectPanelTabToShow"></inspect-correlation>
     </div>
 
     <div class="inspect-layout__tools-right">

--- a/src/modules/inspect/inspect.ts
+++ b/src/modules/inspect/inspect.ts
@@ -13,6 +13,8 @@ interface IInspectRouteParameters {
   view?: string;
   diagramName?: string;
   solutionUri?: string;
+  processInstanceToSelect?: string;
+  flowNodeToSelect?: string;
 }
 
 @inject(EventAggregator, 'SolutionService', 'NotificationService')
@@ -26,6 +28,8 @@ export class Inspect {
   public dashboard: Dashboard;
   public showTokenViewer: boolean = false;
   public tokenViewerButtonDisabled: boolean = false;
+  public processInstanceToSelect: string;
+  public flowNodeToSelect: string;
 
   private eventAggregator: EventAggregator;
   private subscriptions: Array<Subscription>;
@@ -73,6 +77,9 @@ export class Inspect {
     const routeViewIsDashboard: boolean = routeParameters.view === 'dashboard';
     const routeViewIsHeatmap: boolean = routeParameters.view === 'heatmap';
     const routeViewIsInspectCorrelation: boolean = routeParameters.view === 'inspect-correlation';
+
+    this.processInstanceToSelect = routeParameters.processInstanceToSelect;
+    this.flowNodeToSelect = routeParameters.flowNodeToSelect;
 
     if (routeViewIsDashboard) {
       this.showHeatmap = false;

--- a/src/modules/inspect/inspect.ts
+++ b/src/modules/inspect/inspect.ts
@@ -4,7 +4,7 @@ import {activationStrategy} from 'aurelia-router';
 
 import {IDiagram} from '@process-engine/solutionexplorer.contracts';
 
-import {ISolutionEntry, ISolutionService, NotificationType} from '../../contracts/index';
+import {ISolutionEntry, ISolutionService, InspectPanelTab, NotificationType} from '../../contracts/index';
 import environment from '../../environment';
 import {NotificationService} from '../../services/notification-service/notification.service';
 import {Dashboard} from './dashboard/dashboard';
@@ -15,6 +15,7 @@ interface IInspectRouteParameters {
   solutionUri?: string;
   processInstanceToSelect?: string;
   flowNodeToSelect?: string;
+  inspectPanelTabToShow?: InspectPanelTab;
 }
 
 @inject(EventAggregator, 'SolutionService', 'NotificationService')
@@ -30,6 +31,7 @@ export class Inspect {
   public tokenViewerButtonDisabled: boolean = false;
   public processInstanceToSelect: string;
   public flowNodeToSelect: string;
+  public inspectPanelTabToShow: InspectPanelTab;
 
   private eventAggregator: EventAggregator;
   private subscriptions: Array<Subscription>;
@@ -80,6 +82,7 @@ export class Inspect {
 
     this.processInstanceToSelect = routeParameters.processInstanceToSelect;
     this.flowNodeToSelect = routeParameters.flowNodeToSelect;
+    this.inspectPanelTabToShow = routeParameters.inspectPanelTabToShow;
 
     if (routeViewIsDashboard) {
       this.showHeatmap = false;

--- a/src/modules/live-execution-tracker/contracts/ILiveExecutionTracker.Repository.ts
+++ b/src/modules/live-execution-tracker/contracts/ILiveExecutionTracker.Repository.ts
@@ -4,53 +4,105 @@ import {DataModels} from '@process-engine/management_api_contracts';
 
 export interface ILiveExecutionTrackerRepository {
   finishEmptyActivity(
+    identity: IIdentity,
     processInstanceId: string,
     correlationId: string,
     emptyActivity: DataModels.EmptyActivities.EmptyActivity,
   ): Promise<void>;
-  terminateProcess(processInstanceId: string): Promise<void>;
+  terminateProcess(identity: IIdentity, processInstanceId: string): Promise<void>;
 
-  getActiveTokensForProcessInstance(processInstanceId: string): Promise<Array<DataModels.Kpi.ActiveToken> | null>;
-  getCorrelationById(correlationId: string): Promise<DataModels.Correlations.Correlation>;
+  getActiveTokensForProcessInstance(
+    identity: IIdentity,
+    processInstanceId: string,
+  ): Promise<Array<DataModels.Kpi.ActiveToken> | null>;
+  getCorrelationById(identity: IIdentity, correlationId: string): Promise<DataModels.Correlations.Correlation>;
   getEmptyActivitiesForProcessInstance(
+    identity: IIdentity,
     processInstanceId: string,
   ): Promise<DataModels.EmptyActivities.EmptyActivityList | null>;
   getFlowNodeInstancesForProcessInstance(
+    identity: IIdentity,
     processInstanceId: string,
   ): Promise<Array<DataModels.FlowNodeInstances.FlowNodeInstance>>;
-  getProcessModelById(processModelId: string): Promise<DataModels.ProcessModels.ProcessModel>;
+  getProcessModelById(identity: IIdentity, processModelId: string): Promise<DataModels.ProcessModels.ProcessModel>;
   getTokenHistoryGroupForProcessInstance(
+    identity: IIdentity,
     processInstanceId: string,
   ): Promise<DataModels.TokenHistory.TokenHistoryGroup | null>;
 
-  setIdentity(identity: IIdentity): void;
+  isProcessInstanceActive(identity: IIdentity, processInstanceId: string): Promise<boolean>;
 
-  isProcessInstanceActive(processInstanceId: string): Promise<boolean>;
+  createProcessEndedEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription>;
+  createProcessTerminatedEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription>;
 
-  createProcessEndedEventListener(processInstanceId: string, callback: Function): Promise<Subscription>;
-  createProcessTerminatedEventListener(processInstanceId: string, callback: Function): Promise<Subscription>;
-
-  createActivityReachedEventListener(processInstanceId: string, callback: Function): Promise<Subscription>;
-  createActivityFinishedEventListener(processInstanceId: string, callback: Function): Promise<Subscription>;
-  createEmptyActivityWaitingEventListener(processInstanceId: string, callback: Function): Promise<Subscription>;
-  createEmptyActivityFinishedEventListener(processInstanceId: string, callback: Function): Promise<Subscription>;
-  createManualTaskWaitingEventListener(processInstanceId: string, callback: Function): Promise<Subscription>;
-  createManualTaskFinishedEventListener(processInstanceId: string, callback: Function): Promise<Subscription>;
-  createUserTaskWaitingEventListener(processInstanceId: string, callback: Function): Promise<Subscription>;
-  createUserTaskFinishedEventListener(processInstanceId: string, callback: Function): Promise<Subscription>;
-  createBoundaryEventTriggeredEventListener(processInstanceId: string, callback: Function): Promise<Subscription>;
+  createActivityReachedEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription>;
+  createActivityFinishedEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription>;
+  createEmptyActivityWaitingEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription>;
+  createEmptyActivityFinishedEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription>;
+  createManualTaskWaitingEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription>;
+  createManualTaskFinishedEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription>;
+  createUserTaskWaitingEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription>;
+  createUserTaskFinishedEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription>;
+  createBoundaryEventTriggeredEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription>;
   createIntermediateThrowEventTriggeredEventListener(
+    identity: IIdentity,
     processInstanceId: string,
     callback: Function,
   ): Promise<Subscription>;
   createIntermediateCatchEventReachedEventListener(
+    identity: IIdentity,
     processInstanceId: string,
     callback: Function,
   ): Promise<Subscription>;
   createIntermediateCatchEventFinishedEventListener(
+    identity: IIdentity,
     processInstanceId: string,
     callback: Function,
   ): Promise<Subscription>;
 
-  removeSubscription(subscription: Subscription): Promise<void>;
+  removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void>;
 }

--- a/src/modules/live-execution-tracker/contracts/ILiveExecutionTracker.Service.ts
+++ b/src/modules/live-execution-tracker/contracts/ILiveExecutionTracker.Service.ts
@@ -5,39 +5,47 @@ import {DataModels} from '@process-engine/management_api_contracts';
 
 export interface ILiveExecutionTrackerService {
   finishEmptyActivity(
+    identity: IIdentity,
     processInstanceId: string,
     correlationId: string,
     emptyActivity: DataModels.EmptyActivities.EmptyActivity,
   ): Promise<void>;
-  terminateProcess(processInstanceId: string): Promise<void>;
+  terminateProcess(identity: IIdentity, processInstanceId: string): Promise<void>;
 
-  getActiveTokensForProcessInstance(processInstanceId: string): Promise<Array<DataModels.Kpi.ActiveToken> | null>;
-  getCorrelationById(correlationId: string): Promise<DataModels.Correlations.Correlation>;
+  getActiveTokensForProcessInstance(
+    identity: IIdentity,
+    processInstanceId: string,
+  ): Promise<Array<DataModels.Kpi.ActiveToken> | null>;
+  getCorrelationById(identity: IIdentity, correlationId: string): Promise<DataModels.Correlations.Correlation>;
   getEmptyActivitiesForProcessInstance(
+    identity: IIdentity,
     processInstanceId: string,
   ): Promise<DataModels.EmptyActivities.EmptyActivityList | null>;
   getProcessModelByProcessInstanceId(
+    identity: IIdentity,
     correlationId: string,
     processInstanceId: string,
   ): Promise<DataModels.Correlations.CorrelationProcessInstance>;
-  getProcessModelById(processModelId: string): Promise<DataModels.ProcessModels.ProcessModel>;
+  getProcessModelById(identity: IIdentity, processModelId: string): Promise<DataModels.ProcessModels.ProcessModel>;
   getTokenHistoryGroupForProcessInstance(
+    identity: IIdentity,
     processInstanceId: string,
   ): Promise<DataModels.TokenHistory.TokenHistoryGroup | null>;
 
   getProcessInstanceIdOfCallActivityTarget(
+    identity: IIdentity,
     correlationId: string,
     processInstanceIdOfOrigin: string,
     callActivityTargetId: string,
   ): Promise<string>;
   getElementById(elementId: string): IShape;
-  getAllElementsThatCanHaveAToken(): Array<IShape>;
-  getElementsWithActiveToken(processInstanceId: string): Promise<Array<IShape> | null>;
-  getElementsWithTokenHistory(processInstanceId: string): Promise<Array<IShape> | null>;
-  getElementsWithError(processInstanceId: string): Promise<Array<IShape>>;
-  getCallActivities(): Array<IShape>;
-  getActiveCallActivities(processInstanceId: string): Promise<Array<IShape>>;
-  getInactiveCallActivities(processInstanceId: string): Promise<Array<IShape>>;
+  getAllElementsThatCanHaveAToken(identity: IIdentity): Array<IShape>;
+  getElementsWithActiveToken(identity: IIdentity, processInstanceId: string): Promise<Array<IShape> | null>;
+  getElementsWithTokenHistory(identity: IIdentity, processInstanceId: string): Promise<Array<IShape> | null>;
+  getElementsWithError(identity: IIdentity, processInstanceId: string): Promise<Array<IShape>>;
+  getCallActivities(identity: IIdentity): Array<IShape>;
+  getActiveCallActivities(identity: IIdentity, processInstanceId: string): Promise<Array<IShape>>;
+  getInactiveCallActivities(identity: IIdentity, processInstanceId: string): Promise<Array<IShape>>;
   getOutgoingElementsOfElement(
     element: IShape,
     tokenHistoryGroups: DataModels.TokenHistory.TokenHistoryGroup,
@@ -46,42 +54,88 @@ export interface ILiveExecutionTrackerService {
   elementHasActiveToken(elementId: string, activeTokens: Array<DataModels.Kpi.ActiveToken>): boolean;
   elementHasTokenHistory(elementId: string, tokenHistoryGroups: DataModels.TokenHistory.TokenHistoryGroup): boolean;
 
-  setIdentity(identity: IIdentity): void;
-
   importXmlIntoDiagramModeler(xml: string): Promise<void>;
   exportXmlFromDiagramModeler(): Promise<string>;
   clearDiagramColors(): void;
   getColorizedDiagram(
+    identity: IIdentity,
     processInstanceId: string,
     processEngineSupportsGettingFlowNodeInstances?: boolean,
   ): Promise<string>;
 
-  isProcessInstanceActive(processInstanceId: string): Promise<boolean>;
+  isProcessInstanceActive(identity: IIdentity, processInstanceId: string): Promise<boolean>;
 
-  createProcessEndedEventListener(processInstanceId: string, callback: Function): Promise<Subscription>;
-  createProcessTerminatedEventListener(processInstanceId: string, callback: Function): Promise<Subscription>;
+  createProcessEndedEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription>;
+  createProcessTerminatedEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription>;
 
-  createActivityReachedEventListener(processInstanceId: string, callback: Function): Promise<Subscription>;
-  createActivityFinishedEventListener(processInstanceId: string, callback: Function): Promise<Subscription>;
-  createEmptyActivityWaitingEventListener(processInstanceId: string, callback: Function): Promise<Subscription>;
-  createEmptyActivityFinishedEventListener(processInstanceId: string, callback: Function): Promise<Subscription>;
-  createManualTaskWaitingEventListener(processInstanceId: string, callback: Function): Promise<Subscription>;
-  createManualTaskFinishedEventListener(processInstanceId: string, callback: Function): Promise<Subscription>;
-  createUserTaskWaitingEventListener(processInstanceId: string, callback: Function): Promise<Subscription>;
-  createUserTaskFinishedEventListener(processInstanceId: string, callback: Function): Promise<Subscription>;
-  createBoundaryEventTriggeredEventListener(processInstanceId: string, callback: Function): Promise<Subscription>;
+  createActivityReachedEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription>;
+  createActivityFinishedEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription>;
+  createEmptyActivityWaitingEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription>;
+  createEmptyActivityFinishedEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription>;
+  createManualTaskWaitingEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription>;
+  createManualTaskFinishedEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription>;
+  createUserTaskWaitingEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription>;
+  createUserTaskFinishedEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription>;
+  createBoundaryEventTriggeredEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription>;
   createIntermediateThrowEventTriggeredEventListener(
+    identity: IIdentity,
     processInstanceId: string,
     callback: Function,
   ): Promise<Subscription>;
   createIntermediateCatchEventReachedEventListener(
+    identity: IIdentity,
     processInstanceId: string,
     callback: Function,
   ): Promise<Subscription>;
   createIntermediateCatchEventFinishedEventListener(
+    identity: IIdentity,
     processInstanceId: string,
     callback: Function,
   ): Promise<Subscription>;
 
-  removeSubscription(subscription: Subscription): Promise<void>;
+  removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void>;
 }

--- a/src/modules/live-execution-tracker/contracts/ILiveExecutionTracker.Service.ts
+++ b/src/modules/live-execution-tracker/contracts/ILiveExecutionTracker.Service.ts
@@ -54,11 +54,10 @@ export interface ILiveExecutionTrackerService {
   elementHasActiveToken(elementId: string, activeTokens: Array<DataModels.Kpi.ActiveToken>): boolean;
   elementHasTokenHistory(elementId: string, tokenHistoryGroups: DataModels.TokenHistory.TokenHistoryGroup): boolean;
 
-  importXmlIntoDiagramModeler(xml: string): Promise<void>;
-  exportXmlFromDiagramModeler(): Promise<string>;
-  clearDiagramColors(): void;
+  clearDiagramColors(xml: string): Promise<string>;
   getColorizedDiagram(
     identity: IIdentity,
+    xml: string,
     processInstanceId: string,
     processEngineSupportsGettingFlowNodeInstances?: boolean,
   ): Promise<string>;

--- a/src/modules/live-execution-tracker/contracts/ILiveExecutionTracker.Service.ts
+++ b/src/modules/live-execution-tracker/contracts/ILiveExecutionTracker.Service.ts
@@ -34,6 +34,7 @@ export interface ILiveExecutionTrackerService {
   getAllElementsThatCanHaveAToken(): Array<IShape>;
   getElementsWithActiveToken(processInstanceId: string): Promise<Array<IShape> | null>;
   getElementsWithTokenHistory(processInstanceId: string): Promise<Array<IShape> | null>;
+  getElementsWithError(processInstanceId: string): Promise<Array<IShape>>;
   getCallActivities(): Array<IShape>;
   getActiveCallActivities(processInstanceId: string): Promise<Array<IShape>>;
   getInactiveCallActivities(processInstanceId: string): Promise<Array<IShape>>;

--- a/src/modules/live-execution-tracker/live-execution-tracker.ts
+++ b/src/modules/live-execution-tracker/live-execution-tracker.ts
@@ -74,6 +74,8 @@ export class LiveExecutionTracker {
   private notificationService: NotificationService;
   private solutionService: ISolutionService;
 
+  private xml: string;
+
   private processStopped: boolean = false;
   private isAttached: boolean = false;
   private parentProcessInstanceId: string;
@@ -184,9 +186,6 @@ export class LiveExecutionTracker {
       return;
     }
 
-    // Import the xml to the modeler to add colors to it
-    await this.liveExecutionTrackerService.importXmlIntoDiagramModeler(xml);
-
     // Colorize xml & Add overlays
     /*
      * Remove all colors if the diagram has already colored elements.
@@ -194,11 +193,10 @@ export class LiveExecutionTracker {
      * the diagram, one would think in LiveExecutionTracker that the element is
      * active although it is not active.
      */
-    this.liveExecutionTrackerService.clearDiagramColors();
+    const uncoloredXml: string = await this.liveExecutionTrackerService.clearDiagramColors(xml);
+    this.xml = uncoloredXml;
 
-    // Import the xml without colors to DiagramViewer
-    const xmlFromModeler: string = await this.liveExecutionTrackerService.exportXmlFromDiagramModeler();
-    await this.importXmlIntoDiagramViewer(xmlFromModeler);
+    await this.importXmlIntoDiagramViewer(uncoloredXml);
 
     // The version must be later than 8.1.0
     const processEngineSupportsEvents: boolean = this.checkIfProcessEngineSupportsEvents();
@@ -810,6 +808,7 @@ export class LiveExecutionTracker {
       try {
         return await this.liveExecutionTrackerService.getColorizedDiagram(
           this.activeSolutionEntry.identity,
+          this.xml,
           this.processInstanceId,
           this.checkIfProcessEngineSupportsGettingFlowNodeInstances(),
         );

--- a/src/modules/live-execution-tracker/live-execution-tracker.ts
+++ b/src/modules/live-execution-tracker/live-execution-tracker.ts
@@ -21,6 +21,7 @@ import {
   IOverlays,
   ISolutionEntry,
   ISolutionService,
+  InspectPanelTab,
   NotificationType,
 } from '../../contracts/index';
 
@@ -524,6 +525,7 @@ export class LiveExecutionTracker {
       solutionUri: this.activeSolutionEntry.uri,
       processInstanceToSelect: this.processInstanceId,
       flowNodeToSelect: elementId,
+      inspectPanelTabToShow: InspectPanelTab.LogViewer,
     });
   };
 

--- a/src/modules/live-execution-tracker/live-execution-tracker.ts
+++ b/src/modules/live-execution-tracker/live-execution-tracker.ts
@@ -16,7 +16,9 @@ import {
   ICanvas,
   IEvent,
   IEventFunction,
+  IOverlay,
   IOverlayManager,
+  IOverlays,
   ISolutionEntry,
   ISolutionService,
   NotificationType,
@@ -86,7 +88,7 @@ export class LiveExecutionTracker {
   private colorizeAgain: boolean = false;
 
   private eventListenerSubscriptions: Array<Subscription> = [];
-  private elementsWithEventListeners: Array<string> = [];
+  private overlaysWithEventListeners: Array<string> = [];
 
   private liveExecutionTrackerService: ILiveExecutionTrackerService;
 
@@ -381,23 +383,67 @@ export class LiveExecutionTracker {
     this.overlays.clear();
     this.removeEventListenerFromOverlays();
 
-    this.addOverlaysToUserAndManualTasks(elementsWithActiveToken);
-    this.addOverlaysToEmptyActivities(elementsWithActiveToken);
-    this.addOverlaysToActiveCallActivities(elementsWithActiveToken);
-    this.addOverlaysToInactiveCallActivities(inactiveCallActivities);
-    this.addOverlaysToElementsWithError(elementsWithError);
+    const userAndManualTaskOverlays: Array<string> = this.addOverlaysToUserAndManualTasks(elementsWithActiveToken);
+    const emptyActivityOverlays: Array<string> = this.addOverlaysToEmptyActivities(elementsWithActiveToken);
+    const activeCallActivityOverlays: Array<string> = this.addOverlaysToActiveCallActivities(elementsWithActiveToken);
+    const inactiveCallActivityOverlays: Array<string> = this.addOverlaysToInactiveCallActivities(
+      inactiveCallActivities,
+    );
+    const errorElementOverlays: Array<string> = this.addOverlaysToElementsWithError(elementsWithError);
+
+    const elementsWithOverlays: Array<string> = [
+      ...userAndManualTaskOverlays,
+      ...emptyActivityOverlays,
+      ...activeCallActivityOverlays,
+      ...inactiveCallActivityOverlays,
+      ...errorElementOverlays,
+    ];
+
+    this.rearrangeOverlaysForElementWithMultipleOverlays(elementsWithOverlays);
   }
 
   private removeEventListenerFromOverlays(): void {
-    for (const elementId of this.elementsWithEventListeners) {
-      document.getElementById(elementId).removeEventListener('click', this.handleTaskClick);
-      document.getElementById(elementId).removeEventListener('click', this.handleEmptyActivityClick);
-      document.getElementById(elementId).removeEventListener('click', this.handleActiveCallActivityClick);
-      document.getElementById(elementId).removeEventListener('click', this.handleErrorElementClick);
-      document.getElementById(elementId).removeEventListener('click', this.handleInactiveCallActivityClick);
+    for (const overlayId of this.overlaysWithEventListeners) {
+      this.removeEventListenerFromOverlay(overlayId);
     }
 
-    this.elementsWithEventListeners = [];
+    this.overlaysWithEventListeners = [];
+  }
+
+  private addEventListenerToOverlay(overlayHtmlId: string): void {
+    const functionToAdd: EventListenerOrEventListenerObject = this.getEventListenerForOverlayId(overlayHtmlId);
+
+    document.getElementById(overlayHtmlId).addEventListener('click', functionToAdd);
+
+    this.overlaysWithEventListeners.push(overlayHtmlId);
+  }
+
+  private removeEventListenerFromOverlay(overlayHtmlId: string): void {
+    const functionToRemove: EventListenerOrEventListenerObject = this.getEventListenerForOverlayId(overlayHtmlId);
+
+    document.getElementById(overlayHtmlId).removeEventListener('click', functionToRemove);
+
+    this.overlaysWithEventListeners.splice(this.overlaysWithEventListeners.indexOf(overlayHtmlId), 1);
+  }
+
+  private getEventListenerForOverlayId(overlayHtmlId: string): EventListenerOrEventListenerObject {
+    if (overlayHtmlId.endsWith('manual-user-task')) {
+      return this.handleTaskClick;
+    }
+    if (overlayHtmlId.endsWith('empty-activity')) {
+      return this.handleEmptyActivityClick;
+    }
+    if (overlayHtmlId.endsWith('active-call-activity')) {
+      return this.handleActiveCallActivityClick;
+    }
+    if (overlayHtmlId.endsWith('error-element')) {
+      return this.handleErrorElementClick;
+    }
+    if (overlayHtmlId.endsWith('inactive-call-activity')) {
+      return this.handleInactiveCallActivityClick;
+    }
+
+    return undefined;
   }
 
   private addOverlaysToElementsWithError(elementsWithError: Array<IShape>): Array<string> {
@@ -409,24 +455,68 @@ export class LiveExecutionTracker {
     const errorElementIds: Array<string> = elementsWithError.map((element: IShape) => element.id).sort();
 
     for (const element of elementsWithError) {
+      const overlayHtmlId: string = `${element.id}#error-element`;
+
       this.overlays.add(element, {
         position: {
           left: 30,
           top: 25,
         },
-        html: `<div class="let__overlay-button" id="${element.id}"><i class="fas fa-bug let__overlay-button-icon overlay__error-element"></i></div>`,
+        html: `<div class="let__overlay-button" id="${overlayHtmlId}"><i class="fas fa-bug let__overlay-button-icon overlay__error-element"></i></div>`,
       });
 
-      document.getElementById(element.id).addEventListener('click', this.handleErrorElementClick);
-
-      this.elementsWithEventListeners.push(element.id);
+      this.addEventListenerToOverlay(overlayHtmlId);
     }
 
     return errorElementIds;
   }
 
+  private rearrangeOverlaysForElementWithMultipleOverlays(elementsWithOverlays: Array<string>): void {
+    const elementsWithMultipleOverlays: Array<string> = elementsWithOverlays.filter(
+      (element, index, elementArray: Array<string>) => {
+        return elementArray.indexOf(element) === index && elementArray.lastIndexOf(element) !== index;
+      },
+    );
+
+    for (const element of elementsWithMultipleOverlays) {
+      const elementOverlays: Array<IOverlay> = this.elementOverlays(element);
+
+      elementOverlays.forEach((overlay: IOverlay, index: number) => {
+        const overlayHtmlId: string = /id="(.*?)"/g.exec(overlay.html)[1];
+
+        this.removeEventListenerFromOverlay(overlayHtmlId);
+        this.overlays.remove(overlay.id);
+
+        overlay.position.left = 10 + 40 * index;
+
+        this.overlays.add(element, overlay);
+        this.addEventListenerToOverlay(overlayHtmlId);
+      });
+    }
+  }
+
+  private elementOverlays(elementId: string): Array<IOverlay> {
+    const overlaysForElement: Array<IOverlay> = [];
+
+    // eslint-disable-next-line no-underscore-dangle
+    const overlays: IOverlays = this.overlays._overlays;
+    const overlayIds: Array<string> = Object.keys(overlays);
+    for (const overlayId of overlayIds) {
+      const currentOverlay: IOverlay = overlays[overlayId];
+
+      const isOverlayOfElement: boolean = currentOverlay.element.id === elementId;
+
+      if (isOverlayOfElement) {
+        overlaysForElement.push(currentOverlay);
+      }
+    }
+
+    return overlaysForElement;
+  }
+
   private handleErrorElementClick: (event: MouseEvent) => void = (event: MouseEvent): void => {
-    const elementId: string = (event.target as HTMLDivElement).id;
+    const overlayHtmlId: string = (event.target as HTMLDivElement).id;
+    const elementId: string = this.getElementIdByOverlayHtmlId(overlayHtmlId);
 
     this.router.navigateToRoute('inspect', {
       view: 'inspect-correlation',
@@ -452,17 +542,17 @@ export class LiveExecutionTracker {
     const activeEmptyActivitiesIds: Array<string> = activeEmptyActivities.map((element: IShape) => element.id).sort();
 
     for (const element of activeEmptyActivities) {
+      const overlayHtmlId: string = `${element.id}#empty-activity`;
+
       this.overlays.add(element, {
         position: {
           left: 30,
           top: 25,
         },
-        html: `<div class="let__overlay-button" id="${element.id}"><i class="fas fa-play let__overlay-button-icon overlay__empty-task"></i></div>`,
+        html: `<div class="let__overlay-button" id="${overlayHtmlId}"><i class="fas fa-play let__overlay-button-icon overlay__empty-task"></i></div>`,
       });
 
-      document.getElementById(element.id).addEventListener('click', this.handleEmptyActivityClick);
-
-      this.elementsWithEventListeners.push(element.id);
+      this.addEventListenerToOverlay(overlayHtmlId);
     }
 
     return activeEmptyActivitiesIds;
@@ -486,59 +576,45 @@ export class LiveExecutionTracker {
       .sort();
 
     for (const element of activeManualAndUserTasks) {
+      const overlayHtmlId: string = `${element.id}#manual-user-task`;
+
       this.overlays.add(element, {
         position: {
           left: 30,
           top: 25,
         },
-        html: `<div class="let__overlay-button" id="${element.id}"><i class="fas fa-play let__overlay-button-icon"></i></div>`,
+        html: `<div class="let__overlay-button" id="${overlayHtmlId}"><i class="fas fa-play let__overlay-button-icon"></i></div>`,
       });
 
-      document.getElementById(element.id).addEventListener('click', this.handleTaskClick);
-
-      this.elementsWithEventListeners.push(element.id);
+      this.addEventListenerToOverlay(overlayHtmlId);
     }
 
     return activeManualAndUserTaskIds;
   }
 
-  private addOverlaysToInactiveCallActivities(callActivities: Array<IShape>): void {
+  private addOverlaysToInactiveCallActivities(inactiveCallActivities: Array<IShape>): Array<string> {
     const liveExecutionTrackerIsNotAttached: boolean = !this.isAttached;
     if (liveExecutionTrackerIsNotAttached) {
-      return;
+      return [];
     }
 
-    const callActivityIds: Array<string> = callActivities.map((element: IShape) => element.id).sort();
+    const callActivityIds: Array<string> = inactiveCallActivities.map((element: IShape) => element.id).sort();
 
-    // eslint-disable-next-line no-underscore-dangle
-    const overlayIds: Array<string> = Object.keys(this.overlays._overlays);
-    const allCallActivitiesHaveAnOverlay: boolean = callActivityIds.every((callActivityId: string): boolean => {
-      const overlayFound: boolean =
-        overlayIds.find((overlayId: string): boolean => {
-          // eslint-disable-next-line no-underscore-dangle
-          return this.overlays._overlays[overlayId].element.id === callActivityId;
-        }) !== undefined;
+    for (const element of inactiveCallActivities) {
+      const overlayHtmlId: string = `${element.id}#inactive-call-activity`;
 
-      return overlayFound;
-    });
-
-    if (allCallActivitiesHaveAnOverlay) {
-      return;
-    }
-
-    for (const element of callActivities) {
       this.overlays.add(element, {
         position: {
           left: 30,
           top: 25,
         },
-        html: `<div class="let__overlay-button" id="${element.id}"><i class="fas fa-search let__overlay-button-icon"></i></div>`,
+        html: `<div class="let__overlay-button" id="${overlayHtmlId}"><i class="fas fa-search let__overlay-button-icon"></i></div>`,
       });
 
-      document.getElementById(element.id).addEventListener('click', this.handleInactiveCallActivityClick);
-
-      this.elementsWithEventListeners.push(element.id);
+      this.addEventListenerToOverlay(overlayHtmlId);
     }
+
+    return callActivityIds;
   }
 
   private addOverlaysToActiveCallActivities(activeElements: Array<IShape>): Array<string> {
@@ -558,30 +634,34 @@ export class LiveExecutionTracker {
     this.activeCallActivities = activeCallActivities;
 
     for (const element of activeCallActivities) {
+      const overlayHtmlId: string = `${element.id}#active-call-activity`;
+
       this.overlays.add(element, {
         position: {
           left: 30,
           top: 25,
         },
-        html: `<div class="let__overlay-button" id="${element.id}"><i class="fas fa-external-link-square-alt let__overlay-button-icon"></i></div>`,
+        html: `<div class="let__overlay-button" id="${overlayHtmlId}"><i class="fas fa-external-link-square-alt let__overlay-button-icon"></i></div>`,
       });
 
-      document.getElementById(element.id).addEventListener('click', this.handleActiveCallActivityClick);
-
-      this.elementsWithEventListeners.push(element.id);
+      this.addEventListenerToOverlay(overlayHtmlId);
     }
 
     return activeCallActivityIds;
   }
 
   private handleTaskClick: (event: MouseEvent) => void = (event: MouseEvent): void => {
-    const elementId: string = (event.target as HTMLDivElement).id;
+    const overlayHtmlId: string = (event.target as HTMLDivElement).id;
+    const elementId: string = this.getElementIdByOverlayHtmlId(overlayHtmlId);
+
     this.taskId = elementId;
     this.showDynamicUiModal = true;
   };
 
   private handleEmptyActivityClick: (event: MouseEvent) => void = async (event: MouseEvent): Promise<void> => {
-    const elementId: string = (event.target as HTMLDivElement).id;
+    const overlayHtmlId: string = (event.target as HTMLDivElement).id;
+    const elementId: string = this.getElementIdByOverlayHtmlId(overlayHtmlId);
+
     this.taskId = elementId;
 
     const emptyActivitiesInProcessInstance: DataModels.EmptyActivities.EmptyActivityList = await this.liveExecutionTrackerService.getEmptyActivitiesForProcessInstance(
@@ -606,8 +686,10 @@ export class LiveExecutionTracker {
   private handleActiveCallActivityClick: (event: MouseEvent) => Promise<void> = async (
     event: MouseEvent,
   ): Promise<void> => {
-    const elementId: string = (event.target as HTMLDivElement).id;
+    const overlayHtmlId: string = (event.target as HTMLDivElement).id;
+    const elementId: string = this.getElementIdByOverlayHtmlId(overlayHtmlId);
     const element: IShape = this.liveExecutionTrackerService.getElementById(elementId);
+
     const callActivityTargetProcess: string = element.businessObject.calledElement;
 
     const callAcitivityHasNoTargetProcess: boolean = callActivityTargetProcess === undefined;
@@ -627,8 +709,7 @@ export class LiveExecutionTracker {
 
     const errorGettingTargetProcessInstanceId: boolean = targetProcessInstanceId === undefined;
     if (errorGettingTargetProcessInstanceId) {
-      const errorMessage: string =
-        'Could not get processInstanceId of the target process. Please try to click on the call activity again.';
+      const errorMessage: string = 'Target process of call activity not found.';
 
       this.notificationService.showNotification(NotificationType.ERROR, errorMessage);
       return;
@@ -645,7 +726,8 @@ export class LiveExecutionTracker {
   private handleInactiveCallActivityClick: (event: MouseEvent) => Promise<void> = async (
     event: MouseEvent,
   ): Promise<void> => {
-    const elementId: string = (event.target as HTMLDivElement).id;
+    const overlayHtmlId: string = (event.target as HTMLDivElement).id;
+    const elementId: string = this.getElementIdByOverlayHtmlId(overlayHtmlId);
     const element: IShape = this.liveExecutionTrackerService.getElementById(elementId);
     const callActivityTargetProcess: string = element.businessObject.calledElement;
 
@@ -745,6 +827,10 @@ export class LiveExecutionTracker {
     });
 
     return xmlImportPromise;
+  }
+
+  private getElementIdByOverlayHtmlId(overlayHtmlId: string): string {
+    return overlayHtmlId.substring(0, overlayHtmlId.lastIndexOf('#'));
   }
 
   private async importXmlIntoDiagramPreviewViewer(xml: string): Promise<void> {

--- a/src/modules/live-execution-tracker/live-execution-tracker.ts
+++ b/src/modules/live-execution-tracker/live-execution-tracker.ts
@@ -362,8 +362,6 @@ export class LiveExecutionTracker {
   }
 
   private async addOverlays(): Promise<void> {
-    this.overlays.clear();
-
     const elementsWithActiveToken: Array<IShape> = await this.liveExecutionTrackerService.getElementsWithActiveToken(
       this.processInstanceId,
     );
@@ -371,10 +369,24 @@ export class LiveExecutionTracker {
       this.processInstanceId,
     );
 
+    this.overlays.clear();
+    this.removeEventListenerFromOverlays();
+
     this.addOverlaysToUserAndManualTasks(elementsWithActiveToken);
     this.addOverlaysToEmptyActivities(elementsWithActiveToken);
     this.addOverlaysToActiveCallActivities(elementsWithActiveToken);
     this.addOverlaysToInactiveCallActivities(inactiveCallActivities);
+  }
+
+  private removeEventListenerFromOverlays(): void {
+    for (const elementId of this.elementsWithEventListeners) {
+      document.getElementById(elementId).removeEventListener('click', this.handleTaskClick);
+      document.getElementById(elementId).removeEventListener('click', this.handleEmptyActivityClick);
+      document.getElementById(elementId).removeEventListener('click', this.handleActiveCallActivityClick);
+      document.getElementById(elementId).removeEventListener('click', this.handleInactiveCallActivityClick);
+    }
+
+    this.elementsWithEventListeners = [];
   }
 
   private addOverlaysToEmptyActivities(elements: Array<IShape>): Array<string> {
@@ -390,16 +402,6 @@ export class LiveExecutionTracker {
     });
 
     const activeEmptyActivitiesIds: Array<string> = activeEmptyActivities.map((element: IShape) => element.id).sort();
-
-    for (const elementId of this.elementsWithEventListeners) {
-      document.getElementById(elementId).removeEventListener('click', this.handleEmptyActivityClick);
-    }
-
-    for (const callActivity of this.activeCallActivities) {
-      document.getElementById(callActivity.id).removeEventListener('click', this.handleActiveCallActivityClick);
-    }
-
-    this.elementsWithEventListeners = [];
 
     for (const element of activeEmptyActivities) {
       this.overlays.add(element, {
@@ -434,16 +436,6 @@ export class LiveExecutionTracker {
     const activeManualAndUserTaskIds: Array<string> = activeManualAndUserTasks
       .map((element: IShape) => element.id)
       .sort();
-
-    for (const elementId of this.elementsWithEventListeners) {
-      document.getElementById(elementId).removeEventListener('click', this.handleTaskClick);
-    }
-
-    for (const callActivity of this.activeCallActivities) {
-      document.getElementById(callActivity.id).removeEventListener('click', this.handleActiveCallActivityClick);
-    }
-
-    this.elementsWithEventListeners = [];
 
     for (const element of activeManualAndUserTasks) {
       this.overlays.add(element, {

--- a/src/modules/live-execution-tracker/live-execution-tracker.ts
+++ b/src/modules/live-execution-tracker/live-execution-tracker.ts
@@ -463,7 +463,7 @@ export class LiveExecutionTracker {
           left: 30,
           top: 25,
         },
-        html: `<div class="let__overlay-button" id="${overlayHtmlId}"><i class="fas fa-bug let__overlay-button-icon overlay__error-element"></i></div>`,
+        html: `<div class="let__overlay-button" id="${overlayHtmlId}" title="Open process instance in Inspect Correlation."><i class="fas fa-bug let__overlay-button-icon overlay__error-element"></i></div>`,
       });
 
       this.addEventListenerToOverlay(overlayHtmlId);
@@ -551,7 +551,7 @@ export class LiveExecutionTracker {
           left: 30,
           top: 25,
         },
-        html: `<div class="let__overlay-button" id="${overlayHtmlId}"><i class="fas fa-play let__overlay-button-icon overlay__empty-task"></i></div>`,
+        html: `<div class="let__overlay-button" id="${overlayHtmlId}" title="Continue empty activity."><i class="fas fa-play let__overlay-button-icon overlay__empty-task"></i></div>`,
       });
 
       this.addEventListenerToOverlay(overlayHtmlId);
@@ -585,7 +585,7 @@ export class LiveExecutionTracker {
           left: 30,
           top: 25,
         },
-        html: `<div class="let__overlay-button" id="${overlayHtmlId}"><i class="fas fa-play let__overlay-button-icon"></i></div>`,
+        html: `<div class="let__overlay-button" id="${overlayHtmlId}" title="Continue task."><i class="fas fa-play let__overlay-button-icon"></i></div>`,
       });
 
       this.addEventListenerToOverlay(overlayHtmlId);
@@ -610,7 +610,7 @@ export class LiveExecutionTracker {
           left: 30,
           top: 25,
         },
-        html: `<div class="let__overlay-button" id="${overlayHtmlId}"><i class="fas fa-search let__overlay-button-icon"></i></div>`,
+        html: `<div class="let__overlay-button" id="${overlayHtmlId}" title="Show target process."><i class="fas fa-search let__overlay-button-icon"></i></div>`,
       });
 
       this.addEventListenerToOverlay(overlayHtmlId);
@@ -643,7 +643,7 @@ export class LiveExecutionTracker {
           left: 30,
           top: 25,
         },
-        html: `<div class="let__overlay-button" id="${overlayHtmlId}"><i class="fas fa-external-link-square-alt let__overlay-button-icon"></i></div>`,
+        html: `<div class="let__overlay-button" id="${overlayHtmlId}" title="Show target process."><i class="fas fa-external-link-square-alt let__overlay-button-icon"></i></div>`,
       });
 
       this.addEventListenerToOverlay(overlayHtmlId);

--- a/src/modules/live-execution-tracker/live-execution-tracker.ts
+++ b/src/modules/live-execution-tracker/live-execution-tracker.ts
@@ -381,8 +381,8 @@ export class LiveExecutionTracker {
       this.processInstanceId,
     );
 
-    this.overlays.clear();
     this.removeEventListenerFromOverlays();
+    this.overlays.clear();
 
     const userAndManualTaskOverlays: Array<string> = this.addOverlaysToUserAndManualTasks(elementsWithActiveToken);
     const emptyActivityOverlays: Array<string> = this.addOverlaysToEmptyActivities(elementsWithActiveToken);
@@ -422,7 +422,16 @@ export class LiveExecutionTracker {
   private removeEventListenerFromOverlay(overlayHtmlId: string): void {
     const functionToRemove: EventListenerOrEventListenerObject = this.getEventListenerForOverlayId(overlayHtmlId);
 
-    document.getElementById(overlayHtmlId).removeEventListener('click', functionToRemove);
+    const elementWithEventListener: HTMLElement = document.getElementById(overlayHtmlId);
+
+    const elementIsAlreadyRemoved: boolean = elementWithEventListener === null;
+    if (elementIsAlreadyRemoved) {
+      this.overlaysWithEventListeners.splice(this.overlaysWithEventListeners.indexOf(overlayHtmlId), 1);
+
+      return;
+    }
+
+    elementWithEventListener.removeEventListener('click', functionToRemove);
 
     this.overlaysWithEventListeners.splice(this.overlaysWithEventListeners.indexOf(overlayHtmlId), 1);
   }

--- a/src/modules/live-execution-tracker/live-execution-tracker.ts
+++ b/src/modules/live-execution-tracker/live-execution-tracker.ts
@@ -362,6 +362,9 @@ export class LiveExecutionTracker {
   }
 
   private async addOverlays(): Promise<void> {
+    const elementsWithError: Array<IShape> = await this.liveExecutionTrackerService.getElementsWithError(
+      this.processInstanceId,
+    );
     const elementsWithActiveToken: Array<IShape> = await this.liveExecutionTrackerService.getElementsWithActiveToken(
       this.processInstanceId,
     );
@@ -376,6 +379,7 @@ export class LiveExecutionTracker {
     this.addOverlaysToEmptyActivities(elementsWithActiveToken);
     this.addOverlaysToActiveCallActivities(elementsWithActiveToken);
     this.addOverlaysToInactiveCallActivities(inactiveCallActivities);
+    this.addOverlaysToElementsWithError(elementsWithError);
   }
 
   private removeEventListenerFromOverlays(): void {
@@ -383,11 +387,49 @@ export class LiveExecutionTracker {
       document.getElementById(elementId).removeEventListener('click', this.handleTaskClick);
       document.getElementById(elementId).removeEventListener('click', this.handleEmptyActivityClick);
       document.getElementById(elementId).removeEventListener('click', this.handleActiveCallActivityClick);
+      document.getElementById(elementId).removeEventListener('click', this.handleErrorElementClick);
       document.getElementById(elementId).removeEventListener('click', this.handleInactiveCallActivityClick);
     }
 
     this.elementsWithEventListeners = [];
   }
+
+  private addOverlaysToElementsWithError(elementsWithError: Array<IShape>): Array<string> {
+    const liveExecutionTrackerIsNotAttached: boolean = !this.isAttached;
+    if (liveExecutionTrackerIsNotAttached) {
+      return [];
+    }
+
+    const errorElementIds: Array<string> = elementsWithError.map((element: IShape) => element.id).sort();
+
+    for (const element of elementsWithError) {
+      this.overlays.add(element, {
+        position: {
+          left: 30,
+          top: 25,
+        },
+        html: `<div class="let__overlay-button" id="${element.id}"><i class="fas fa-bug let__overlay-button-icon overlay__error-element"></i></div>`,
+      });
+
+      document.getElementById(element.id).addEventListener('click', this.handleErrorElementClick);
+
+      this.elementsWithEventListeners.push(element.id);
+    }
+
+    return errorElementIds;
+  }
+
+  private handleErrorElementClick: (event: MouseEvent) => void = (event: MouseEvent): void => {
+    const elementId: string = (event.target as HTMLDivElement).id;
+
+    this.router.navigateToRoute('inspect', {
+      view: 'inspect-correlation',
+      diagramName: this.activeDiagram.name,
+      solutionUri: this.activeSolutionEntry.uri,
+      processInstanceToSelect: this.processInstanceId,
+      flowNodeToSelect: elementId,
+    });
+  };
 
   private addOverlaysToEmptyActivities(elements: Array<IShape>): Array<string> {
     const liveExecutionTrackerIsNotAttached: boolean = !this.isAttached;

--- a/src/modules/live-execution-tracker/services/live-execution-tracker.service.ts
+++ b/src/modules/live-execution-tracker/services/live-execution-tracker.service.ts
@@ -484,7 +484,7 @@ export class LiveExecutionTrackerService implements ILiveExecutionTrackerService
     return this.liveExecutionTrackerRepository.terminateProcess(processInstanceId);
   }
 
-  private async getElementsWithError(processInstanceId: string): Promise<Array<IShape>> {
+  public async getElementsWithError(processInstanceId: string): Promise<Array<IShape>> {
     const flowNodeInstances: Array<
       DataModels.FlowNodeInstances.FlowNodeInstance
     > = await this.liveExecutionTrackerRepository.getFlowNodeInstancesForProcessInstance(processInstanceId);

--- a/src/modules/live-execution-tracker/services/live-execution-tracker.service.ts
+++ b/src/modules/live-execution-tracker/services/live-execution-tracker.service.ts
@@ -33,134 +33,232 @@ export class LiveExecutionTrackerService implements ILiveExecutionTrackerService
     this.elementRegistry = this.diagramModeler.get('elementRegistry');
   }
 
-  public setIdentity(identity: IIdentity): void {
-    this.liveExecutionTrackerRepository.setIdentity(identity);
+  public isProcessInstanceActive(identity: IIdentity, processInstanceId: string): Promise<boolean> {
+    return this.liveExecutionTrackerRepository.isProcessInstanceActive(identity, processInstanceId);
   }
 
-  public isProcessInstanceActive(processInstanceId: string): Promise<boolean> {
-    return this.liveExecutionTrackerRepository.isProcessInstanceActive(processInstanceId);
-  }
-
-  public getCorrelationById(correlationId: string): Promise<DataModels.Correlations.Correlation> {
-    return this.liveExecutionTrackerRepository.getCorrelationById(correlationId);
+  public getCorrelationById(identity: IIdentity, correlationId: string): Promise<DataModels.Correlations.Correlation> {
+    return this.liveExecutionTrackerRepository.getCorrelationById(identity, correlationId);
   }
 
   public getTokenHistoryGroupForProcessInstance(
+    identity: IIdentity,
     processInstanceId: string,
   ): Promise<DataModels.TokenHistory.TokenHistoryGroup | null> {
-    return this.liveExecutionTrackerRepository.getTokenHistoryGroupForProcessInstance(processInstanceId);
+    return this.liveExecutionTrackerRepository.getTokenHistoryGroupForProcessInstance(identity, processInstanceId);
   }
 
-  public getActiveTokensForProcessInstance(processInstanceId: string): Promise<Array<DataModels.Kpi.ActiveToken>> {
-    return this.liveExecutionTrackerRepository.getActiveTokensForProcessInstance(processInstanceId);
+  public getActiveTokensForProcessInstance(
+    identity: IIdentity,
+    processInstanceId: string,
+  ): Promise<Array<DataModels.Kpi.ActiveToken>> {
+    return this.liveExecutionTrackerRepository.getActiveTokensForProcessInstance(identity, processInstanceId);
   }
 
   public getEmptyActivitiesForProcessInstance(
+    identity: IIdentity,
     processInstanceId: string,
   ): Promise<DataModels.EmptyActivities.EmptyActivityList | null> {
-    return this.liveExecutionTrackerRepository.getEmptyActivitiesForProcessInstance(processInstanceId);
+    return this.liveExecutionTrackerRepository.getEmptyActivitiesForProcessInstance(identity, processInstanceId);
   }
 
-  public getProcessModelById(processModelId: string): Promise<DataModels.ProcessModels.ProcessModel> {
-    return this.liveExecutionTrackerRepository.getProcessModelById(processModelId);
+  public getProcessModelById(
+    identity: IIdentity,
+    processModelId: string,
+  ): Promise<DataModels.ProcessModels.ProcessModel> {
+    return this.liveExecutionTrackerRepository.getProcessModelById(identity, processModelId);
   }
 
   public finishEmptyActivity(
+    identity: IIdentity,
     processInstanceId: string,
     correlationId: string,
     emptyActivity: DataModels.EmptyActivities.EmptyActivity,
   ): Promise<void> {
-    return this.liveExecutionTrackerRepository.finishEmptyActivity(processInstanceId, correlationId, emptyActivity);
+    return this.liveExecutionTrackerRepository.finishEmptyActivity(
+      identity,
+      processInstanceId,
+      correlationId,
+      emptyActivity,
+    );
   }
 
-  public createProcessEndedEventListener(processInstanceId: string, callback: Function): Promise<Subscription> {
-    return this.liveExecutionTrackerRepository.createProcessEndedEventListener(processInstanceId, callback);
+  public createProcessEndedEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription> {
+    return this.liveExecutionTrackerRepository.createProcessEndedEventListener(identity, processInstanceId, callback);
   }
 
-  public createProcessTerminatedEventListener(processInstanceId: string, callback: Function): Promise<Subscription> {
-    return this.liveExecutionTrackerRepository.createProcessTerminatedEventListener(processInstanceId, callback);
+  public createProcessTerminatedEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription> {
+    return this.liveExecutionTrackerRepository.createProcessTerminatedEventListener(
+      identity,
+      processInstanceId,
+      callback,
+    );
   }
 
-  public createUserTaskWaitingEventListener(processInstanceId: string, callback: Function): Promise<Subscription> {
-    return this.liveExecutionTrackerRepository.createUserTaskWaitingEventListener(processInstanceId, callback);
+  public createUserTaskWaitingEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription> {
+    return this.liveExecutionTrackerRepository.createUserTaskWaitingEventListener(
+      identity,
+      processInstanceId,
+      callback,
+    );
   }
 
-  public createUserTaskFinishedEventListener(processInstanceId: string, callback: Function): Promise<Subscription> {
-    return this.liveExecutionTrackerRepository.createUserTaskFinishedEventListener(processInstanceId, callback);
+  public createUserTaskFinishedEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription> {
+    return this.liveExecutionTrackerRepository.createUserTaskFinishedEventListener(
+      identity,
+      processInstanceId,
+      callback,
+    );
   }
 
-  public createManualTaskWaitingEventListener(processInstanceId: string, callback: Function): Promise<Subscription> {
-    return this.liveExecutionTrackerRepository.createManualTaskWaitingEventListener(processInstanceId, callback);
+  public createManualTaskWaitingEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription> {
+    return this.liveExecutionTrackerRepository.createManualTaskWaitingEventListener(
+      identity,
+      processInstanceId,
+      callback,
+    );
   }
 
-  public createManualTaskFinishedEventListener(processInstanceId: string, callback: Function): Promise<Subscription> {
-    return this.liveExecutionTrackerRepository.createManualTaskFinishedEventListener(processInstanceId, callback);
+  public createManualTaskFinishedEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription> {
+    return this.liveExecutionTrackerRepository.createManualTaskFinishedEventListener(
+      identity,
+      processInstanceId,
+      callback,
+    );
   }
 
-  public createEmptyActivityWaitingEventListener(processInstanceId: string, callback: Function): Promise<Subscription> {
-    return this.liveExecutionTrackerRepository.createEmptyActivityWaitingEventListener(processInstanceId, callback);
+  public createEmptyActivityWaitingEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription> {
+    return this.liveExecutionTrackerRepository.createEmptyActivityWaitingEventListener(
+      identity,
+      processInstanceId,
+      callback,
+    );
   }
 
   public createEmptyActivityFinishedEventListener(
+    identity: IIdentity,
     processInstanceId: string,
     callback: Function,
   ): Promise<Subscription> {
-    return this.liveExecutionTrackerRepository.createEmptyActivityFinishedEventListener(processInstanceId, callback);
+    return this.liveExecutionTrackerRepository.createEmptyActivityFinishedEventListener(
+      identity,
+      processInstanceId,
+      callback,
+    );
   }
 
-  public createActivityReachedEventListener(processInstanceId: string, callback: Function): Promise<Subscription> {
-    return this.liveExecutionTrackerRepository.createActivityReachedEventListener(processInstanceId, callback);
+  public createActivityReachedEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription> {
+    return this.liveExecutionTrackerRepository.createActivityReachedEventListener(
+      identity,
+      processInstanceId,
+      callback,
+    );
   }
 
-  public createActivityFinishedEventListener(processInstanceId: string, callback: Function): Promise<Subscription> {
-    return this.liveExecutionTrackerRepository.createActivityFinishedEventListener(processInstanceId, callback);
+  public createActivityFinishedEventListener(
+    identity: IIdentity,
+    processInstanceId: string,
+    callback: Function,
+  ): Promise<Subscription> {
+    return this.liveExecutionTrackerRepository.createActivityFinishedEventListener(
+      identity,
+      processInstanceId,
+      callback,
+    );
   }
 
   public createBoundaryEventTriggeredEventListener(
+    identity: IIdentity,
     processInstanceId: string,
     callback: Function,
   ): Promise<Subscription> {
-    return this.liveExecutionTrackerRepository.createBoundaryEventTriggeredEventListener(processInstanceId, callback);
+    return this.liveExecutionTrackerRepository.createBoundaryEventTriggeredEventListener(
+      identity,
+      processInstanceId,
+      callback,
+    );
   }
 
   public createIntermediateThrowEventTriggeredEventListener(
+    identity: IIdentity,
     processInstanceId: string,
     callback: Function,
   ): Promise<Subscription> {
     return this.liveExecutionTrackerRepository.createIntermediateThrowEventTriggeredEventListener(
+      identity,
       processInstanceId,
       callback,
     );
   }
 
   public createIntermediateCatchEventReachedEventListener(
+    identity: IIdentity,
     processInstanceId: string,
     callback: Function,
   ): Promise<Subscription> {
     return this.liveExecutionTrackerRepository.createIntermediateCatchEventReachedEventListener(
+      identity,
       processInstanceId,
       callback,
     );
   }
 
   public createIntermediateCatchEventFinishedEventListener(
+    identity: IIdentity,
     processInstanceId: string,
     callback: Function,
   ): Promise<Subscription> {
     return this.liveExecutionTrackerRepository.createIntermediateCatchEventFinishedEventListener(
+      identity,
       processInstanceId,
       callback,
     );
   }
 
-  public removeSubscription(subscription: Subscription): Promise<void> {
-    return this.liveExecutionTrackerRepository.removeSubscription(subscription);
+  public removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void> {
+    return this.liveExecutionTrackerRepository.removeSubscription(identity, subscription);
   }
 
-  public async getElementsWithActiveToken(processInstanceId: string): Promise<Array<IShape> | null> {
+  public async getElementsWithActiveToken(
+    identity: IIdentity,
+    processInstanceId: string,
+  ): Promise<Array<IShape> | null> {
     const elements: Array<IShape> = this.getAllElementsThatCanHaveAToken();
 
     const activeTokens: Array<DataModels.Kpi.ActiveToken> | null = await this.getActiveTokensForProcessInstance(
+      identity,
       processInstanceId,
     );
     const couldNotGetActiveTokens: boolean = activeTokens === null;
@@ -181,10 +279,11 @@ export class LiveExecutionTrackerService implements ILiveExecutionTrackerService
     return elementsWithActiveToken;
   }
 
-  public async getElementsWithTokenHistory(processInstanceId: string): Promise<Array<IShape>> {
+  public async getElementsWithTokenHistory(identity: IIdentity, processInstanceId: string): Promise<Array<IShape>> {
     const elements: Array<IShape> = this.getAllElementsThatCanHaveAToken();
 
     const tokenHistoryGroups: DataModels.TokenHistory.TokenHistoryGroup = await this.getTokenHistoryGroupForProcessInstance(
+      identity,
       processInstanceId,
     );
 
@@ -325,10 +424,10 @@ export class LiveExecutionTrackerService implements ILiveExecutionTrackerService
     return callActivities;
   }
 
-  public async getActiveCallActivities(processInstanceId: string): Promise<Array<IShape>> {
+  public async getActiveCallActivities(identity: IIdentity, processInstanceId: string): Promise<Array<IShape>> {
     const activeTokens: Array<
       DataModels.Kpi.ActiveToken
-    > = await this.liveExecutionTrackerRepository.getActiveTokensForProcessInstance(processInstanceId);
+    > = await this.liveExecutionTrackerRepository.getActiveTokensForProcessInstance(identity, processInstanceId);
 
     const callActivities: Array<IShape> = this.getCallActivities();
 
@@ -339,10 +438,10 @@ export class LiveExecutionTrackerService implements ILiveExecutionTrackerService
     return inactiveCallActivities;
   }
 
-  public async getInactiveCallActivities(processInstanceId: string): Promise<Array<IShape>> {
+  public async getInactiveCallActivities(identity: IIdentity, processInstanceId: string): Promise<Array<IShape>> {
     const activeTokens: Array<
       DataModels.Kpi.ActiveToken
-    > = await this.liveExecutionTrackerRepository.getActiveTokensForProcessInstance(processInstanceId);
+    > = await this.liveExecutionTrackerRepository.getActiveTokensForProcessInstance(identity, processInstanceId);
 
     const callActivities: Array<IShape> = this.getCallActivities();
 
@@ -354,10 +453,11 @@ export class LiveExecutionTrackerService implements ILiveExecutionTrackerService
   }
 
   public async getProcessModelByProcessInstanceId(
+    identity: IIdentity,
     correlationId: string,
     processInstanceId: string,
   ): Promise<DataModels.Correlations.CorrelationProcessInstance> {
-    const correlation: DataModels.Correlations.Correlation = await this.getCorrelationById(correlationId);
+    const correlation: DataModels.Correlations.Correlation = await this.getCorrelationById(identity, correlationId);
 
     const errorGettingCorrelation: boolean = correlation === undefined;
     if (errorGettingCorrelation) {
@@ -380,11 +480,12 @@ export class LiveExecutionTrackerService implements ILiveExecutionTrackerService
   }
 
   public async getProcessInstanceIdOfCallActivityTarget(
+    identity: IIdentity,
     correlationId: string,
     processInstanceIdOfOrigin: string,
     callActivityTargetId: string,
   ): Promise<string> {
-    const correlation: DataModels.Correlations.Correlation = await this.getCorrelationById(correlationId);
+    const correlation: DataModels.Correlations.Correlation = await this.getCorrelationById(identity, correlationId);
 
     const errorGettingCorrelation: boolean = correlation === undefined;
     if (errorGettingCorrelation) {
@@ -461,17 +562,18 @@ export class LiveExecutionTrackerService implements ILiveExecutionTrackerService
   }
 
   public async getColorizedDiagram(
+    identity: IIdentity,
     processInstanceId: string,
     processEngineSupportsGettingFlowNodeInstances?: boolean,
   ): Promise<string> {
-    const elementsWithActiveToken: Array<IShape> = await this.getElementsWithActiveToken(processInstanceId);
-    const elementsWithTokenHistory: Array<IShape> = await this.getElementsWithTokenHistory(processInstanceId);
+    const elementsWithActiveToken: Array<IShape> = await this.getElementsWithActiveToken(identity, processInstanceId);
+    const elementsWithTokenHistory: Array<IShape> = await this.getElementsWithTokenHistory(identity, processInstanceId);
 
     this.colorizeElements(elementsWithTokenHistory, defaultBpmnColors.green);
     this.colorizeElements(elementsWithActiveToken, defaultBpmnColors.orange);
 
     if (processEngineSupportsGettingFlowNodeInstances) {
-      const elementsWithError: Array<IShape> = await this.getElementsWithError(processInstanceId);
+      const elementsWithError: Array<IShape> = await this.getElementsWithError(identity, processInstanceId);
       this.colorizeElements(elementsWithError, defaultBpmnColors.red);
     }
 
@@ -480,14 +582,14 @@ export class LiveExecutionTrackerService implements ILiveExecutionTrackerService
     return colorizedXml;
   }
 
-  public terminateProcess(processInstanceId: string): Promise<void> {
-    return this.liveExecutionTrackerRepository.terminateProcess(processInstanceId);
+  public terminateProcess(identity: IIdentity, processInstanceId: string): Promise<void> {
+    return this.liveExecutionTrackerRepository.terminateProcess(identity, processInstanceId);
   }
 
-  public async getElementsWithError(processInstanceId: string): Promise<Array<IShape>> {
+  public async getElementsWithError(identity: IIdentity, processInstanceId: string): Promise<Array<IShape>> {
     const flowNodeInstances: Array<
       DataModels.FlowNodeInstances.FlowNodeInstance
-    > = await this.liveExecutionTrackerRepository.getFlowNodeInstancesForProcessInstance(processInstanceId);
+    > = await this.liveExecutionTrackerRepository.getFlowNodeInstancesForProcessInstance(identity, processInstanceId);
 
     return flowNodeInstances
       .filter((flowNodeInstance: DataModels.FlowNodeInstances.FlowNodeInstance) => {

--- a/src/modules/live-execution-tracker/services/live-execution-tracker.service.ts
+++ b/src/modules/live-execution-tracker/services/live-execution-tracker.service.ts
@@ -492,7 +492,7 @@ export class LiveExecutionTrackerService implements ILiveExecutionTrackerService
       return undefined;
     }
 
-    const {processInstanceId} = correlation.processInstances.find(
+    const processInstance: DataModels.Correlations.CorrelationProcessInstance = correlation.processInstances.find(
       (correlationProcessInstance: DataModels.Correlations.CorrelationProcessInstance): boolean => {
         const targetProcessModelFound: boolean =
           correlationProcessInstance.parentProcessInstanceId === processInstanceIdOfOrigin &&
@@ -502,7 +502,9 @@ export class LiveExecutionTrackerService implements ILiveExecutionTrackerService
       },
     );
 
-    return processInstanceId;
+    const processInstanceFound: boolean = processInstance !== undefined;
+
+    return processInstanceFound ? processInstance.processInstanceId : undefined;
   }
 
   public async clearDiagramColors(xml: string): Promise<string> {


### PR DESCRIPTION
## Changes

1. Add Overlays to Elements With Error
2. Refactor LiveExecutionTrackerService
3. Fix Displaying of Notification in Case of Incorrectly Configured CallActivity
4. Add Tooltips to Overlays

PR: #1642

## How to test the changes

- Run a process with at least one element that creates an error
- **Notice that there will be a button (<img width="20" src="https://user-images.githubusercontent.com/20394992/62776590-474e5280-baab-11e9-8ef2-03c5ebe86908.png">) to navigate to the inspect-correlation view**
- Click on the button
- **Notice that the inspect-correlation view will be opened with the correct processInstance and the error element already selected.**

- Run a process with a call activity with an invalid target process
- **Notice that the two overlays will be displayed next to each other**

 
