### PR TITLE
🐛 Fix Reloading Inspect After Diagram Was Removed

### DIFF
--- a/src/modules/inspect/inspect.ts
+++ b/src/modules/inspect/inspect.ts
@@ -213,7 +213,11 @@ export class Inspect {
           return diagram.name === diagramName;
         });
       } else {
-        this.activeDiagram = await this.activeSolutionEntry.service.loadDiagram(diagramName);
+        try {
+          this.activeDiagram = await this.activeSolutionEntry.service.loadDiagram(diagramName);
+        } catch {
+          // If loading the diagram failed, do nothing
+        }
       }
     }
   }


### PR DESCRIPTION
# Changes

1. Fix Reloading Inspect After Diagram Was Removed

## Issues

Closes #1653 

PR: #1668

## How to test the changes

- Open a diagram
- Go to Inspect
- Remove the diagram (outside the BPMN Studio).
- Reload the BPMN Studio
- **Notice that the BPMN Studio will still be displayed instead of a white screen.**
