### PR TITLE
✨Start process with initial token

### DIFF
--- a/src/modules/design/design.html
+++ b/src/modules/design/design.html
@@ -62,6 +62,7 @@
           <textarea class="form-control input-field design-modal__textarea" id="initialToken" rows="4" placeholder="Put your JSON payload here." value.bind="origin.diagramDetail.initialToken"></textarea>
           <small class="form-text text-muted">
               Setting an initial token (JSON payload) is optional; use this if you want to start your process with parameter.
+              If the StartEvent has a TextAnnotation which starts with `StartToken:`, it is used as default token.
           </small>
         </div>
 

--- a/src/modules/design/design.html
+++ b/src/modules/design/design.html
@@ -62,7 +62,7 @@
           <textarea class="form-control input-field design-modal__textarea" id="initialToken" rows="4" placeholder="Put your JSON payload here." value.bind="origin.diagramDetail.initialToken"></textarea>
           <small class="form-text text-muted">
               Setting an initial token (JSON payload) is optional; use this if you want to start your process with parameter.
-              If the StartEvent has a TextAnnotation which starts with `StartToken:`, it is used as default token.
+              If the StartEvent has a TextAnnotation beginning with `StartToken:`, it is used as the default token.
           </small>
         </div>
 

--- a/src/modules/design/diagram-detail/diagram-detail.ts
+++ b/src/modules/design/diagram-detail/diagram-detail.ts
@@ -233,8 +233,12 @@ export class DiagramDetail {
 
     this.dropInvalidFormData();
 
+    this.getTokenFromStartEventAnnotation();
+    const defaultToken: any = this.getInitialTokenValues(this.initialToken);
+    const startToken = defaultToken === '' ? undefined : defaultToken;
+
     const startRequestPayload: DataModels.ProcessModels.ProcessStartRequestPayload = {
-      inputValues: parsedInitialToken,
+      inputValues: parsedInitialToken || startToken,
       correlationId: this.customCorrelationId,
     };
 


### PR DESCRIPTION
## Changes

1. Start a process with the modeled StartToken annotation as initial token payload

## Issues

PR: #1779 

## How to test the changes

- start a process
- start a process with the custom start modal
- start a process which contains a start event with a text annotation starting with `StartToken:`
- start a process with the custom start modal and a start event with a start token
- see that the expected token is used for starting the process
