### PR TITLE
🐛 Fix bug where no correlations found message was displayed after a reload

### DIFF
--- a/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.ts
+++ b/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.ts
@@ -27,7 +27,7 @@ export class DiagramViewer {
   @bindable public activeDiagram: IDiagram;
   @bindable public selectedFlowNode: IShape;
   @bindable public activeSolutionEntry: ISolutionEntry;
-  public noCorrelationsFound: boolean = true;
+  public noCorrelationsFound: boolean;
   public xmlIsNotSelected: boolean = true;
   public canvasModel: HTMLElement;
 
@@ -54,6 +54,9 @@ export class DiagramViewer {
   }
 
   public attached(): void {
+    if (!this.activeDiagram) {
+      this.noCorrelationsFound = true;
+    }
     // eslint-disable-next-line 6river/new-cap
     this.diagramViewer = new bundle.viewer({
       additionalModules: [bundle.ZoomScrollModule, bundle.MoveCanvasModule],
@@ -233,6 +236,10 @@ export class DiagramViewer {
 
     if (diagramViewerIsNotSet) {
       return;
+    }
+
+    if (!this.activeDiagram) {
+      this.noCorrelationsFound = true;
     }
 
     this.diagramViewer.clear();

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/components/correlation-list/correlation-list.ts
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/components/correlation-list/correlation-list.ts
@@ -47,6 +47,10 @@ export class CorrelationList {
   }
 
   public correlationsChanged(): void {
+    if (!this.activeDiagram) {
+      return;
+    }
+
     const processInstancesWithCorrelation = this.getProcessInstancesWithCorrelations(
       this.correlations,
       this.activeDiagram.id,


### PR DESCRIPTION
## Changes

1. Fix displaying `No Correlations found` message

## Issues

Closes #1745 

PR: #1750 

## How to test the changes

> Describe how others can test your changes (not required when fixing typos, linter errors and such)
