### PR TITLE
✨Add intermediate link events to property panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -643,9 +643,9 @@
       }
     },
     "@process-engine/bpmn-elements_contracts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@process-engine/bpmn-elements_contracts/-/bpmn-elements_contracts-2.0.0.tgz",
-      "integrity": "sha512-t4iVT/ZDmSHOdUeQFwKqmHPrl3iANzkakuRCIQxHa92qeWrpiMWMc3R7NSFXb7DgkQ/lhDR1gBjvy9CJnZ6ICg==",
+      "version": "2.0.0-bc9a859f-b2",
+      "resolved": "https://registry.npmjs.org/@process-engine/bpmn-elements_contracts/-/bpmn-elements_contracts-2.0.0-bc9a859f-b2.tgz",
+      "integrity": "sha512-H5h/RMUVJUMSlBmUc5SnIxjDVx684Qy8Xdh23unNflssXaTS+E56EtCYbEd94U18t5n2spbsRF5Zat6/A0tetQ==",
       "dev": true
     },
     "@process-engine/bpmn-js-bpmnlint": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@essential-projects/eslint-config": "^1.0.4",
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/iam_contracts": "^3.6.0",
-    "@process-engine/bpmn-elements_contracts": "^2.0.0",
+    "@process-engine/bpmn-elements_contracts": "2.0.0-bc9a859f-b2",
     "@process-engine/management_api_contracts": "^11.0.1",
     "@process-engine/solutionexplorer.contracts": "^1.0.1",
     "@process-engine/solutionexplorer.repository.contracts": "^4.2.0",

--- a/src/modules/design/property-panel/indextabs/general/general.ts
+++ b/src/modules/design/property-panel/indextabs/general/general.ts
@@ -15,6 +15,7 @@ import {ScriptTaskSection} from './sections/script-task/script-task';
 import {ServiceTaskSection} from './sections/service-task/service-task';
 import {SignalEventSection} from './sections/signal-event/signal-event';
 import {TimerEventSection} from './sections/timer-event/timer-event';
