### PR TITLE
✨ Open bpmn.io in browser instead in electron

### DIFF
--- a/electron_app/electron.ts
+++ b/electron_app/electron.ts
@@ -1,3 +1,7 @@
+import fs from 'fs';
+import path from 'path';
+import {homedir} from 'os';
+
 import {
   App,
   BrowserWindow,
@@ -9,13 +13,11 @@ import {
   MenuItemConstructorOptions,
   WebContents,
 } from 'electron';
-import fs from 'fs';
-import {CancellationToken, autoUpdater} from '@process-engine/electron-updater';
-import path from 'path';
 import openAboutWindow, {AboutWindowInfo} from 'about-window';
 import getPort from 'get-port';
-import {homedir} from 'os';
+import open from 'open';
 
+import {CancellationToken, autoUpdater} from '@process-engine/electron-updater';
 import * as pe from '@process-engine/process_engine_runtime';
 
 import electronOidc from './electron-oidc';

--- a/electron_app/electron.ts
+++ b/electron_app/electron.ts
@@ -728,13 +728,10 @@ function getHelpMenu(): MenuItem {
 }
 
 function getAboutWindowInfo(): AboutWindowInfo {
-  const iconPath: string = releaseChannel.isDev()
-    ? path.join(__dirname, '..', 'build/icon.png')
-    : path.join(__dirname, '../../../build/icon.png');
   const copyrightYear: number = new Date().getFullYear();
 
   return {
-    icon_path: iconPath,
+    icon_path: path.join(__dirname, '../../../build/icon.png'),
     product_name: getProductName(),
     bug_report_url: 'https://github.com/process-engine/bpmn-studio/issues/new',
     homepage: 'www.process-engine.io',

--- a/electron_app/electron.ts
+++ b/electron_app/electron.ts
@@ -349,6 +349,13 @@ function createMainWindow(): void {
     browserWindow = null;
   });
 
+  browserWindow.webContents.on('new-window', (event: any, url: string) => {
+    if (url !== browserWindow.webContents.getURL()) {
+      event.preventDefault();
+      open(url);
+    }
+  });
+
   setOpenDiagramListener();
   setOpenSolutionsListener();
   setSaveDiagramAsListener();


### PR DESCRIPTION
## Changes

1. Open bpmn.io in browser instead in electron

## Issues

Closes #1477 

PR: #1682 

## How to test the changes

- click on the bpmn.io icon on the modeler/viewer
- click on the bpmn.io link
- see that it opens up in a new browser tab
- open the about window
- see that it opens in an electron window

- same for the identity server login/logout
- the links on the dashboard view should open in the same electron window (BPMN Studio)
