### PR TITLE
🐛 Fix Icon Path for About Window

### DIFF
--- a/electron_app/electron.ts
+++ b/electron_app/electron.ts
@@ -731,7 +731,9 @@ function getAboutWindowInfo(): AboutWindowInfo {
   const copyrightYear: number = new Date().getFullYear();
 
   return {
-    icon_path: path.join(__dirname, '../../../build/icon.png'),
+    icon_path: releaseChannel.isDev()
+      ? path.join(__dirname, '../../../build/icon.png')
+      : path.join(__dirname, '../../../../../build/icon.png'),
     product_name: getProductName(),
     bug_report_url: 'https://github.com/process-engine/bpmn-studio/issues/new',
     homepage: 'www.process-engine.io',


### PR DESCRIPTION
## Changes

1. Fix Icon Path for About Window

PR: #1715 

## How to test the changes

- Open the About Window
- **Notice that the BPMN Studio icon will be displayed**
