### PR TITLE
✨ Persists Property Panel Input Heights

### DIFF
--- a/src/modules/design/property-panel/indextabs/general/sections/basics/basics.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/basics/basics.html
@@ -27,7 +27,7 @@
         <tr>
           <td>
               Docs <a class="docs-enlarge-link" click.delegate="showModal = true"><small class="docs-enlarge-text">Enlarge</small></a>
-            <textarea type="text" class="props-input-textarea" value.bind="elementDocumentation" change.delegate="updateDocumentation()" disabled.bind="!isEditable" aria-multiline="true"></textarea>
+            <textarea type="text" ref="docsInput" class="props-input-textarea" value.bind="elementDocumentation" change.delegate="updateDocumentation()" disabled.bind="!isEditable" aria-multiline="true"></textarea>
           </td>
         </tr>
       </table>

--- a/src/modules/design/property-panel/indextabs/general/sections/basics/basics.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/basics/basics.ts
@@ -24,6 +24,8 @@ export class BasicsSection implements ISection {
   public showModal: boolean = false;
   public elementType: string;
 
+  public docsInput: HTMLElement;
+
   private modeling: IModeling;
   private modeler: IBpmnModeler;
   private bpmnModdle: IBpmnModdle;
@@ -60,10 +62,19 @@ export class BasicsSection implements ISection {
     this.setValidationRules();
   }
 
+  public attached(): void {
+    this.recoverInputHeight();
+
+    this.saveInputHeightOnChange();
+  }
+
   public detached(): void {
+    this.docsInput.removeEventListener('mousedown', this.saveInputHeightOnMouseUp);
+
     if (!this.validationError) {
       return;
     }
+
     this.businessObjInPanel.id = this.previousProcessRefId;
     this.validationController.validate();
   }
@@ -195,6 +206,22 @@ export class BasicsSection implements ISection {
       .withMessage('ID already exists.')
       .on(this.businessObjInPanel);
   }
+
+  private saveInputHeightOnChange(): void {
+    this.docsInput.addEventListener('mousedown', this.saveInputHeightOnMouseUp);
+  }
+
+  private recoverInputHeight(): void {
+    this.docsInput.style.height = `${localStorage.getItem('docsInputHeight')}px`;
+  }
+
+  private saveInputHeightOnMouseUp: EventListenerOrEventListenerObject = () => {
+    const resizeListenerFunction: EventListenerOrEventListenerObject = (): void => {
+      localStorage.setItem('docsInputHeight', this.docsInput.clientHeight.toString());
+      window.removeEventListener('mouseup', resizeListenerFunction);
+    };
+    window.addEventListener('mouseup', resizeListenerFunction);
+  };
 
   private publishDiagramChange(): void {
     this.eventAggregator.publish(environment.events.diagramChange);

--- a/src/modules/design/property-panel/indextabs/general/sections/script-task/script-task.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/script-task/script-task.html
@@ -8,7 +8,7 @@
         <tr>
           <th>Script</th>
           <td>
-            <textarea class="props-textarea name-input" value.bind="businessObjInPanel.script" change.delegate="updateScript()" disabled.bind="!isEditable"></textarea>
+            <textarea class="props-textarea name-input" ref="scriptInput" value.bind="businessObjInPanel.script" change.delegate="updateScript()" disabled.bind="!isEditable"></textarea>
           </td>
         </tr>
       </table>

--- a/src/modules/design/property-panel/indextabs/general/sections/script-task/script-task.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/script-task/script-task.ts
@@ -12,6 +12,8 @@ export class ScriptTaskSection implements ISection {
   public canHandleElement: boolean = false;
   public businessObjInPanel: IScriptTaskElement;
 
+  public scriptInput: HTMLElement;
+
   private eventAggregator: EventAggregator;
 
   constructor(eventAggregator?: EventAggregator) {
@@ -20,6 +22,16 @@ export class ScriptTaskSection implements ISection {
 
   public activate(model: IPageModel): void {
     this.businessObjInPanel = model.elementInPanel.businessObject;
+  }
+
+  public attached(): void {
+    this.recoverInputHeight();
+
+    this.saveInputHeightOnChange();
+  }
+
+  public detached(): void {
+    this.scriptInput.removeEventListener('mousedown', this.saveInputHeightOnMouseUp);
   }
 
   public isSuitableForElement(element: IShape): boolean {
@@ -37,6 +49,22 @@ export class ScriptTaskSection implements ISection {
       element.businessObject.$type === 'bpmn:ScriptTask'
     );
   }
+
+  private saveInputHeightOnChange(): void {
+    this.scriptInput.addEventListener('mousedown', this.saveInputHeightOnMouseUp);
+  }
+
+  private recoverInputHeight(): void {
+    this.scriptInput.style.height = `${localStorage.getItem('scriptTaskInputHeight')}px`;
+  }
+
+  private saveInputHeightOnMouseUp: EventListenerOrEventListenerObject = () => {
+    const resizeListenerFunction: EventListenerOrEventListenerObject = (): void => {
+      localStorage.setItem('scriptTaskInputHeight', this.scriptInput.clientHeight.toString());
+      window.removeEventListener('mouseup', resizeListenerFunction);
+    };
+    window.addEventListener('mouseup', resizeListenerFunction);
+  };
 
   private publishDiagramChange(): void {
     this.eventAggregator.publish(environment.events.diagramChange);

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.html
@@ -14,7 +14,7 @@
         <tr>
           <th>Payload<a class="payload-enlarge-link" click.delegate="showModal = true"><small class="payload-enlarge-text">Enlarge</small></a></th>
           <td>
-            <textarea class="props-textarea name-input" value.bind="selectedPayload" change.delegate="payloadChanged()" disabled.bind="!model.isEditable"></textarea>
+            <textarea class="props-textarea name-input" ref="payloadInput" value.bind="selectedPayload" change.delegate="payloadChanged()" disabled.bind="!model.isEditable"></textarea>
           </td>
         </tr>
     </div>

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.ts
@@ -15,11 +15,23 @@ export class ExternalTask {
   public selectedPayload: string;
   public showModal: boolean = false;
 
+  public payloadInput: HTMLElement;
+
   private eventAggregator: EventAggregator;
   private serviceTaskService: ServiceTaskService;
 
   constructor(eventAggregator?: EventAggregator) {
     this.eventAggregator = eventAggregator;
+  }
+
+  public attached(): void {
+    this.recoverInputHeight();
+
+    this.saveInputHeightOnChange();
+  }
+
+  public detached(): void {
+    this.payloadInput.removeEventListener('mousedown', this.saveInputHeightOnMouseUp);
   }
 
   public modelChanged(): void {
@@ -63,6 +75,22 @@ export class ExternalTask {
 
     payloadProperty.value = value;
   }
+
+  private saveInputHeightOnChange(): void {
+    this.payloadInput.addEventListener('mousedown', this.saveInputHeightOnMouseUp);
+  }
+
+  private recoverInputHeight(): void {
+    this.payloadInput.style.height = `${localStorage.getItem('externalTaskPayloadInputHeight')}px`;
+  }
+
+  private saveInputHeightOnMouseUp: EventListenerOrEventListenerObject = () => {
+    const resizeListenerFunction: EventListenerOrEventListenerObject = (): void => {
+      localStorage.setItem('externalTaskPayloadInputHeight', this.payloadInput.clientHeight.toString());
+      window.removeEventListener('mouseup', resizeListenerFunction);
+    };
+    window.addEventListener('mouseup', resizeListenerFunction);
+  };
 
   private publishDiagramChange(): void {
     this.eventAggregator.publish(environment.events.diagramChange);


### PR DESCRIPTION
## Changes

1. Save Input Height of ScriptTask Input Field
2. Save Input Height of ExternalTask Payload Input Field
3. Save Input Height of Docs Input Field

## Issues

Closes #1681 

PR: #1697

## How to test the changes

- Open up a diagram
- Click on a ScriptTask/External Task/anything
- Resize the resizable inputs
- Reload or change the diagram
- **Notice that the inputs will keep their height.**
