### PR TITLE
✨ Make Diagrams Deployable via Solution Explorer

### DIFF
--- a/aurelia_project/environments/dev.ts
+++ b/aurelia_project/environments/dev.ts
@@ -69,6 +69,7 @@ export default {
       onDiagramDeployed: 'diagramdetail:diagram:ondeployed',
       printDiagram: 'diagramdetail:diagram:print',
       saveDiagram: 'diagramdetail:diagram:save',
+      saveDiagramDone: 'diagramdetail:diagram:save:done',
       saveDiagramAs: 'diagramdetail:diagram:save:as',
       exportDiagramAs: 'diagramdetail:diagram:exportas',
       startProcess: 'diagramdetail:process:start',

--- a/aurelia_project/environments/dev.ts
+++ b/aurelia_project/environments/dev.ts
@@ -32,6 +32,11 @@ export default {
     differsFromOriginal: 'differsFromOriginal',
     diagramChangedOutsideTheStudio: 'diagramChangedOutsideTheStudio',
     xmlChanged: 'xmlChanged',
+    deployModals: {
+      showSaveBeforeDeployModal: 'deployModals:saveBeforeDeployModal:show',
+      showRemoteSolutionSelectionModal: 'deployModals:remoteSolutionSelectionModal:show',
+      showOverwriteDiagramModal: 'deployModals:overwriteDiagramModal:show',
+    },
     startPage: {
       openLocalSolution: 'startpage:openlocalsolution',
       openDiagram: 'startpage:openDiagram',

--- a/aurelia_project/environments/dev.ts
+++ b/aurelia_project/environments/dev.ts
@@ -32,6 +32,7 @@ export default {
     differsFromOriginal: 'differsFromOriginal',
     diagramChangedOutsideTheStudio: 'diagramChangedOutsideTheStudio',
     xmlChanged: 'xmlChanged',
+    diagramWasSaved: 'diagramWasSaved',
     deployModals: {
       showSaveBeforeDeployModal: 'deployModals:saveBeforeDeployModal:show',
       showRemoteSolutionSelectionModal: 'deployModals:remoteSolutionSelectionModal:show',
@@ -62,7 +63,6 @@ export default {
       toggleDashboardView: 'navbar:tools:inspectButtons:toggleDashboardView',
       toggleHeatmapView: 'navbar:tools:inspectButtons:toggleHeatmapView',
       toggleInspectCorrelationView: 'navbar:tools:inspectButtons:toggleInspectCorrelationView',
-      diagramChangesResolved: 'navbar:diagram:changesResolved',
       updateActiveSolutionAndDiagram: 'navbar:activeSolution:diagram:update',
     },
     diagramDetail: {

--- a/src/app.html
+++ b/src/app.html
@@ -6,9 +6,12 @@
   <require from="./modules/navbar/navbar"></require>
   <require from="./modules/solution-explorer/solution-explorer-panel/solution-explorer-panel"></require>
   <require from="./modules/status-bar/status-bar"></require>
+  <require from="./modules/deploy-modals/deploy-modals"></require>
 
   <div class="bpmn-studio-layout">
     <nav-bar></nav-bar>
+
+    <deploy-modals></deploy-modals>
 
     <div class="bpmn-studio-layout__content">
       <solution-explorer-panel show.bind="showSolutionExplorer" data-test-solution-explorer-panel></solution-explorer-panel>

--- a/src/modules/deploy-modals/deploy-modals.html
+++ b/src/modules/deploy-modals/deploy-modals.html
@@ -1,0 +1,40 @@
+<template>
+  <require from='./deploy-modals.css'></require>
+
+  <modal if.bind="showSaveBeforeDeployModal"
+         header-text="Save Diagram Before Deploying"
+         body-text="In order to deploy your diagram, you have to save your recent changes to disk.">
+    <template replace-part="modal-footer">
+      <button type="button" class="btn btn-default" data-dismiss="modal" click.delegate="cancelSaveBeforeDeployModal()">Cancel</button>
+      <button type="button" class="btn btn-primary" data-dismiss="modal" click.delegate="saveDiagramAndDeploy()">Save and deploy</button>
+    </template>
+  </modal>
+
+  <modal if.bind="showRemoteSolutionOnDeployModal"
+         header-text="Multiple Connected ProcessEngines Found">
+    <template replace-part="modal-body">
+      Choose a remote ProcessEngines; the diagram will be deployed to your selection.
+      <select class="form-control" value.bind="selectedRemoteSolution">
+        <option repeat.for="entry of remoteSolutions" model.bind="entry">${entry.uri}</option>
+      </select>
+    </template>
+
+    <template replace-part="modal-footer">
+      <button type="button" class="btn btn-default" data-dismiss="modal" click.delegate="cancelMultipleRemoteSolutionModal()">Cancel</button>
+      <button type="button" class="btn btn-primary" data-dismiss="modal" click.delegate="selectRemoteSolution(selectedRemoteSolution)">Deploy Process</button>
+    </template>
+  </modal>
+
+
+  <modal show.bind="showOverwriteDiagramModal"
+         header-text="Warning: Diagram already exists!">
+    <template replace-part="modal-body">
+      The target solution already contains a diagram with that name and ID.<br>
+      Are you sure you want to overwrite the deployed diagram with your local version?
+    </template>
+    <template replace-part="modal-footer">
+      <button type="button" class="btn btn-default" data-dismiss="modal" click.delegate="cancelOverwriteModal()">Cancel</button>
+      <button type="button" class="btn btn-primary" data-dismiss="modal" click.delegate="overwriteDiagram()">Deploy</button>
+    </template>
+  </modal>
+</template>

--- a/src/modules/deploy-modals/deploy-modals.html
+++ b/src/modules/deploy-modals/deploy-modals.html
@@ -13,7 +13,7 @@
   <modal if.bind="showRemoteSolutionOnDeployModal"
          header-text="Multiple Connected ProcessEngines Found">
     <template replace-part="modal-body">
-      Choose a remote ProcessEngines; the diagram will be deployed to your selection.
+      Choose the remote ProcessEngine to which to deploy the diagram.
       <select class="form-control" value.bind="selectedRemoteSolution">
         <option repeat.for="entry of remoteSolutions" model.bind="entry">${entry.uri}</option>
       </select>

--- a/src/modules/deploy-modals/deploy-modals.ts
+++ b/src/modules/deploy-modals/deploy-modals.ts
@@ -1,0 +1,117 @@
+import {inject} from 'aurelia-framework';
+import {EventAggregator, Subscription} from 'aurelia-event-aggregator';
+
+import environment from '../../environment';
+import {ISolutionEntry} from '../../contracts';
+import {SolutionService} from '../../services/solution-service/SolutionService';
+
+@inject(EventAggregator, 'SolutionService')
+export class DeployModals {
+  public showSaveBeforeDeployModal: boolean = false;
+  public showRemoteSolutionOnDeployModal: boolean = false;
+  public showOverwriteDiagramModal: boolean = false;
+  public remoteSolutions: Array<ISolutionEntry>;
+
+  public cancelSaveBeforeDeployModal: Function;
+  public saveDiagramAndDeploy: Function;
+
+  public cancelMultipleRemoteSolutionModal: Function;
+  public selectRemoteSolution: Function;
+
+  public cancelOverwriteModal: Function;
+  public overwriteDiagram: Function;
+
+  private solutionService: SolutionService;
+
+  private subscriptions: Array<Subscription>;
+  private eventAggregator: EventAggregator;
+
+  constructor(eventAggregator: EventAggregator, solutionService: SolutionService) {
+    this.eventAggregator = eventAggregator;
+    this.solutionService = solutionService;
+  }
+
+  public attached(): void {
+    this.subscriptions = [
+      this.eventAggregator.subscribe(
+        environment.events.deployModals.showSaveBeforeDeployModal,
+        (callback: Function) => {
+          this.handleSaveBeforeDeploy(callback);
+        },
+      ),
+
+      this.eventAggregator.subscribe(
+        environment.events.deployModals.showRemoteSolutionSelectionModal,
+        (callback: Function) => {
+          this.handleRemoteSolutionSelection(callback);
+        },
+      ),
+
+      this.eventAggregator.subscribe(
+        environment.events.deployModals.showOverwriteDiagramModal,
+        (callback: Function) => {
+          this.handleOverwriting(callback);
+        },
+      ),
+    ];
+  }
+
+  public detached(): void {
+    this.subscriptions.forEach((subscription: Subscription) => {
+      subscription.dispose();
+    });
+  }
+
+  public handleSaveBeforeDeploy(callback: Function): void {
+    this.showSaveBeforeDeployModal = true;
+
+    this.cancelSaveBeforeDeployModal = (): void => {
+      this.showSaveBeforeDeployModal = false;
+
+      callback(false);
+    };
+
+    this.saveDiagramAndDeploy = (): void => {
+      this.showSaveBeforeDeployModal = false;
+
+      callback(true);
+    };
+  }
+
+  public handleRemoteSolutionSelection(callback: Function): void {
+    this.updateRemoteSolutions();
+    this.showRemoteSolutionOnDeployModal = true;
+
+    this.cancelMultipleRemoteSolutionModal = (): void => {
+      this.showRemoteSolutionOnDeployModal = false;
+
+      callback();
+    };
+
+    this.selectRemoteSolution = (remoteSolution: ISolutionEntry): void => {
+      this.showRemoteSolutionOnDeployModal = false;
+
+      callback(remoteSolution);
+    };
+  }
+
+  public handleOverwriting(callback: Function): void {
+    this.showOverwriteDiagramModal = true;
+
+    this.cancelOverwriteModal = (): void => {
+      this.showOverwriteDiagramModal = false;
+
+      callback(false);
+    };
+
+    this.overwriteDiagram = (): void => {
+      this.showOverwriteDiagramModal = false;
+
+      callback(true);
+    };
+  }
+
+  private updateRemoteSolutions(): void {
+    this.remoteSolutions = this.solutionService.getRemoteSolutionEntries();
+  }
+}

--- a/src/modules/design/design.html
+++ b/src/modules/design/design.html
@@ -31,30 +31,6 @@
       </div>
     </div>
 
-    <modal show.bind="showSaveBeforeDeployModal"
-          header-text="Save Diagram Before Deploying"
-          body-text="In order to deploy your diagram, you have to save your recent changes to disk.">
-      <template replace-part="modal-footer">
-        <button type="button" class="btn btn-default" data-dismiss="modal" id="cancelDeploy" click.delegate="diagramDetail.cancelSaveBeforeDeployModal()"> Cancel</button>
-        <button type="button" class="btn btn-primary" data-dismiss="modal" id="saveButtonDeploy" click.delegate="diagramDetail.saveDiagramAndDeploy()"> Save and deploy</button>
-      </template>
-    </modal>
-
-    <modal if.bind="showRemoteSolutionOnDeployModal"
-          header-text="Multiple Connected ProcessEngines Found">
-      <template replace-part="modal-body">
-        Choose a remote ProcessEngines; the diagram will be deployed to your selection.
-        <select class="form-control" value.bind="diagramDetail.selectedRemoteSolution">
-          <option repeat.for="entry of connectedRemoteSolutions" model.bind="entry">${entry.uri}</option>
-        </select>
-      </template>
-
-      <template replace-part="modal-footer">
-        <button type="button" class="btn btn-default" data-dismiss="modal" id="cancelButtonRemoteSolutionsOnDeploy" click.delegate="diagramDetail.cancelDialog()">Cancel</button>
-        <button type="button" class="btn btn-primary" data-dismiss="modal" id="saveButtonRemoteSolutionsOnDeploy" click.delegate="diagramDetail.uploadProcess(diagramDetail.selectedRemoteSolution)" >Deploy Process</button>
-      </template>
-    </modal>
-
     <modal show.bind="showSaveForStartModal"
           header-text="Document Contains Changes"
           body-text="Your process has unsaved changes. Save changes to diagram before starting the process?">
@@ -133,18 +109,5 @@
         <button type="button" class="btn btn-primary" data-dismiss="modal" id="js-choose-diagram" click.delegate="setDiffDestination(selectedDiagram.solutionUri, selectedDiagram.diagram.name)">Compare</button>
       </template>
     </modal>
-
-    <modal show.bind="diagramDetail.showDiagramExistingModal"
-          header-text="Warning: Diagram already exists!">
-      <template replace-part="modal-body">
-        The target solution already contains a diagram with that name and ID.<br>
-        Are you sure you want to overwrite the deployed diagram with your local version?
-      </template>
-      <template replace-part="modal-footer">
-        <button type="button" class="btn btn-default" id="cancelDiagramDeploy">Cancel</button>
-        <button type="button" class="btn btn-primary" id="overrideDiagramOnSolution">Deploy</button>
-      </template>
-    </modal>
-
   </div>
 </template>

--- a/src/modules/design/design.ts
+++ b/src/modules/design/design.ts
@@ -130,7 +130,6 @@ export class Design {
         this.ipcRenderer.send('menu_show-all-menu-entries');
       }
 
-      const diagramNameIsSet: boolean = routeParameters.diagramName !== undefined;
       if (diagramNameIsSet) {
         await this.setActiveDiagram(routeParameters.diagramName, routeParameters.diagramUri);
       }

--- a/src/modules/design/diagram-detail/diagram-detail.ts
+++ b/src/modules/design/diagram-detail/diagram-detail.ts
@@ -14,33 +14,20 @@ import {
 import {DataModels, IManagementApi} from '@process-engine/management_api_contracts';
 import {IDiagram} from '@process-engine/solutionexplorer.contracts';
 
-import {
-  DiagramStateChange,
-  IDiagramState,
-  IElementRegistry,
-  ISolutionEntry,
-  ISolutionService,
-  IUserInputValidationRule,
-  NotificationType,
-} from '../../../contracts/index';
+import {IElementRegistry, ISolutionEntry, IUserInputValidationRule, NotificationType} from '../../../contracts/index';
 
 import environment from '../../../environment';
 import {NotificationService} from '../../../services/notification-service/notification.service';
-import {OpenDiagramsSolutionExplorerService} from '../../../services/solution-explorer-services/OpenDiagramsSolutionExplorerService';
 import {BpmnIo} from '../bpmn-io/bpmn-io';
-import {OpenDiagramStateService} from '../../../services/solution-explorer-services/OpenDiagramStateService';
 import {DeployDiagramService} from '../../../services/deploy-diagram-service/deploy-diagram.service';
 import {SaveDiagramService} from '../../../services/save-diagram-service/save-diagram.service';
 
 @inject(
   'ManagementApiClientService',
   'NotificationService',
-  'SolutionService',
   EventAggregator,
   Router,
   ValidationController,
-  'OpenDiagramService',
-  'OpenDiagramStateService',
   DeployDiagramService,
   SaveDiagramService,
 )
@@ -72,7 +59,6 @@ export class DiagramDetail {
   private router: Router;
   private validationController: ValidationController;
   private ipcRenderer: any;
-  private solutionService: ISolutionService;
   private managementApiClient: IManagementApi;
   private correlationIdValidationRegExpList: IUserInputValidationRule = {
     alphanumeric: /^[a-z0-9]/i,
@@ -81,31 +67,23 @@ export class DiagramDetail {
   };
 
   private clickedOnCustomStart: boolean = false;
-  private openDiagramService: OpenDiagramsSolutionExplorerService;
-  private openDiagramStateService: OpenDiagramStateService;
   private deployDiagramService: DeployDiagramService;
   private saveDiagramService: SaveDiagramService;
 
   constructor(
     managementApiClient: IManagementApi,
     notificationService: NotificationService,
-    solutionService: ISolutionService,
     eventAggregator: EventAggregator,
     router: Router,
     validationController: ValidationController,
-    openDiagramService: OpenDiagramsSolutionExplorerService,
-    openDiagramStateService: OpenDiagramStateService,
     deployDiagramService: DeployDiagramService,
     saveDiagramService: SaveDiagramService,
   ) {
     this.notificationService = notificationService;
-    this.solutionService = solutionService;
     this.eventAggregator = eventAggregator;
     this.router = router;
     this.validationController = validationController;
     this.managementApiClient = managementApiClient;
-    this.openDiagramService = openDiagramService;
-    this.openDiagramStateService = openDiagramStateService;
     this.deployDiagramService = deployDiagramService;
     this.saveDiagramService = saveDiagramService;
 

--- a/src/modules/design/diagram-detail/diagram-detail.ts
+++ b/src/modules/design/diagram-detail/diagram-detail.ts
@@ -141,8 +141,10 @@ export class DiagramDetail {
       this.validationController.subscribe((event: ValidateEvent) => {
         this.handleFormValidateEvents(event);
       }),
-      this.eventAggregator.subscribe(environment.events.diagramDetail.saveDiagram, () => {
-        this.saveDiagram();
+      this.eventAggregator.subscribe(environment.events.diagramDetail.saveDiagram, async () => {
+        await this.saveDiagram();
+
+        this.eventAggregator.publish(environment.events.diagramDetail.saveDiagramDone);
       }),
       this.eventAggregator.subscribe(environment.events.diagramDetail.uploadProcess, () => {
         this.deployDiagram();

--- a/src/modules/design/diagram-detail/diagram-detail.ts
+++ b/src/modules/design/diagram-detail/diagram-detail.ts
@@ -310,7 +310,7 @@ export class DiagramDetail {
     this.diagramHasChanged = false;
   }
 
-  public async saveDiagramAs(): Promise<void> {
+  public async saveDiagramAs(path?: string): Promise<void> {
     if (this.diagramIsInvalid) {
       return;
     }
@@ -321,7 +321,7 @@ export class DiagramDetail {
       return;
     }
 
-    await this.saveDiagramService.saveDiagramAs(this.activeSolutionEntry, this.activeDiagram, xml);
+    await this.saveDiagramService.saveDiagramAs(this.activeSolutionEntry, this.activeDiagram, xml, path);
 
     this.bpmnio.saveStateForNewUri = true;
     this.bpmnio.saveCurrentXML();

--- a/src/modules/navbar/navbar.ts
+++ b/src/modules/navbar/navbar.ts
@@ -88,7 +88,13 @@ export class NavBar {
         this.diagramContainsUnsavedChanges = isDiagramChanged;
       }),
 
-      this.eventAggregator.subscribe(environment.events.navBar.diagramChangesResolved, () => {
+      this.eventAggregator.subscribe(environment.events.diagramWasSaved, (diagramUri: string) => {
+        const activeDiagramWasSaved: boolean = diagramUri === this.activeDiagram.uri;
+
+        if (!activeDiagramWasSaved) {
+          return;
+        }
+
         this.diagramContainsUnsavedChanges = false;
       }),
 

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.html
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.html
@@ -9,7 +9,7 @@
     </div>
 
     <div class="diagram-contextmenu" ref="diagramContextMenu" show.bind="showContextMenu">
-      <div if.bind="canRenameDiagram()" class="diagram-contextmenu__entry" click.delegate="duplicateDiagram()">
+      <div show.bind="canRenameDiagram" class="diagram-contextmenu__entry" click.delegate="duplicateDiagram()">
         Duplicate
       </div>
       <div class="diagram-contextmenu__entry" click.delegate="deployDiagram()">
@@ -55,7 +55,7 @@
           <div class="diagram-entry__actions">
             <button
               class.bind="activeDiagramUri !== diagram.uri ? 'button' : 'button button--disabled'"
-              if.bind="canRenameDiagram()"
+              if.bind="canRenameDiagram"
               click.delegate="startRenamingOfDiagram(diagram, $event)"
               title.bind="activeDiagramUri !== diagram.uri ? 'Rename the diagram' : 'The diagram is currently open, it cant be renamed.'">
 

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.html
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.html
@@ -8,8 +8,8 @@
       <i class="fa fa-spinner fa-spin"></i>
     </div>
 
-    <div class="diagram-contextmenu" ref="diagramContextMenu" show.bind="showContextMenu && canRenameDiagram()">
-      <div class="diagram-contextmenu__entry" click.delegate="duplicateDiagram()">
+    <div class="diagram-contextmenu" ref="diagramContextMenu" show.bind="showContextMenu">
+      <div if.bind="canRenameDiagram()" class="diagram-contextmenu__entry" click.delegate="duplicateDiagram()">
         Duplicate
       </div>
       <div class="diagram-contextmenu__entry" click.delegate="deployDiagram()">

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.html
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.html
@@ -98,5 +98,15 @@
       <button type="button" class="btn btn-primary" data-dismiss="modal" id="saveButtonCloseView">Save</button>
     </template>
   </modal>
+  <modal if.bind="isSavingDiagrams"
+         body-style="min-height: 230px"
+         header-text="Saving Diagrams">
+    <template replace-part="modal-body">
+      <div class="saving-diagram-modal__loading-spinner">
+        <img class="saving-diagram-modal__loading-spinner-icon" src="src/resources/images/gears.svg">
+        <h3 class="saving-diagram-modal__loading-spinner-text">Saving "${currentlySavingDiagramName}"...</h3>
+        </div>
+    </template>
+  </modal>
 
 </template>

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.html
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.html
@@ -12,6 +12,9 @@
       <div class="diagram-contextmenu__entry" click.delegate="duplicateDiagram()">
         Duplicate
       </div>
+      <div class="diagram-contextmenu__entry" click.delegate="deployDiagram()">
+        Deploy
+      </div>
     </div>
 
     <ul if.bind="!solutionIsNotLoaded" class="solution__diagram-list">

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.scss
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.scss
@@ -152,3 +152,27 @@
 .diagram-contextmenu__entry:hover {
   background-color: #dcdbdb;
 }
+
+.saving-diagram-modal__loading-spinner {
+  display: inline-block;
+  width: 100%;
+  height: 100%;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.saving-diagram-modal__loading-spinner-icon {
+  position: absolute;
+  left: 50%;
+  top: calc(50% - 22px);
+  height: 150px;
+  transform: translate(-50%, -50%);
+}
+
+.saving-diagram-modal__loading-spinner-text {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-top: 5px;
+  bottom: 10px;
+}

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -597,16 +597,6 @@ export class SolutionExplorerSolution {
       return undefined;
     }
 
-    /**
-     * We have to check if THIS solution is the "Open Diagrams"-Solution
-     * because it is our special case here and if the ACTIVE solution is the
-     * "Open Diagrams"-Solution we need to return the uri anyway.
-     */
-    const openDiagramSolutionIsActive: boolean = solutionUri === 'about:open-diagrams';
-    if (this.displayedSolutionEntry.isOpenDiagramService && openDiagramSolutionIsActive) {
-      return this.activeDiagram.uri;
-    }
-
     return this.activeDiagram.uri;
   }
 

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -15,6 +15,7 @@ import {
   IDiagramCreationService,
   IDiagramState,
   IDiagramStateList,
+  IDiagramStateListEntry,
   ISolutionEntry,
   ISolutionService,
   NotificationType,
@@ -825,7 +826,11 @@ export class SolutionExplorerSolution {
 
     this.isSavingDiagrams = true;
 
-    const diagramStateList: IDiagramStateList = this.openDiagramStateService.loadDiagramStateForAllDiagrams();
+    const diagramStateList: IDiagramStateList = this.openDiagramStateService
+      .loadDiagramStateForAllDiagrams()
+      .filter((diagramStateListEntry: IDiagramStateListEntry) => {
+        return diagramStateListEntry.diagramState.metadata.isChanged;
+      });
 
     for (const diagramStateListEntry of diagramStateList) {
       const isActiveDiagram: boolean =

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -438,7 +438,16 @@ export class SolutionExplorerSolution {
       return;
     }
 
-    await this.deployDiagramService.deployDiagram(this.displayedSolutionEntry, this.diagramInContextMenu);
+    const diagramState: IDiagramState | null = this.openDiagramStateService.loadDiagramState(
+      this.diagramInContextMenu.uri,
+    );
+    const diagramHasState: boolean = diagramState !== null;
+    console.log(diagramHasState);
+    console.log(this.diagramInContextMenu.uri);
+
+    const xml: string | undefined = diagramHasState ? diagramState.data.xml : undefined;
+
+    await this.deployDiagramService.deployDiagram(this.displayedSolutionEntry, this.diagramInContextMenu, xml);
   }
 
   /*

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -867,7 +867,7 @@ export class SolutionExplorerSolution {
   }
 
   private saveActiveDiagram(): Promise<void> {
-    return new Promise((resolve: Function) => {
+    return new Promise((resolve: Function): void => {
       this.eventAggregator.subscribeOnce(environment.events.diagramDetail.saveDiagramDone, () => {
         resolve();
       });
@@ -877,7 +877,7 @@ export class SolutionExplorerSolution {
   }
 
   private waitForSaving(): Promise<void> {
-    return new Promise((resolve: Function) => {
+    return new Promise((resolve: Function): void => {
       setTimeout(() => {
         resolve();
       }, 550);

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -657,20 +657,12 @@ export class SolutionExplorerSolution {
 
       const diagramState: IDiagramState = this.openDiagramStateService.loadDiagramState(currentDiagram.uri);
       const diagramHasUnsavedChanges: boolean = diagramState !== null && diagramState.metadata.isChanged;
-
-      let saveDiagram: boolean = false;
       let closeDiagram: boolean = true;
 
       if (diagramHasUnsavedChanges) {
         const closeModalResult: CloseModalResult = await this.showCloseDiagramModal(currentDiagram, false);
 
         closeDiagram = closeModalResult !== CloseModalResult.Cancel;
-        saveDiagram = closeModalResult === CloseModalResult.Save;
-      }
-
-      const diagramIsNewDiagram: boolean = currentDiagram.uri.startsWith('about:open-diagrams');
-      if (saveDiagram && diagramIsNewDiagram) {
-        await this.waitForNavigation();
       }
 
       if (isLastDiagram) {
@@ -687,14 +679,6 @@ export class SolutionExplorerSolution {
 
   private get isCurrentlyRenamingDiagram(): boolean {
     return this.currentlyRenamingDiagram !== null;
-  }
-
-  private waitForNavigation(): Promise<void> {
-    return new Promise((resolve: Function): void => {
-      this.eventAggregator.subscribeOnce('router:navigation:success', () => {
-        resolve();
-      });
-    });
   }
 
   private navigateToStartPage(): Promise<void> {

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -525,6 +525,7 @@ export class SolutionExplorerSolution {
 
     const updateDiagramState: Function = () => {
       diagramState.metadata.isChanged = this.isActiveDiagramChanged;
+
       this.openDiagramStateService.updateDiagramState(diagramUri, diagramState);
     };
 

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -24,6 +24,7 @@ import {NotificationService} from '../../../services/notification-service/notifi
 import {OpenDiagramsSolutionExplorerService} from '../../../services/solution-explorer-services/OpenDiagramsSolutionExplorerService';
 import {OpenDiagramStateService} from '../../../services/solution-explorer-services/OpenDiagramStateService';
 import {DeleteDiagramModal} from './delete-diagram-modal/delete-diagram-modal';
+import {DeployDiagramService} from '../../../services/deploy-diagram-service/deploy-diagram.service';
 
 const ENTER_KEY: string = 'Enter';
 const ESCAPE_KEY: string = 'Escape';
@@ -53,6 +54,7 @@ interface IDiagramCreationState extends IDiagramNameInputState {
   'SolutionService',
   'OpenDiagramStateService',
   BindingSignaler,
+  DeployDiagramService,
 )
 export class SolutionExplorerSolution {
   public activeDiagram: IDiagram;
@@ -76,6 +78,7 @@ export class SolutionExplorerSolution {
   private diagramCreationService: IDiagramCreationService;
   private notificationService: NotificationService;
   private openDiagramStateService: OpenDiagramStateService;
+  private deployDiagramService: DeployDiagramService;
 
   private diagramRoute: string = 'design';
   private inspectView: string;
@@ -117,6 +120,7 @@ export class SolutionExplorerSolution {
     solutionService: ISolutionService,
     openDiagramStateService: OpenDiagramStateService,
     bindingSignaler: BindingSignaler,
+    deployDiagramService: DeployDiagramService,
   ) {
     this.router = router;
     this.eventAggregator = eventAggregator;
@@ -126,6 +130,7 @@ export class SolutionExplorerSolution {
     this.globalSolutionService = solutionService;
     this.openDiagramStateService = openDiagramStateService;
     this.bindingSignaler = bindingSignaler;
+    this.deployDiagramService = deployDiagramService;
   }
 
   public async attached(): Promise<void> {
@@ -425,6 +430,15 @@ export class SolutionExplorerSolution {
 
     await this.solutionService.saveDiagram(duplicatedDiagram, duplicatedDiagram.uri);
     await this.updateSolution();
+  }
+
+  public async deployDiagram(): Promise<void> {
+    const noDiagramInContextMenu: boolean = this.diagramInContextMenu === undefined;
+    if (noDiagramInContextMenu) {
+      return;
+    }
+
+    await this.deployDiagramService.deployDiagram(this.displayedSolutionEntry, this.diagramInContextMenu);
   }
 
   /*

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -159,7 +159,7 @@ export class SolutionExplorerSolution {
         }
       }),
 
-      this.eventAggregator.subscribe(environment.events.navBar.diagramChangesResolved, () => {
+      this.eventAggregator.subscribe(environment.events.diagramWasSaved, () => {
         this.isActiveDiagramChanged = false;
         this.bindingSignaler.signal('diagramChanges');
       }),
@@ -889,7 +889,7 @@ export class SolutionExplorerSolution {
       };
 
       const saveFunction: EventListenerOrEventListenerObject = async (): Promise<void> => {
-        this.eventAggregator.subscribeOnce(environment.events.navBar.diagramChangesResolved, async () => {
+        this.eventAggregator.subscribeOnce(environment.events.diagramWasSaved, async () => {
           if (shouldNavigate) {
             await this.navigateBack();
           }

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -513,7 +513,8 @@ export class SolutionExplorerSolution {
     return false;
   }
 
-  public canRenameDiagram(): boolean {
+  @computedFrom('displayedSolutionEntry.isOpenDiagramService', 'openedSolution')
+  public get canRenameDiagram(): boolean {
     return (
       !this.displayedSolutionEntry.isOpenDiagramService &&
       this.openedSolution &&

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -818,18 +818,14 @@ export class SolutionExplorerSolution {
     const diagramStateList: IDiagramStateList = this.openDiagramStateService.loadDiagramStateForAllDiagrams();
 
     for (const diagramStateListEntry of diagramStateList) {
-      const isActiveDiagram: boolean =
-        this.activeDiagram !== undefined && this.activeDiagram.uri === diagramStateListEntry.uri;
-      if (isActiveDiagram) {
-        await this.saveActiveDiagram();
-        await this.waitForSaving();
-
-        continue;
-      }
-
       const diagramToSave: IDiagram = this.openedDiagrams.find((diagram: IDiagram) => {
         return diagram.uri === diagramStateListEntry.uri;
       });
+
+      const diagramNotFound: boolean = diagramToSave === undefined;
+      if (diagramNotFound) {
+        return;
+      }
 
       diagramToSave.xml = diagramStateListEntry.diagramState.data.xml;
 
@@ -843,16 +839,6 @@ export class SolutionExplorerSolution {
 
       await this.waitForSaving();
     }
-  }
-
-  private saveActiveDiagram(): Promise<void> {
-    return new Promise((resolve: Function) => {
-      this.eventAggregator.subscribeOnce(environment.events.diagramDetail.saveDiagramDone, () => {
-        resolve();
-      });
-
-      this.eventAggregator.publish(environment.events.diagramDetail.saveDiagram);
-    });
   }
 
   private wait500ms(): Promise<void> {

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -840,7 +840,7 @@ export class SolutionExplorerSolution {
 
       const diagramNotFound: boolean = diagramToSave === undefined;
       if (diagramNotFound) {
-        return;
+        continue;
       }
 
       this.currentlySavingDiagramName = diagramToSave.name;

--- a/src/services/deploy-diagram-service/deploy-diagram.service.ts
+++ b/src/services/deploy-diagram-service/deploy-diagram.service.ts
@@ -1,0 +1,194 @@
+import {inject} from 'aurelia-framework';
+import {EventAggregator} from 'aurelia-event-aggregator';
+import {Router} from 'aurelia-router';
+
+import {IDiagram} from '@process-engine/solutionexplorer.contracts';
+import * as bundle from '@process-engine/bpmn-js-custom-bundle';
+
+import {IModdleElement} from '@process-engine/bpmn-elements_contracts';
+import environment from '../../environment';
+import {SolutionService} from '../solution-service/SolutionService';
+import {SaveDiagramService} from '../save-diagram-service/save-diagram.service';
+import {IBpmnModdle, IBpmnModeler, IDefinition, ISolutionEntry, NotificationType} from '../../contracts/index';
+import {NotificationService} from '../notification-service/notification.service';
+
+@inject(EventAggregator, 'SolutionService', SaveDiagramService, Router, 'NotificationService')
+export class DeployDiagramService {
+  private router: Router;
+  private eventAggregator: EventAggregator;
+  private notificationService: NotificationService;
+
+  private solutionService: SolutionService;
+  private saveDiagramService: SaveDiagramService;
+
+  private modeler: IBpmnModeler;
+  private moddle: IBpmnModdle;
+
+  constructor(
+    eventAggregator: EventAggregator,
+    solutionService: SolutionService,
+    saveDiagramService: SaveDiagramService,
+    router: Router,
+    notificationService: NotificationService,
+  ) {
+    this.eventAggregator = eventAggregator;
+    this.solutionService = solutionService;
+    this.saveDiagramService = saveDiagramService;
+    this.router = router;
+    this.notificationService = notificationService;
+
+    // eslint-disable-next-line 6river/new-cap
+    this.modeler = new bundle.modeler({
+      moddleExtensions: {
+        camunda: bundle.camundaModdleDescriptor,
+      },
+    });
+
+    this.moddle = this.modeler.get('moddle');
+  }
+
+  public async deployDiagram(solution: ISolutionEntry, diagram: IDiagram, xml?: string): Promise<void> {
+    const diagramHasChanges: boolean = xml !== undefined;
+    if (diagramHasChanges) {
+      const shouldSaveDiagram: boolean = await this.shouldSaveDiagram();
+
+      if (shouldSaveDiagram) {
+        this.saveDiagramService.saveDiagram(solution, diagram, xml);
+      } else {
+        return;
+      }
+    }
+
+    const remoteSolutionToDeployTo: ISolutionEntry = await this.getRemoteSolutionToDeployTo();
+    if (remoteSolutionToDeployTo === undefined) {
+      return;
+    }
+
+    await this.uploadProcess(remoteSolutionToDeployTo, diagram);
+  }
+
+  private async uploadProcess(solutionToDeployTo: ISolutionEntry, diagram: IDiagram): Promise<void> {
+    const processModelId: string = await this.getProcessModelIdForXml(diagram.xml);
+
+    const diagramIsAlreadyDeployed: boolean = await this.diagramIsAlreadyDeployed(solutionToDeployTo, processModelId);
+    if (diagramIsAlreadyDeployed) {
+      const shouldOverwriteDiagram: boolean = await this.shouldOverwriteDiagram();
+
+      if (!shouldOverwriteDiagram) {
+        return;
+      }
+    }
+
+    try {
+      diagram.id = processModelId;
+
+      const bpmnFileSuffix: string = '.bpmn';
+
+      const diagramUriWithoutSuffix: string = diagram.uri.endsWith(bpmnFileSuffix)
+        ? diagram.uri.slice(0, bpmnFileSuffix.length)
+        : diagram.uri;
+
+      const copyOfDiagram: IDiagram = {
+        id: diagram.id,
+        name: diagram.name,
+        uri: diagramUriWithoutSuffix,
+        xml: diagram.xml,
+      };
+
+      await solutionToDeployTo.service.saveDiagram(copyOfDiagram, solutionToDeployTo.uri);
+
+      const deployedDiagram: IDiagram = await solutionToDeployTo.service.loadDiagram(processModelId);
+
+      this.router.navigateToRoute('design', {
+        diagramName: deployedDiagram.name,
+        solutionUri: solutionToDeployTo.uri,
+      });
+
+      this.notificationService.showNotification(
+        NotificationType.SUCCESS,
+        'Diagram was successfully uploaded to the connected ProcessEngine.',
+      );
+
+      this.eventAggregator.publish(environment.events.diagramDetail.onDiagramDeployed, processModelId);
+    } catch (error) {
+      this.notificationService.showNotification(NotificationType.ERROR, `Unable to update diagram: ${error}.`);
+    }
+  }
+
+  private async getProcessModelIdForXml(xml: string): Promise<string> {
+    return new Promise((resolve: Function, reject: Function): void => {
+      this.moddle.fromXML(xml, (error: Error, definitions: IDefinition): void => {
+        const errorOccured: boolean = error !== undefined;
+        if (errorOccured) {
+          reject(error);
+        }
+
+        // eslint-disable-next-line no-underscore-dangle
+        const rootElements: Array<IModdleElement> = definitions.rootElements;
+
+        const processModel: IModdleElement = rootElements.find((definition: IModdleElement) => {
+          return definition.$type === 'bpmn:Process';
+        });
+        const processModelId: string = processModel.id;
+
+        resolve(processModelId);
+      });
+    });
+  }
+
+  private async diagramIsAlreadyDeployed(solution: ISolutionEntry, processModelId: string): Promise<boolean> {
+    try {
+      await solution.service.loadDiagram(processModelId);
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private get multipleRemoteSolutionsExist(): boolean {
+    const remoteSolutions = this.solutionService.getRemoteSolutionEntries();
+
+    return remoteSolutions.length > 1;
+  }
+
+  private get firstRemoteSolution(): ISolutionEntry {
+    const remoteSolutions = this.solutionService.getRemoteSolutionEntries();
+
+    return remoteSolutions[0];
+  }
+
+  private shouldOverwriteDiagram(): Promise<boolean> {
+    return new Promise((resolve: Function): void => {
+      this.eventAggregator.publish(
+        environment.events.deployModals.showOverwriteDiagramModal,
+        (shouldOverwrite: boolean) => {
+          resolve(shouldOverwrite);
+        },
+      );
+    });
+  }
+
+  private shouldSaveDiagram(): Promise<boolean> {
+    return new Promise((resolve: Function): void => {
+      this.eventAggregator.publish(environment.events.deployModals.showSaveBeforeDeployModal, (shouldSave: boolean) => {
+        resolve(shouldSave);
+      });
+    });
+  }
+
+  private getRemoteSolutionToDeployTo(): Promise<ISolutionEntry> {
+    return new Promise((resolve: Function): void => {
+      if (this.multipleRemoteSolutionsExist) {
+        this.eventAggregator.publish(
+          environment.events.deployModals.showRemoteSolutionSelectionModal,
+          (selectedRemoteSolution: ISolutionEntry) => {
+            resolve(selectedRemoteSolution);
+          },
+        );
+      } else {
+        resolve(this.firstRemoteSolution);
+      }
+    });
+  }
+}

--- a/src/services/deploy-diagram-service/deploy-diagram.service.ts
+++ b/src/services/deploy-diagram-service/deploy-diagram.service.ts
@@ -50,13 +50,7 @@ export class DeployDiagramService {
   public async deployDiagram(solution: ISolutionEntry, diagram: IDiagram, xml?: string): Promise<void> {
     const diagramHasChanges: boolean = xml !== undefined;
     if (diagramHasChanges) {
-      const shouldSaveDiagram: boolean = await this.shouldSaveDiagram();
-
-      if (shouldSaveDiagram) {
-        this.saveDiagramService.saveDiagram(solution, diagram, xml);
-      } else {
-        return;
-      }
+      diagram.xml = xml;
     }
 
     const remoteSolutionToDeployTo: ISolutionEntry = await this.getRemoteSolutionToDeployTo();

--- a/src/services/deploy-diagram-service/index.ts
+++ b/src/services/deploy-diagram-service/index.ts
@@ -1,0 +1,6 @@
+import {FrameworkConfiguration} from 'aurelia-framework';
+import {DeployDiagramService} from './deploy-diagram.service';
+
+export function configure(config: FrameworkConfiguration): void {
+  config.container.registerSingleton('DeployDiagramService', DeployDiagramService);
+}

--- a/src/services/save-diagram-service/index.ts
+++ b/src/services/save-diagram-service/index.ts
@@ -1,0 +1,6 @@
+import {FrameworkConfiguration} from 'aurelia-framework';
+import {SaveDiagramService} from './save-diagram.service';
+
+export function configure(config: FrameworkConfiguration): void {
+  config.container.registerSingleton('SaveDiagramService', SaveDiagramService);
+}

--- a/src/services/save-diagram-service/save-diagram.service.ts
+++ b/src/services/save-diagram-service/save-diagram.service.ts
@@ -88,7 +88,7 @@ export class SaveDiagramService {
         this.openDiagramStateService.updateDiagramState(diagramToSave.uri, diagramState);
       }
 
-      this.eventAggregator.publish(environment.events.navBar.diagramChangesResolved);
+      this.eventAggregator.publish(environment.events.diagramWasSaved, diagramToSave.uri);
     } catch (error) {
       this.notificationService.showNotification(NotificationType.ERROR, `Unable to save the file: ${error}.`);
 
@@ -168,8 +168,6 @@ export class SaveDiagramService {
       } else {
         this.openDiagramStateService.saveDiagramState(path, diagram.xml, undefined, undefined, false);
       }
-
-      this.eventAggregator.publish(environment.events.navBar.diagramChangesResolved);
     } catch (error) {
       this.notificationService.showNotification(NotificationType.ERROR, `Unable to save the file: ${error}.`);
 
@@ -204,7 +202,7 @@ export class SaveDiagramService {
     });
 
     this.eventAggregator.subscribeOnce('router:navigation:success', () => {
-      this.eventAggregator.publish(environment.events.navBar.diagramChangesResolved);
+      this.eventAggregator.publish(environment.events.diagramWasSaved, diagramToSave.uri);
     });
 
     setTimeout(() => {

--- a/src/services/save-diagram-service/save-diagram.service.ts
+++ b/src/services/save-diagram-service/save-diagram.service.ts
@@ -141,7 +141,21 @@ export class SaveDiagramService {
     };
 
     try {
+      this.openDiagramStateService.saveDiagramState(pathToSaveTo, diagram.xml, undefined, undefined, false, [
+        {
+          change: 'save',
+          xml: xml,
+        },
+      ]);
+
       await solutionToSaveTo.service.saveDiagram(diagram, pathToSaveTo);
+
+      const diagramState: IDiagramState | null = this.openDiagramStateService.loadDiagramState(pathToSaveTo);
+      if (diagramState !== null) {
+        diagramState.metadata.isChanged = false;
+
+        this.openDiagramStateService.updateDiagramState(pathToSaveTo, diagramState);
+      }
 
       const diagramChange: Array<DiagramStateChange> = [{change: 'save', xml: diagram.xml}];
       const previousDiagramsState: IDiagramState | null = this.openDiagramStateService.loadDiagramState(diagram.uri);

--- a/src/services/save-diagram-service/save-diagram.service.ts
+++ b/src/services/save-diagram-service/save-diagram.service.ts
@@ -141,12 +141,10 @@ export class SaveDiagramService {
     };
 
     try {
-      this.openDiagramStateService.saveDiagramState(pathToSaveTo, diagram.xml, undefined, undefined, false, [
-        {
-          change: 'save',
-          xml: xml,
-        },
-      ]);
+      this.openDiagramStateService.saveDiagramState(pathToSaveTo, diagram.xml, undefined, undefined, false, {
+        change: 'save',
+        xml: xml,
+      });
 
       await solutionToSaveTo.service.saveDiagram(diagram, pathToSaveTo);
 
@@ -157,12 +155,12 @@ export class SaveDiagramService {
         this.openDiagramStateService.updateDiagramState(pathToSaveTo, diagramState);
       }
 
-      const diagramChange: Array<DiagramStateChange> = [{change: 'save', xml: diagram.xml}];
+      const diagramChange: DiagramStateChange = {change: 'save', xml: diagram.xml};
       const previousDiagramsState: IDiagramState | null = this.openDiagramStateService.loadDiagramState(diagram.uri);
 
       const previousDiagramHasState: boolean = previousDiagramsState !== null;
       if (previousDiagramHasState) {
-        previousDiagramsState.metadata.changes = diagramChange;
+        previousDiagramsState.metadata.change = diagramChange;
 
         this.openDiagramStateService.updateDiagramState(path, previousDiagramsState);
       } else {

--- a/src/services/save-diagram-service/save-diagram.service.ts
+++ b/src/services/save-diagram-service/save-diagram.service.ts
@@ -91,6 +91,10 @@ export class SaveDiagramService {
 
       throw error;
     }
+
+    setTimeout(() => {
+      this.isSaving = false;
+    }, 500);
   }
 
   public async saveDiagramAs(

--- a/src/services/save-diagram-service/save-diagram.service.ts
+++ b/src/services/save-diagram-service/save-diagram.service.ts
@@ -199,9 +199,7 @@ export class SaveDiagramService {
       solutionUri: solutionToSaveTo.uri,
     });
 
-    this.eventAggregator.subscribeOnce('router:navigation:success', () => {
-      this.eventAggregator.publish(environment.events.diagramWasSaved, diagramToSave.uri);
-    });
+    this.eventAggregator.publish(environment.events.diagramWasSaved, diagramToSave.uri);
 
     setTimeout(() => {
       this.isSaving = false;

--- a/src/services/save-diagram-service/save-diagram.service.ts
+++ b/src/services/save-diagram-service/save-diagram.service.ts
@@ -81,6 +81,13 @@ export class SaveDiagramService {
 
       await solutionToSaveTo.service.saveDiagram(diagramToSave);
 
+      const diagramState: IDiagramState | null = this.openDiagramStateService.loadDiagramState(diagramToSave.uri);
+      if (diagramState !== null) {
+        diagramState.metadata.isChanged = false;
+
+        this.openDiagramStateService.updateDiagramState(diagramToSave.uri, diagramState);
+      }
+
       this.eventAggregator.publish(environment.events.navBar.diagramChangesResolved);
     } catch (error) {
       this.notificationService.showNotification(NotificationType.ERROR, `Unable to save the file: ${error}.`);

--- a/src/services/save-diagram-service/save-diagram.service.ts
+++ b/src/services/save-diagram-service/save-diagram.service.ts
@@ -1,0 +1,204 @@
+import {EventAggregator} from 'aurelia-event-aggregator';
+import {inject} from 'aurelia-framework';
+import {Router} from 'aurelia-router';
+
+import {IDiagram} from '@process-engine/solutionexplorer.contracts';
+
+import {DiagramStateChange, IDiagramState, ISolutionEntry, NotificationType} from '../../contracts/index';
+import environment from '../../environment';
+import {NotificationService} from '../notification-service/notification.service';
+import {OpenDiagramsSolutionExplorerService} from '../solution-explorer-services/OpenDiagramsSolutionExplorerService';
+import {SolutionService} from '../solution-service/SolutionService';
+import {OpenDiagramStateService} from '../solution-explorer-services/OpenDiagramStateService';
+
+@inject(EventAggregator, NotificationService, 'OpenDiagramService', 'SolutionService', Router, OpenDiagramStateService)
+export class SaveDiagramService {
+  private eventAggregator: EventAggregator;
+  private notificationService: NotificationService;
+  private openDiagramStateService: OpenDiagramStateService;
+  private openDiagramService: OpenDiagramsSolutionExplorerService;
+  private solutionService: SolutionService;
+  private router: Router;
+  private ipcRenderer: any;
+
+  private isSaving: boolean = false;
+
+  constructor(
+    eventAggregator: EventAggregator,
+    notificationService: NotificationService,
+    openDiagramService: OpenDiagramsSolutionExplorerService,
+    solutionService: SolutionService,
+    router: Router,
+    openDiagramStateService: OpenDiagramStateService,
+  ) {
+    this.eventAggregator = eventAggregator;
+    this.notificationService = notificationService;
+    this.openDiagramService = openDiagramService;
+    this.solutionService = solutionService;
+    this.router = router;
+    this.openDiagramStateService = openDiagramStateService;
+
+    const isRunningInElectron: boolean = Boolean((window as any).nodeRequire);
+    if (isRunningInElectron) {
+      this.ipcRenderer = (window as any).nodeRequire('electron').ipcRenderer;
+    }
+  }
+
+  /**
+   * Saves the current diagram.
+   */
+  public async saveDiagram(solutionToSaveTo: ISolutionEntry, activeDiagram: IDiagram, xml: string): Promise<void> {
+    if (this.isSaving) {
+      return;
+    }
+    this.isSaving = true;
+
+    const savingTargetIsRemoteSolution: boolean = solutionToSaveTo.uri.startsWith('http');
+    if (savingTargetIsRemoteSolution) {
+      setTimeout(() => {
+        this.isSaving = false;
+      }, 500);
+
+      return;
+    }
+
+    const diagramIsUnsavedDiagram: boolean = activeDiagram.uri.startsWith('about:open-diagrams');
+    if (diagramIsUnsavedDiagram) {
+      this.isSaving = false;
+
+      await this.saveDiagramAs(solutionToSaveTo, activeDiagram, xml);
+
+      return;
+    }
+
+    try {
+      activeDiagram.xml = xml;
+
+      this.openDiagramStateService.setDiagramChange(activeDiagram.uri, {
+        change: 'save',
+        xml: xml,
+      });
+
+      await solutionToSaveTo.service.saveDiagram(activeDiagram);
+
+      this.eventAggregator.publish(environment.events.navBar.diagramChangesResolved);
+    } catch (error) {
+      this.notificationService.showNotification(NotificationType.ERROR, `Unable to save the file: ${error}.`);
+
+      setTimeout(() => {
+        this.isSaving = false;
+      }, 500);
+
+      throw error;
+    }
+  }
+
+  public async saveDiagramAs(
+    solutionToSaveTo: ISolutionEntry,
+    activeDiagram: IDiagram,
+    xml: string,
+    path?: string,
+  ): Promise<void> {
+    const isRemoteSolution: boolean = activeDiagram.uri.startsWith('http');
+    if (isRemoteSolution || this.isSaving) {
+      return;
+    }
+
+    this.isSaving = true;
+
+    const pathIsSet: boolean = path !== undefined;
+    const pathToSaveTo: string = pathIsSet ? path : await this.getPathToSaveTo();
+
+    const diagramIsUnsaved: boolean = activeDiagram.uri.startsWith('about:open-diagrams');
+    if (diagramIsUnsaved) {
+      const lastIndexOfSlash: number = pathToSaveTo.lastIndexOf('/');
+      const lastIndexOfBackSlash: number = pathToSaveTo.lastIndexOf('\\');
+      const indexBeforeFilename: number = Math.max(lastIndexOfSlash, lastIndexOfBackSlash) + 1;
+
+      const filename: string = pathToSaveTo.slice(indexBeforeFilename, pathToSaveTo.length).replace('.bpmn', '');
+
+      const temporaryDiagramName: string = activeDiagram.uri.replace('about:open-diagrams/', '').replace('.bpmn', '');
+
+      xml = xml.replace(new RegExp(temporaryDiagramName, 'g'), filename);
+    }
+
+    const diagram: IDiagram = {
+      name: activeDiagram.name,
+      id: activeDiagram.id,
+      uri: activeDiagram.uri,
+      xml: xml,
+    };
+
+    try {
+      await solutionToSaveTo.service.saveDiagram(diagram, pathToSaveTo);
+
+      const diagramChange: Array<DiagramStateChange> = [{change: 'save', xml: diagram.xml}];
+      const previousDiagramsState: IDiagramState | null = this.openDiagramStateService.loadDiagramState(diagram.uri);
+
+      const previousDiagramHasState: boolean = previousDiagramsState !== null;
+      if (previousDiagramHasState) {
+        previousDiagramsState.metadata.changes = diagramChange;
+
+        this.openDiagramStateService.updateDiagramState(path, previousDiagramsState);
+      } else {
+        this.openDiagramStateService.saveDiagramState(path, diagram.xml, undefined, undefined, false);
+      }
+
+      this.eventAggregator.publish(environment.events.navBar.diagramChangesResolved);
+    } catch (error) {
+      this.notificationService.showNotification(NotificationType.ERROR, `Unable to save the file: ${error}.`);
+
+      setTimeout(() => {
+        this.isSaving = false;
+      }, 500);
+
+      throw error;
+    }
+
+    await this.openDiagramService.closeDiagram(activeDiagram);
+    this.solutionService.removeOpenDiagramByUri(activeDiagram.uri);
+
+    try {
+      activeDiagram = await this.openDiagramService.openDiagram(pathToSaveTo, solutionToSaveTo.identity);
+      this.solutionService.addOpenDiagram(activeDiagram);
+    } catch {
+      const alreadyOpenedDiagram: IDiagram = await this.openDiagramService.getOpenedDiagramByURI(pathToSaveTo);
+
+      await this.openDiagramService.closeDiagram(alreadyOpenedDiagram);
+
+      activeDiagram = await this.openDiagramService.openDiagram(pathToSaveTo, solutionToSaveTo.identity);
+    }
+
+    xml = activeDiagram.xml;
+    solutionToSaveTo = this.solutionService.getSolutionEntryForUri('about:open-diagrams');
+
+    await this.router.navigateToRoute('design', {
+      diagramName: activeDiagram.name,
+      diagramUri: activeDiagram.uri,
+      solutionUri: solutionToSaveTo.uri,
+    });
+
+    this.eventAggregator.subscribeOnce('router:navigation:success', () => {
+      this.eventAggregator.publish(environment.events.navBar.diagramChangesResolved);
+    });
+
+    setTimeout(() => {
+      this.isSaving = false;
+    }, 500);
+  }
+
+  private async getPathToSaveTo(): Promise<string> {
+    return new Promise((resolve: Function, reject: Function): void => {
+      this.ipcRenderer.once('save_diagram_as', async (event: Event, savePath: string) => {
+        const noFileSelected: boolean = savePath === null;
+        if (noFileSelected) {
+          reject(new Error('No file was selected.'));
+        }
+
+        resolve(savePath);
+      });
+
+      this.ipcRenderer.send('open_save-diagram-as_dialog');
+    });
+  }
+}

--- a/src/services/solution-explorer-services/OpenDiagramsSolutionExplorerService.ts
+++ b/src/services/solution-explorer-services/OpenDiagramsSolutionExplorerService.ts
@@ -193,7 +193,7 @@ export class OpenDiagramsSolutionExplorerService implements ISolutionExplorerSer
 
               const diagramWasChangedByStudio: boolean =
                 (change !== undefined && (change.change === 'save' && change.xml === xml)) ||
-                change.change === 'create';
+                (change !== undefined && change.change === 'create');
 
               if (diagramWasChangedByStudio) {
                 isSaving = false;


### PR DESCRIPTION
## Changes

1. Move Saving to Save Diagram Service
2. Move Deploying to Deploy Diagram Service
3. Add Context Menu Entry for Deploying
4. Fix Saving All Diagrams
5. Add 'Saving Diagrams' Modal

## Issues

Closes #1395
Closes #1710 

PR: #1696

## How to test the changes

- Check if saving/save as is still possible via 'Design'

- Check if deploying is still possible via 'Design'

- Right click on a diagram from a local solution
- Click on Deploy
- **Notice that the diagram will be deployed.**
