### PR TITLE
👷 Prevent builds for automated commits

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,9 @@ def buildIsRequired = true
 
 pipeline {
   agent any
+  options {
+    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20'))
+  }
   tools {
     nodejs "node-lts"
   }


### PR DESCRIPTION
## Changes

1. Refactor CI Pipeline to keep only the last 20 builds
2. Add step `Check if build is required` to check if a commit was made by the CI user
3. Add `expression {buildIsRequired == true}` condition to all steps to skip builds for ci user commits

## Issues

PR: #1760

## How to test the changes

Run some builds.