### PR TITLE
:twisted_rightwards_arrows: :bug: Avoid Displaying Notification When Creating Diagram

### DIFF
--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -1018,6 +1018,7 @@ export class SolutionExplorerSolution {
       return;
     }
 
+    this.eventAggregator.publish(environment.events.diagramChangedByStudio);
     await this.openDiagramAndUpdateSolution(emptyDiagram);
   };
 
@@ -1045,6 +1046,7 @@ export class SolutionExplorerSolution {
         return;
       }
 
+      this.eventAggregator.publish(environment.events.diagramChangedByStudio);
       await this.openDiagramAndUpdateSolution(emptyDiagram);
     } else if (pressedKey === ESCAPE_KEY) {
       this.resetDiagramCreation();


### PR DESCRIPTION
## Changes

1. Avoid Displaying Notification When Creating Diagram

## Issues

Closes #1663 

PR: #1662

## How to test the changes

- Click on the 'Create new diagram'-button next to a solution (<img width="20" src="https://user-images.githubusercontent.com/20394992/63252672-82514280-c270-11e9-863a-788c4bdf94de.png">)
- Enter a diagram name
- Hit enter or klick anywhere
- **Notice that no notification will be displayed.**

