### PR TITLE
🐛 Fix Active Diagram Highlighting in SolutionExplorer

### DIFF
--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -1343,7 +1343,14 @@ export class SolutionExplorerSolution {
       try {
         const activeSolution: ISolution = await this.solutionService.loadSolution();
         this.activeDiagram = activeSolution.diagrams.find((diagram: IDiagram) => {
-          return diagram.name === diagramName && (diagram.uri === diagramUri || diagramUri === undefined);
+          const currentDiagramIsGivenDiagram: boolean = diagram.uri === diagramUri;
+
+          const solutionIsRemoteSolution: boolean = solutionUri.startsWith('http');
+          const diagramIsInGivenSolution: boolean = solutionIsRemoteSolution
+            ? diagram.uri.includes(solutionUri)
+            : diagram.uri.includes(`${solutionUri}/${diagram.name}.bpmn`);
+
+          return diagram.name === diagramName && (currentDiagramIsGivenDiagram || diagramIsInGivenSolution);
         });
       } catch {
         // Do nothing


### PR DESCRIPTION
## Changes

1. Fix Active Diagram Highlighting in SolutionExplorer

## Issues

Closes #1695

PR: #1723

## How to test the changes

- Open multiple solutions that contain the same diagram
- Deploy the diagram
- **Notice that only the diagram entry of the remote solution is highlighted.**