+import {LinkEventSection} from './sections/link-event/link-event';
 
 export class General implements IIndextab {
   public title: string = 'General';
@@ -34,6 +35,7 @@ export class General implements IIndextab {
   public conditionalEventSection: ISection = new ConditionalEventSection();
   public processSection: ISection = new ProcessSection();
   public serviceTaskSection: ISection = new ServiceTaskSection();
+  public linkEventSection: ISection = new LinkEventSection();
 
   public sections: Array<ISection> = [
     this.basicsSection,
@@ -50,6 +52,7 @@ export class General implements IIndextab {
     this.conditionalEventSection,
     this.processSection,
     this.serviceTaskSection,
+    this.linkEventSection,
   ];
 
   public canHandleElement: boolean = true;

--- a/src/modules/design/property-panel/indextabs/general/sections/link-event/link-event.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/link-event/link-event.html
@@ -1,0 +1,17 @@
+<template>
+  <require from="./link-event.css"></require>
+  <require from="../../../../styles/sections.css"></require>
+  <div class="section-panel">
+    <div class="panel__heading">Link Event</div>
+    <div class="panel__content">
+      <table class="props-table">
+        <tr>
+          <th>Link Name</th>
+          <td>
+            <input type="text" class="props-input" value.bind="linkEventName & updateTrigger:'blur':'paste'" disabled.bind="!isEditable">
+          </td>
+        </tr>
+      </table>
+    </div>
+  </div>
+</template>

--- a/src/modules/design/property-panel/indextabs/general/sections/link-event/link-event.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/link-event/link-event.ts
@@ -1,0 +1,63 @@
+import {EventAggregator} from 'aurelia-event-aggregator';
+import {inject, observable} from 'aurelia-framework';
+
+import {ILinkEventElement, IShape} from '@process-engine/bpmn-elements_contracts';
+
+import {IPageModel, ISection} from '../../../../../../../contracts';
+import environment from '../../../../../../../environment';
+
+@inject(EventAggregator)
+export class LinkEventSection implements ISection {
+  public path: string = '/sections/link-event/link-event';
+  public canHandleElement: boolean = false;
+  @observable public linkEventName: string = '';
+
+  private businessObjInPanel: ILinkEventElement;
+  private eventAggregator: EventAggregator;
+
+  constructor(eventAggregator?: EventAggregator) {
+    this.eventAggregator = eventAggregator;
+  }
+
+  public activate(model: IPageModel): void {
+    this.businessObjInPanel = model.elementInPanel.businessObject as ILinkEventElement;
+    this.linkEventName = this.businessObjInPanel.eventDefinitions[0].name || '';
+  }
+
+  public isSuitableForElement(elementShape: IShape): boolean {
+    if (!this.elementIsLinkEvent(elementShape)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  public linkEventNameChanged(newValue, oldValue): void {
+    if (oldValue === undefined) {
+      return;
+    }
+
+    this.businessObjInPanel.eventDefinitions[0].name = newValue;
+    this.publishDiagramChange();
+  }
+
+  private elementIsLinkEvent(element: IShape): boolean {
+    const elementHasNoBusinessObject: boolean = element === undefined || element.businessObject === undefined;
+    if (elementHasNoBusinessObject) {
+      return false;
+    }
+
+    const eventElement: ILinkEventElement = element.businessObject as ILinkEventElement;
+
+    const elementIsLinkEvent: boolean =
+      eventElement.eventDefinitions !== undefined &&
+      eventElement.eventDefinitions[0] !== undefined &&
+      eventElement.eventDefinitions[0].$type === 'bpmn:LinkEventDefinition';
+
+    return elementIsLinkEvent;
+  }
+
+  private publishDiagramChange(): void {
+    this.eventAggregator.publish(environment.events.diagramChange);
+  }
+}

--- a/src/modules/design/property-panel/indextabs/general/sections/link-event/link-event.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/link-event/link-event.ts
@@ -25,11 +25,19 @@ export class LinkEventSection implements ISection {
   }
 
   public isSuitableForElement(elementShape: IShape): boolean {
-    if (!this.elementIsLinkEvent(elementShape)) {
+    const elementHasNoBusinessObject: boolean = elementShape === undefined || elementShape.businessObject === undefined;
+    if (elementHasNoBusinessObject) {
       return false;
     }
 
-    return true;
+    const eventElement: ILinkEventElement = elementShape.businessObject as ILinkEventElement;
+
+    const elementIsLinkEvent: boolean =
+      eventElement.eventDefinitions !== undefined &&
+      eventElement.eventDefinitions[0] !== undefined &&
+      eventElement.eventDefinitions[0].$type === 'bpmn:LinkEventDefinition';
+
+    return elementIsLinkEvent;
   }
 
   public linkEventNameChanged(newValue, oldValue): void {
@@ -39,22 +47,6 @@ export class LinkEventSection implements ISection {
 
     this.businessObjInPanel.eventDefinitions[0].name = newValue;
     this.publishDiagramChange();
-  }
-
-  private elementIsLinkEvent(element: IShape): boolean {
-    const elementHasNoBusinessObject: boolean = element === undefined || element.businessObject === undefined;
-    if (elementHasNoBusinessObject) {
-      return false;
-    }
-
-    const eventElement: ILinkEventElement = element.businessObject as ILinkEventElement;
-
-    const elementIsLinkEvent: boolean =
-      eventElement.eventDefinitions !== undefined &&
-      eventElement.eventDefinitions[0] !== undefined &&
-      eventElement.eventDefinitions[0].$type === 'bpmn:LinkEventDefinition';
-
-    return elementIsLinkEvent;
   }
 
   private publishDiagramChange(): void {


### PR DESCRIPTION
## Changes

1. Update bpmn-elements_contracts
2. Add link event section

## Issues

Closes #1644 

PR: #1684 

## How to test the changes

- create/open a diagram
- add an intermediate event
- change its type to `Link catch/throw event`
- see that the `Link Event `section is shown on the PropertyPanel
- change the `Link Name`
- save the diagram
- reload
- select the element
- see that the name is correct
