### PR TITLE
🚚 Link to the Getting Started instead of outdated documentation

### DIFF
--- a/electron_app/electron.js
+++ b/electron_app/electron.js
@@ -600,7 +600,7 @@ Main._createMainWindow = () => {
         label: 'Help',
         submenu: [
           {
-            label: 'Getting-Started',
+            label: 'Getting Started',
             click: () => {
               const documentationUrl = 'https://www.process-engine.io/docs/getting-started/';
               electron.shell.openExternal(documentationUrl);

--- a/electron_app/electron.js
+++ b/electron_app/electron.js
@@ -600,9 +600,9 @@ Main._createMainWindow = () => {
         label: 'Help',
         submenu: [
           {
-            label: 'Documentation',
+            label: 'Getting-Started',
             click: () => {
-              const documentationUrl = 'https://www.process-engine.io/documentation/';
+              const documentationUrl = 'https://www.process-engine.io/docs/getting-started/';
               electron.shell.openExternal(documentationUrl);
             },
           },


### PR DESCRIPTION
## Changes

1. Link to the Getting Started instead of outdated documentation

## Issues

PR: #1655 


## How to test the changes

- start the electron app
- look at the electron context menu 
- click on `help`
- click on `Getting Started`
- realize that a new tab/window of your standard browser has opened the Getting Started page
