### PR TITLE
🐛 Fix aurelia-validation build error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2798,12 +2798,12 @@
       }
     },
     "aurelia-validation": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/aurelia-validation/-/aurelia-validation-1.4.0.tgz",
-      "integrity": "sha512-UPI+Ui6TthIp/V27u3ME8IMtbeyUvULpOJWAzD24R2qIUebLGersjBPEd99nJsE2MeGeiQZ9/bwB/y4R1fV0iQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/aurelia-validation/-/aurelia-validation-1.5.0.tgz",
+      "integrity": "sha512-kwZTlo49SlWyDnOiHcJ5CsoHE5w/XxjzF526oJ9T1rvQT1n4pzicsUnH1ey+mQ1vCc3dEM3ysn91zOWfbR//iw==",
       "requires": {
         "aurelia-binding": "^2.1.5",
-        "aurelia-dependency-injection": "^1.4.1",
+        "aurelia-dependency-injection": "^1.5.0",
         "aurelia-logging": "^1.5.0",
         "aurelia-pal": "^1.8.0",
         "aurelia-task-queue": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@types/mocha": "^5.2.7",
     "about-window": "1.13.0",
     "aurelia-open-id-connect": "2.0.2",
-    "aurelia-validation": "1.4.0",
+    "aurelia-validation": "1.5.0",
     "bootstrap": "^4.3.1",
     "bpmn-js-differ": "2.0.2",
     "clipboard-polyfill": "2.8.1",


### PR DESCRIPTION
## Changes

Recently, a build error related to `aurelia-validation` came up.

See this build, for example:
https://ci.process-engine.io/blue/organizations/jenkins/process-engine_node-lts%2Fbpmn-studio/detail/develop/261/pipeline/62#step-125-log-104

Updating the package to 1.5.0 solves this issue.

## Issues

PR: #1761

## How to test the changes

- Build the application
- There should be no more errors