### PR TITLE
🐛Refresh solutionentries and open solutions without an internal pe

### DIFF
--- a/electron_app/electron.ts
+++ b/electron_app/electron.ts
@@ -22,6 +22,7 @@ import open from 'open';
 
 import {CancellationToken, autoUpdater} from '@process-engine/electron-updater';
 import * as pe from '@process-engine/process_engine_runtime';
+import {version as ProcessEngineVersion} from '@process-engine/process_engine_runtime/package.json';
 
 import electronOidc from './electron-oidc';
 import oidcConfig from './oidc-config';
@@ -866,6 +867,10 @@ async function startInternalProcessEngine(): Promise<any> {
   // will be running; this 'get_host' request ist emitted in src/main.ts.
   ipcMain.on('get_host', (event: IpcMainEvent) => {
     event.returnValue = `localhost:${port}`;
+  });
+
+  ipcMain.on('get_version', (event: IpcMainEvent) => {
+    event.returnValue = ProcessEngineVersion;
   });
 
   // TODO: Check if the ProcessEngine instance is now run on the UI thread.

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,7 @@ export function configure(aurelia: Aurelia): void {
   if ((window as any).nodeRequire) {
     const ipcRenderer: any = (window as any).nodeRequire('electron').ipcRenderer;
     const newHost: string = ipcRenderer.sendSync('get_host');
-    const ProcessEngineVersion: string = ipcRenderer.sendSync('get_version');
+    const processEngineVersion: string = ipcRenderer.sendSync('get_version');
     /**
      * Currently the internal PE is always connected via http.
      * This will be subject to change.
@@ -25,7 +25,7 @@ export function configure(aurelia: Aurelia): void {
     const processEngineBaseRouteWithProtocol: string = `http://${newHost}`;
 
     localStorage.setItem('InternalProcessEngineRoute', processEngineBaseRouteWithProtocol);
-    localStorage.setItem('InternalProcessEngineVersion', ProcessEngineVersion);
+    localStorage.setItem('InternalProcessEngineVersion', processEngineVersion);
 
     aurelia.container.registerInstance('InternalProcessEngineBaseRoute', processEngineBaseRouteWithProtocol);
   } else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,7 @@ export function configure(aurelia: Aurelia): void {
   if ((window as any).nodeRequire) {
     const ipcRenderer: any = (window as any).nodeRequire('electron').ipcRenderer;
     const newHost: string = ipcRenderer.sendSync('get_host');
-
+    const ProcessEngineVersion: string = ipcRenderer.sendSync('get_version');
     /**
      * Currently the internal PE is always connected via http.
      * This will be subject to change.
@@ -25,11 +25,13 @@ export function configure(aurelia: Aurelia): void {
     const processEngineBaseRouteWithProtocol: string = `http://${newHost}`;
 
     localStorage.setItem('InternalProcessEngineRoute', processEngineBaseRouteWithProtocol);
+    localStorage.setItem('InternalProcessEngineVersion', ProcessEngineVersion);
 
     aurelia.container.registerInstance('InternalProcessEngineBaseRoute', processEngineBaseRouteWithProtocol);
   } else {
     (window as any).process = process;
     localStorage.setItem('InternalProcessEngineRoute', environment.baseRoute);
+    localStorage.setItem('InternalProcessEngineVersion', null);
     aurelia.container.registerInstance('InternalProcessEngineBaseRoute', null);
   }
 

--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.html
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.html
@@ -18,8 +18,8 @@
   
             <i class="fa ${solutionEntry.fontAwesomeIconClass} solution-entry__solution-icon" title.bind="solutionEntry.fontAwesomeIconClass === 'fa-bolt' ? 'ProcessEngine Disconnected!' : ''"></i>
     
-            <i if.bind="solutionEntry.uri.startsWith('http') && isProcessEngineNewerThanInternal(solutionEntry)" class="fas fa-info-circle version-info version-info--new" click.capture="showNewerModal($event)" title="ProcessEngine is newer. Click to show more information."></i>
-            <i if.bind="solutionEntry.uri.startsWith('http') && isProcessEngineOlderThanInternal(solutionEntry)" class="fas fa-info-circle version-info version-info--old" click.capture="showOlderModal($event)" title="ProcessEngine is outdated. Click to show more information."></i>
+            <i if.bind="solutionEntry.uri.startsWith('http') && isProcessEngineNewerThanInternal(solutionEntry) & signal:'update-version-icon'" class="fas fa-info-circle version-info version-info--new" click.capture="showNewerModal($event)" title="ProcessEngine is newer. Click to show more information."></i>
+            <i if.bind="solutionEntry.uri.startsWith('http') && isProcessEngineOlderThanInternal(solutionEntry) & signal:'update-version-icon'" class="fas fa-info-circle version-info version-info--old" click.capture="showOlderModal($event)" title="ProcessEngine is outdated. Click to show more information."></i>
 
             <span class="solution-entry__solution-name" data-test-solution-entry-name="${getSolutionName(solutionEntry.uri)}" data-test-solution-is-internal="${solutionIsInternalSolution(solutionEntry)}">${getSolutionName(solutionEntry.uri)}</span>
           </div>
@@ -82,7 +82,7 @@
         </div>
 
         <solution-explorer-solution
-          displayed-solution-entry.bind="solutionEntry"
+          displayed-solution-entry.two-way="solutionEntry"
           solution-service.bind="solutionEntry.service"
           open-diagram-service.bind="openDiagramService"
           view-model.ref="solutionEntryViewModels[solutionEntry.uri]"

--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
@@ -88,6 +88,7 @@ export class SolutionExplorerList {
     });
 
     this.internalSolutionUri = window.localStorage.getItem('InternalProcessEngineRoute');
+    this.internalProcessEngineVersion = window.localStorage.getItem('InternalProcessEngineVersion');
   }
 
   /**
@@ -182,7 +183,6 @@ export class SolutionExplorerList {
   public async openSolution(uri: string, insertAtBeginning: boolean = false, identity?: IIdentity): Promise<void> {
     this.solutionsToOpen.push(uri);
 
-    this.internalProcessEngineVersion = await this.getProcessEngineVersionFromInternalPE(this.internalSolutionUri);
     const uriIsRemote: boolean = uri.startsWith('http');
 
     let solutionExplorer: ISolutionExplorerService;

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -1,8 +1,9 @@
 /* eslint-disable max-lines */
 import {EventAggregator, Subscription} from 'aurelia-event-aggregator';
-import {NewInstance, bindable, computedFrom, inject} from 'aurelia-framework';
+import {NewInstance, bindable, computedFrom, inject, observable} from 'aurelia-framework';
 import {Router} from 'aurelia-router';
 import {ControllerValidateResult, ValidateResult, ValidationController, ValidationRules} from 'aurelia-validation';
+import {BindingSignaler} from 'aurelia-templating-resources';
 
 import {join} from 'path';
 
@@ -57,6 +58,7 @@ interface IDiagramCreationState extends IDiagramNameInputState {
   'OpenDiagramStateService',
   DeployDiagramService,
   SaveDiagramService,
+  BindingSignaler,
 )
 export class SolutionExplorerSolution {
   public activeDiagram: IDiagram;
@@ -66,7 +68,7 @@ export class SolutionExplorerSolution {
   // Fields below are bound from the html view.
   @bindable public solutionService: ISolutionExplorerService;
   @bindable public openDiagramService: OpenDiagramsSolutionExplorerService;
-  @bindable public displayedSolutionEntry: ISolutionEntry;
+  @bindable @observable public displayedSolutionEntry: ISolutionEntry;
   @bindable public fontAwesomeIconClass: string;
   public createNewDiagramInput: HTMLInputElement;
   public diagramContextMenu: HTMLElement;
@@ -116,6 +118,7 @@ export class SolutionExplorerSolution {
 
   private sortedDiagramsOfSolutions: Array<IDiagram> = [];
   private diagramStatesChangedCallbackId: string;
+  private signaler: BindingSignaler;
 
   constructor(
     router: Router,
@@ -127,6 +130,7 @@ export class SolutionExplorerSolution {
     openDiagramStateService: OpenDiagramStateService,
     deployDiagramService: DeployDiagramService,
     saveDiagramService: SaveDiagramService,
+    bindingSignaler: BindingSignaler,
   ) {
     this.router = router;
     this.eventAggregator = eventAggregator;
@@ -137,6 +141,7 @@ export class SolutionExplorerSolution {
     this.openDiagramStateService = openDiagramStateService;
     this.deployDiagramService = deployDiagramService;
     this.saveDiagramService = saveDiagramService;
+    this.signaler = bindingSignaler;
 
     this.updateDiagramStateList();
     this.diagramStatesChangedCallbackId = this.openDiagramStateService.onDiagramStatesChanged(() => {
@@ -277,6 +282,7 @@ export class SolutionExplorerSolution {
     try {
       this.openedSolution = await this.solutionService.loadSolution();
 
+      await this.updateSolutionEntry();
       const updatedDiagramList: Array<IDiagram> = this.displayedSolutionEntry.isOpenDiagramService
         ? this.openedSolution.diagrams
         : this.openedSolution.diagrams.sort(this.diagramSorter);
@@ -303,6 +309,28 @@ export class SolutionExplorerSolution {
         this.fontAwesomeIconClass = 'fa-bolt';
         this.processEngineRunning = false;
       }
+    }
+  }
+
+  private async updateSolutionEntry(): Promise<void> {
+    const solutionIsNotRemote: boolean = !this.displayedSolutionEntry.uri.startsWith('http');
+    if (solutionIsNotRemote) {
+      return;
+    }
+
+    try {
+      const response = await fetch(this.displayedSolutionEntry.uri);
+      const responseJsonBody = await response.json();
+
+      const authorityResponse = await fetch(`${this.displayedSolutionEntry.uri}/security/authority`);
+      const authorityJsonBody = await authorityResponse.json();
+
+      this.displayedSolutionEntry.authority = authorityJsonBody.authority;
+      this.displayedSolutionEntry.processEngineVersion = responseJsonBody.version;
+      this.globalSolutionService.addSolutionEntry(this.displayedSolutionEntry);
+      this.signaler.signal('update-version-icon');
+    } catch (error) {
+      throw error;
     }
   }
 

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -318,20 +318,16 @@ export class SolutionExplorerSolution {
       return;
     }
 
-    try {
-      const response = await fetch(this.displayedSolutionEntry.uri);
-      const responseJsonBody = await response.json();
+    const response = await fetch(this.displayedSolutionEntry.uri);
+    const responseJsonBody = await response.json();
 
-      const authorityResponse = await fetch(`${this.displayedSolutionEntry.uri}/security/authority`);
-      const authorityJsonBody = await authorityResponse.json();
+    const authorityResponse = await fetch(`${this.displayedSolutionEntry.uri}/security/authority`);
+    const authorityJsonBody = await authorityResponse.json();
 
-      this.displayedSolutionEntry.authority = authorityJsonBody.authority;
-      this.displayedSolutionEntry.processEngineVersion = responseJsonBody.version;
-      this.globalSolutionService.addSolutionEntry(this.displayedSolutionEntry);
-      this.signaler.signal('update-version-icon');
-    } catch (error) {
-      throw error;
-    }
+    this.displayedSolutionEntry.authority = authorityJsonBody.authority;
+    this.displayedSolutionEntry.processEngineVersion = responseJsonBody.version;
+    this.globalSolutionService.addSolutionEntry(this.displayedSolutionEntry);
+    this.signaler.signal('update-version-icon');
   }
 
   /*


### PR DESCRIPTION
## Changes

1. Update the runtime version and authority while fetching the processmodels.
2. Fix bug where the studio does not add solutions if the internal processengine is not running

## Issues

Closes #1775 
Closes #1772 
Closes #1752 

PR: #1781 

## How to test the changes

> Describe how others can test your changes (not required when fixing typos, linter errors and such)
