### PR TITLE
🐛 Fix Diagram Creation When Diagram Called 'Untitled' Exists

### DIFF
--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -968,6 +968,7 @@ export class SolutionExplorerSolution {
 
       const diagramIndex: number = parseInt(diagram.name.replace('Untitled-', ''));
 
+      // eslint-disable-next-line no-restricted-globals
       return !isNaN(diagramIndex);
     });
 

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -960,9 +960,15 @@ export class SolutionExplorerSolution {
 
   private async openNewDiagram(): Promise<void> {
     const unsavedDiagrams: Array<IDiagram> = this.openedDiagrams.filter((diagram: IDiagram): boolean => {
-      const diagramIsUnsavedDiagram: boolean = diagram.name.startsWith('Untitled');
+      const diagramIsUnsavedDiagram: boolean = diagram.name.startsWith('Untitled-');
 
-      return diagramIsUnsavedDiagram;
+      if (!diagramIsUnsavedDiagram) {
+        return false;
+      }
+
+      const diagramIndex: number = parseInt(diagram.name.replace('Untitled-', ''));
+
+      return !isNaN(diagramIndex);
     });
 
     const unsavedDiagramIndexes: Array<number> = unsavedDiagrams.map((diagram: IDiagram) => {


### PR DESCRIPTION
## Changes

1. Fix Diagram Creation When Diagram Called 'Untitled' Exists

PR: #1648

## How to test the changes

- Open a diagram called/starting with 'Untitled'
- Create a new diagram via CMD/CTRL + N
- **Notice that the new diagram will be created correctly.**
