### PR TITLE
🐛 Store process engine logs in bpmn studio workspace

### DIFF
--- a/electron_app/electron.ts
+++ b/electron_app/electron.ts
@@ -877,9 +877,15 @@ async function startInternalProcessEngine(): Promise<any> {
   // See issue https://github.com/process-engine/bpmn-studio/issues/312
   try {
     const sqlitePath = getDatabaseFolder();
+    const logFilepath = getLogFolder();
+
+    const startupArgs = {
+      sqlitePath: sqlitePath,
+      logFilePath: logFilepath,
+    };
 
     // eslint-disable-next-line global-require
-    pe.startRuntime(sqlitePath);
+    pe.startRuntime(startupArgs);
 
     console.log('Internal ProcessEngine started successfully.');
     internalProcessEngineStatus = 'success';
@@ -900,6 +906,14 @@ async function startInternalProcessEngine(): Promise<any> {
       internalProcessEngineStartupError,
     );
   }
+}
+
+function getLogFolder(): string {
+  return path.join(getConfigFolder(), getProcessEngineLogFolderName());
+}
+
+function getProcessEngineLogFolderName(): string {
+  return 'process_engine_logs';
 }
 
 function getDatabaseFolder(): string {

--- a/package-lock.json
+++ b/package-lock.json
@@ -802,13 +802,13 @@
       }
     },
     "@process-engine/consumer_api_core": {
-      "version": "6.2.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@process-engine/consumer_api_core/-/consumer_api_core-6.2.0-beta.2.tgz",
-      "integrity": "sha512-YsjFC8ZGyUQQnRIwXwQSAomGtYW7YOuQ6tBX2ZABNHSxIWMiA9EgdiERV5C8bLcJR0NXbQLor4jfNNCLV45eBQ==",
+      "version": "6.2.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/@process-engine/consumer_api_core/-/consumer_api_core-6.2.0-alpha.10.tgz",
+      "integrity": "sha512-0aUG5HSrXcx+e9ECoiNlffP2xzbDpAjjaQr6T/s9M3fXeLrWCG1NAC+yuS4MXhjLj/CjHTLmT58Q21hyKEL2Wg==",
       "requires": {
         "@essential-projects/errors_ts": "^1.5.0",
         "@process-engine/consumer_api_contracts": "^9.0.0",
-        "@process-engine/persistence_api.contracts": "1.1.0-beta.3",
+        "@process-engine/persistence_api.contracts": "1.1.0-alpha.4",
         "@process-engine/process_engine_contracts": "^46.0.0",
         "bluebird": "~3.5.2",
         "bluebird-global": "~1.0.1",
@@ -941,30 +941,29 @@
       }
     },
     "@process-engine/logging.repository.file_system": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@process-engine/logging.repository.file_system/-/logging.repository.file_system-1.3.0.tgz",
-      "integrity": "sha512-674Q8ZOnilEqPLCgObCnVoNOvLMnqlAd9c+txZhM2ifeikZFVG+G4+CsriMntbZ3Lcd1ot67ZKn9Dnxv5ztQ1Q==",
+      "version": "2.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@process-engine/logging.repository.file_system/-/logging.repository.file_system-2.0.0-alpha.1.tgz",
+      "integrity": "sha512-tdpbvDyR6XILwZzq9ZvdQ3072rDDBvm4g93kXscApoyPKS/K/2oCp03vNFjVTiHABs3QtHk2neMVMK7nvDPdKw==",
       "requires": {
-        "@process-engine/logging_api_contracts": "^1.0.0",
+        "@process-engine/logging_api_contracts": "2.0.0-alpha.1",
         "moment": "^2.24.0"
       }
     },
     "@process-engine/logging_api_contracts": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@process-engine/logging_api_contracts/-/logging_api_contracts-1.1.0.tgz",
-      "integrity": "sha512-F0XkTUHA28Ih0Im1z1FWKC7jbS2xFFcgF4CaLjbub2VC/TwfgvFRG50ZjcHV0dHfR24ziIaYZqeA6NMwY/h9Mw==",
+      "version": "2.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@process-engine/logging_api_contracts/-/logging_api_contracts-2.0.0-alpha.1.tgz",
+      "integrity": "sha512-1Q7AuwnPs8oCsSKmInwhD++ez0JDNjahCrS5/B1UZ56MFJswtB+7AlnXjeu1cHAk1AwVRMwid0VcE7fHwmHEig==",
       "requires": {
         "@essential-projects/iam_contracts": "^3.4.0",
-        "@types/express": "^4.16.0",
         "@types/node": "^10.12.2"
       }
     },
     "@process-engine/logging_api_core": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@process-engine/logging_api_core/-/logging_api_core-1.1.0.tgz",
-      "integrity": "sha512-hXoylgmE2hUtrkUz5S4qrIM1z7n6q0/+ePxwXxTPbt6M+dz5Xumlq+aF1Ein0U0+zsb6DCQqVdk04C+A3hDrXA==",
+      "version": "2.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@process-engine/logging_api_core/-/logging_api_core-2.0.0-alpha.1.tgz",
+      "integrity": "sha512-k+xSL19MzcPDMqlXnlF2FuElYxTFQ5VjCthVgMkEqB8UcUigJ1IAL+P+7hT8o1yTBP1ancuJ5LGi1/iWbgiOQw==",
       "requires": {
-        "@process-engine/logging_api_contracts": "^1.0.0",
+        "@process-engine/logging_api_contracts": "2.0.0-alpha.1",
         "moment": "^2.24.0"
       }
     },
@@ -996,15 +995,15 @@
       }
     },
     "@process-engine/management_api_core": {
-      "version": "6.2.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@process-engine/management_api_core/-/management_api_core-6.2.0-beta.2.tgz",
-      "integrity": "sha512-nejG7zr7yihthxqfPEJPeCu2ElzDI7IAQncdCiWixQtX2T5K8WJ7bo4/99wenYzRjHLBasNFqys0YEmTTQa9+A==",
+      "version": "6.2.0-alpha.9",
+      "resolved": "https://registry.npmjs.org/@process-engine/management_api_core/-/management_api_core-6.2.0-alpha.9.tgz",
+      "integrity": "sha512-f1zWaJ70dJDiA0uoadFjqMGDbc1wiKyjE6hyEmYJAzaiqZ/rLIrtJqSvZF2ukk0vaP735vrq0O7g1PA8VHxxOQ==",
       "requires": {
         "@essential-projects/errors_ts": "^1.5.0",
         "@process-engine/logging_api_contracts": "^1.0.3",
         "@process-engine/management_api_contracts": "^13.0.0",
         "@process-engine/metrics_api_contracts": "^2.0.0",
-        "@process-engine/persistence_api.contracts": "1.1.0-beta.3",
+        "@process-engine/persistence_api.contracts": "1.1.0-alpha.4",
         "@process-engine/process_engine_contracts": "^46.0.0",
         "bluebird": "~3.5.2",
         "bluebird-global": "~1.0.1",
@@ -1012,6 +1011,18 @@
         "loggerhythm": "~3.0.3",
         "moment": "~2.24.0",
         "node-uuid": "^1.4.8"
+      },
+      "dependencies": {
+        "@process-engine/logging_api_contracts": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@process-engine/logging_api_contracts/-/logging_api_contracts-1.1.0.tgz",
+          "integrity": "sha512-F0XkTUHA28Ih0Im1z1FWKC7jbS2xFFcgF4CaLjbub2VC/TwfgvFRG50ZjcHV0dHfR24ziIaYZqeA6NMwY/h9Mw==",
+          "requires": {
+            "@essential-projects/iam_contracts": "^3.4.0",
+            "@types/express": "^4.16.0",
+            "@types/node": "^10.12.2"
+          }
+        }
       }
     },
     "@process-engine/management_api_http": {
@@ -1032,13 +1043,25 @@
       }
     },
     "@process-engine/metrics.repository.file_system": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@process-engine/metrics.repository.file_system/-/metrics.repository.file_system-2.0.0.tgz",
-      "integrity": "sha512-fOfSmG3h5mAf+ZILCFHHnXGaEpIT1cVdFElh2Tkgq8a6L6on0Vu+DMtw86kvU15P8+Jv2x+F5rFB4DiA4xVouQ==",
+      "version": "3.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@process-engine/metrics.repository.file_system/-/metrics.repository.file_system-3.0.0-alpha.1.tgz",
+      "integrity": "sha512-dZPDTdZj6+/xZuaMdHSWZ9Rgdl9PjotHQEMEYCJ3ruT61Vx/d0zbI6iy+W+q1kre6l9RUr4dwNc3AOvvCHFYeQ==",
       "requires": {
         "@essential-projects/errors_ts": "^1.5.0",
-        "@process-engine/metrics_api_contracts": "^2.0.0",
+        "@process-engine/metrics_api_contracts": "3.0.0-alpha.1",
         "moment": "^2.24.0"
+      },
+      "dependencies": {
+        "@process-engine/metrics_api_contracts": {
+          "version": "3.0.0-alpha.1",
+          "resolved": "https://registry.npmjs.org/@process-engine/metrics_api_contracts/-/metrics_api_contracts-3.0.0-alpha.1.tgz",
+          "integrity": "sha512-TWERrCw/BfaT3+gCzoFyUVQRILlRpGGNkkXIQtx0jeVkEuKxanXgWQDASwTyprDxVnYzOiyxLy5K+y4kXfRkEQ==",
+          "requires": {
+            "@essential-projects/iam_contracts": "^3.4.0",
+            "@types/node": "^10.12.2",
+            "moment": "^2.24.0"
+          }
+        }
       }
     },
     "@process-engine/metrics_api_contracts": {
@@ -1053,32 +1076,44 @@
       }
     },
     "@process-engine/metrics_api_core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@process-engine/metrics_api_core/-/metrics_api_core-2.0.0.tgz",
-      "integrity": "sha512-58JHY61qG3qoaJAoiX4Ttwo4TmHQQ4rqc4cmcdDSRO+Iv7qjTCZiRq5m5R9IwJwQ6USD9RQUW15U7mf533U4oA==",
+      "version": "3.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@process-engine/metrics_api_core/-/metrics_api_core-3.0.0-alpha.1.tgz",
+      "integrity": "sha512-g8s+8yugiMpSxx6hH0Vxly849OFS34jJMWRhnZcDBFFN7gCS9XloNDUXk8saSsoxqV92Q6slkWfMm7WUDVZHSw==",
       "requires": {
-        "@process-engine/metrics_api_contracts": "^2.0.0",
+        "@process-engine/metrics_api_contracts": "3.0.0-alpha.1",
         "moment": "^2.24.0"
+      },
+      "dependencies": {
+        "@process-engine/metrics_api_contracts": {
+          "version": "3.0.0-alpha.1",
+          "resolved": "https://registry.npmjs.org/@process-engine/metrics_api_contracts/-/metrics_api_contracts-3.0.0-alpha.1.tgz",
+          "integrity": "sha512-TWERrCw/BfaT3+gCzoFyUVQRILlRpGGNkkXIQtx0jeVkEuKxanXgWQDASwTyprDxVnYzOiyxLy5K+y4kXfRkEQ==",
+          "requires": {
+            "@essential-projects/iam_contracts": "^3.4.0",
+            "@types/node": "^10.12.2",
+            "moment": "^2.24.0"
+          }
+        }
       }
     },
     "@process-engine/persistence_api.contracts": {
-      "version": "1.1.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@process-engine/persistence_api.contracts/-/persistence_api.contracts-1.1.0-beta.3.tgz",
-      "integrity": "sha512-rAB1A7sM2ds4O32tzXsbiaHS0J0iRn9mWkkVU1Z/S8/MhYR3d1ACE6l/WL0AB32K+L/aOR6Tr3mS2pcX3luMRg==",
+      "version": "1.1.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@process-engine/persistence_api.contracts/-/persistence_api.contracts-1.1.0-alpha.4.tgz",
+      "integrity": "sha512-C+q6oieSJKLS0PckUq1/pymn3a/xy/uIEwVbEcNDquHMYQ4uEJ5mAxhULnfc7xu1FWzr5ncSTdVk9MMmxFId3g==",
       "requires": {
         "@essential-projects/iam_contracts": "^3.4.1"
       }
     },
     "@process-engine/persistence_api.repositories.sequelize": {
-      "version": "1.1.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@process-engine/persistence_api.repositories.sequelize/-/persistence_api.repositories.sequelize-1.1.0-beta.4.tgz",
-      "integrity": "sha512-OUR0Hi/k9oOPslayzB7/Z2T+uz7JiCxE0sM18AZByu+Hkin1nl81nV2sUlST83fe1/dhA4iYGVd9hs2MHmygMQ==",
+      "version": "1.1.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@process-engine/persistence_api.repositories.sequelize/-/persistence_api.repositories.sequelize-1.1.0-alpha.6.tgz",
+      "integrity": "sha512-x/HjMJWzB6g8STNbxefKWvYAxQNhwriqF1RcuwxAI98JbGHap+k7Y6RPNKhF9gf0QIqS4uUj5BB9QEt8cAx68Q==",
       "requires": {
         "@essential-projects/bootstrapper_contracts": "^1.3.0",
         "@essential-projects/errors_ts": "^1.4.0",
         "@essential-projects/iam_contracts": "^3.4.1",
         "@essential-projects/sequelize_connection_manager": "^3.0.0",
-        "@process-engine/persistence_api.contracts": "1.1.0-beta.4",
+        "@process-engine/persistence_api.contracts": "1.1.0-alpha.6",
         "bcryptjs": "^2.4.3",
         "bluebird": "^3.5.2",
         "bluebird-global": "^1.0.1",
@@ -1089,9 +1124,9 @@
       },
       "dependencies": {
         "@process-engine/persistence_api.contracts": {
-          "version": "1.1.0-beta.4",
-          "resolved": "https://registry.npmjs.org/@process-engine/persistence_api.contracts/-/persistence_api.contracts-1.1.0-beta.4.tgz",
-          "integrity": "sha512-t3xby6ZH7ylqm9lxppyODQR67M2xH3sJ1jXgNTcrdwI2Llsk6nqaCsHsQTm2Mi0v8WQiedVWyCktpJ35oyriGw==",
+          "version": "1.1.0-alpha.6",
+          "resolved": "https://registry.npmjs.org/@process-engine/persistence_api.contracts/-/persistence_api.contracts-1.1.0-alpha.6.tgz",
+          "integrity": "sha512-NplAx8qQgLI+XTTMowwB2/iBLo2mpXO50Ea1XbZiinVKrBQ9IlvqZVReg7TfmVuCVJrfJyGE8Zdd/B0Ixt5a9w==",
           "requires": {
             "@essential-projects/iam_contracts": "^3.4.1"
           }
@@ -1099,22 +1134,22 @@
       }
     },
     "@process-engine/persistence_api.services": {
-      "version": "1.1.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@process-engine/persistence_api.services/-/persistence_api.services-1.1.0-beta.4.tgz",
-      "integrity": "sha512-1X7esW/03Uq9BQV5uc+Yth6dQMvKDTkiUCocJCdOn13M0R6CTgiyMidLUr8r5vK12YyPUTIWrtl4Kr01+iAlMQ==",
+      "version": "1.1.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@process-engine/persistence_api.services/-/persistence_api.services-1.1.0-alpha.6.tgz",
+      "integrity": "sha512-i8Mjh28EH00Rm3CHczurtG40nBKxvwbd1g+lLw7A/tPSPyxiX7nbGlBnVgfIg20wzHEDZBIf1wZdDmhmSbGThQ==",
       "requires": {
         "@essential-projects/errors_ts": "^1.4.4",
         "@essential-projects/iam_contracts": "^3.4.1",
-        "@process-engine/persistence_api.contracts": "1.1.0-beta.4",
+        "@process-engine/persistence_api.contracts": "1.1.0-alpha.6",
         "bluebird-global": "^1.0.1",
         "clone": "^2.1.2",
         "loggerhythm": "^3.0.3"
       },
       "dependencies": {
         "@process-engine/persistence_api.contracts": {
-          "version": "1.1.0-beta.4",
-          "resolved": "https://registry.npmjs.org/@process-engine/persistence_api.contracts/-/persistence_api.contracts-1.1.0-beta.4.tgz",
-          "integrity": "sha512-t3xby6ZH7ylqm9lxppyODQR67M2xH3sJ1jXgNTcrdwI2Llsk6nqaCsHsQTm2Mi0v8WQiedVWyCktpJ35oyriGw==",
+          "version": "1.1.0-alpha.6",
+          "resolved": "https://registry.npmjs.org/@process-engine/persistence_api.contracts/-/persistence_api.contracts-1.1.0-alpha.6.tgz",
+          "integrity": "sha512-NplAx8qQgLI+XTTMowwB2/iBLo2mpXO50Ea1XbZiinVKrBQ9IlvqZVReg7TfmVuCVJrfJyGE8Zdd/B0Ixt5a9w==",
           "requires": {
             "@essential-projects/iam_contracts": "^3.4.1"
           }
@@ -1122,19 +1157,31 @@
       }
     },
     "@process-engine/persistence_api.use_cases": {
-      "version": "1.1.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@process-engine/persistence_api.use_cases/-/persistence_api.use_cases-1.1.0-beta.4.tgz",
-      "integrity": "sha512-uv+kBVYCALMCt5q8AFliTN3oSuGvtMKeBEQWv2iDYY4vGFlHbd4rO2IGQFhMDNQn2TyldVgOv/2woB39yS/Brw==",
+      "version": "1.1.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@process-engine/persistence_api.use_cases/-/persistence_api.use_cases-1.1.0-alpha.6.tgz",
+      "integrity": "sha512-wq3HmVzdvQNaZCYAx2Ye2L/O6aybuISdSVf6L1o1j/8yxN6eRIqmeldhV3y6THSqAm5E26usr7KQpPLo15yxBg==",
       "requires": {
         "@essential-projects/errors_ts": "^1.4.3",
         "@essential-projects/iam_contracts": "^3.4.1",
-        "@process-engine/persistence_api.contracts": "1.1.0-beta.4"
+        "@process-engine/logging_api_contracts": "2.0.0-alpha.1",
+        "@process-engine/metrics_api_contracts": "3.0.0-alpha.1",
+        "@process-engine/persistence_api.contracts": "1.1.0-alpha.6"
       },
       "dependencies": {
+        "@process-engine/metrics_api_contracts": {
+          "version": "3.0.0-alpha.1",
+          "resolved": "https://registry.npmjs.org/@process-engine/metrics_api_contracts/-/metrics_api_contracts-3.0.0-alpha.1.tgz",
+          "integrity": "sha512-TWERrCw/BfaT3+gCzoFyUVQRILlRpGGNkkXIQtx0jeVkEuKxanXgWQDASwTyprDxVnYzOiyxLy5K+y4kXfRkEQ==",
+          "requires": {
+            "@essential-projects/iam_contracts": "^3.4.0",
+            "@types/node": "^10.12.2",
+            "moment": "^2.24.0"
+          }
+        },
         "@process-engine/persistence_api.contracts": {
-          "version": "1.1.0-beta.4",
-          "resolved": "https://registry.npmjs.org/@process-engine/persistence_api.contracts/-/persistence_api.contracts-1.1.0-beta.4.tgz",
-          "integrity": "sha512-t3xby6ZH7ylqm9lxppyODQR67M2xH3sJ1jXgNTcrdwI2Llsk6nqaCsHsQTm2Mi0v8WQiedVWyCktpJ35oyriGw==",
+          "version": "1.1.0-alpha.6",
+          "resolved": "https://registry.npmjs.org/@process-engine/persistence_api.contracts/-/persistence_api.contracts-1.1.0-alpha.6.tgz",
+          "integrity": "sha512-NplAx8qQgLI+XTTMowwB2/iBLo2mpXO50Ea1XbZiinVKrBQ9IlvqZVReg7TfmVuCVJrfJyGE8Zdd/B0Ixt5a9w==",
           "requires": {
             "@essential-projects/iam_contracts": "^3.4.1"
           }
@@ -1151,15 +1198,15 @@
       }
     },
     "@process-engine/process_engine_core": {
-      "version": "12.12.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.12.0-beta.2.tgz",
-      "integrity": "sha512-GIk/0YJTrHaLYb2+vgH7tvdxs7yLPFw9cuwf12EOextLcJ11RR8HHszvlH6TiYwygE8zDrjetpQV0unSPn9w1A==",
+      "version": "12.12.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.12.0-alpha.12.tgz",
+      "integrity": "sha512-RY+xxjEscbhh7U7oehNjSkra+ozLGvuRwq1PLOinDyoJJ46CXCxjT4Wy7NOAu2cE463awheDYCMUCJh2BEV6YA==",
       "requires": {
         "@essential-projects/errors_ts": "^1.5.0",
         "@essential-projects/timing_contracts": "^5.0.0",
         "@process-engine/logging_api_contracts": "^1.0.0",
         "@process-engine/metrics_api_contracts": "^2.0.0",
-        "@process-engine/persistence_api.contracts": "1.1.0-beta.3",
+        "@process-engine/persistence_api.contracts": "1.1.0-alpha.4",
         "@process-engine/process_engine_contracts": "^46.0.0",
         "@types/clone": "^0.1.30",
         "@types/socket.io": "^2.1.2",
@@ -1173,12 +1220,24 @@
         "node-uuid": "^1.4.8",
         "should": "^13.2.3",
         "xml2js": "^0.4.19"
+      },
+      "dependencies": {
+        "@process-engine/logging_api_contracts": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@process-engine/logging_api_contracts/-/logging_api_contracts-1.1.0.tgz",
+          "integrity": "sha512-F0XkTUHA28Ih0Im1z1FWKC7jbS2xFFcgF4CaLjbub2VC/TwfgvFRG50ZjcHV0dHfR24ziIaYZqeA6NMwY/h9Mw==",
+          "requires": {
+            "@essential-projects/iam_contracts": "^3.4.0",
+            "@types/express": "^4.16.0",
+            "@types/node": "^10.12.2"
+          }
+        }
       }
     },
     "@process-engine/process_engine_runtime": {
-      "version": "9.1.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_runtime/-/process_engine_runtime-9.1.0-beta.4.tgz",
-      "integrity": "sha512-FcEfqe5MHsjL++W2idDpVicSOMbUQ9kMhjCbzgbtGJRUn3oREz0cmqOW7oEG+xTXpwS1F5T6Vh9BwhxNVx94OA==",
+      "version": "9.1.0-feature-7ae11f-k1vsgn1u",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_runtime/-/process_engine_runtime-9.1.0-feature-7ae11f-k1vsgn1u.tgz",
+      "integrity": "sha512-7DEiEexRsZeY4e7fem93ZbrfFWu6gvgra0YasXmhzJ+w5OU+3Kk6ROSDHs+fMgfqlQAKp/Ybhx1Oe8QQXeyf1g==",
       "requires": {
         "@essential-projects/bootstrapper": "3.4.0",
         "@essential-projects/bootstrapper_node": "3.3.0",
@@ -1186,19 +1245,19 @@
         "@essential-projects/http": "2.4.0",
         "@essential-projects/http_extension": "6.7.0",
         "@essential-projects/timing": "5.0.0",
-        "@process-engine/consumer_api_core": "6.2.0-beta.2",
+        "@process-engine/consumer_api_core": "6.2.0-alpha.10",
         "@process-engine/consumer_api_http": "5.1.0",
         "@process-engine/iam": "1.7.1",
-        "@process-engine/logging.repository.file_system": "1.3.0",
-        "@process-engine/logging_api_core": "1.1.0",
-        "@process-engine/management_api_core": "6.2.0-beta.2",
+        "@process-engine/logging.repository.file_system": "2.0.0-alpha.1",
+        "@process-engine/logging_api_core": "2.0.0-alpha.1",
+        "@process-engine/management_api_core": "6.2.0-alpha.9",
         "@process-engine/management_api_http": "5.1.0",
-        "@process-engine/metrics.repository.file_system": "2.0.0",
-        "@process-engine/metrics_api_core": "2.0.0",
-        "@process-engine/persistence_api.repositories.sequelize": "1.1.0-beta.4",
-        "@process-engine/persistence_api.services": "1.1.0-beta.4",
-        "@process-engine/persistence_api.use_cases": "1.1.0-beta.4",
-        "@process-engine/process_engine_core": "12.12.0-beta.2",
+        "@process-engine/metrics.repository.file_system": "3.0.0-alpha.1",
+        "@process-engine/metrics_api_core": "3.0.0-alpha.1",
+        "@process-engine/persistence_api.repositories.sequelize": "1.1.0-alpha.6",
+        "@process-engine/persistence_api.services": "1.1.0-alpha.6",
+        "@process-engine/persistence_api.use_cases": "1.1.0-alpha.6",
+        "@process-engine/process_engine_core": "12.12.0-alpha.12",
         "@types/socket.io": "^2.1.0",
         "@types/socket.io-client": "^1.4.32",
         "addict-ioc": "~2.5.3",
@@ -1225,14 +1284,12 @@
     "@process-engine/solutionexplorer.contracts": {
       "version": "1.2.0-beta.1",
       "resolved": "https://registry.npmjs.org/@process-engine/solutionexplorer.contracts/-/solutionexplorer.contracts-1.2.0-beta.1.tgz",
-      "integrity": "sha512-qprE7VskWXoNeK/3Z7gVfUgEEei95yh413FnDpP0hCtU4Ar1cAD09kqcE3YgcKdqZb1wKA6mgkmnQrsmnSOT8Q==",
-      "dev": true
+      "integrity": "sha512-qprE7VskWXoNeK/3Z7gVfUgEEei95yh413FnDpP0hCtU4Ar1cAD09kqcE3YgcKdqZb1wKA6mgkmnQrsmnSOT8Q=="
     },
     "@process-engine/solutionexplorer.repository.contracts": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@process-engine/solutionexplorer.repository.contracts/-/solutionexplorer.repository.contracts-4.3.0.tgz",
       "integrity": "sha512-FcR4i778TNrAJ827RdgSJ4BHlSNGgm4+rLHQT/dafkgtc8xta/NvlvnM+iDuD4Oyi09Zxalt/K/w518WRQhFwA==",
-      "dev": true,
       "requires": {
         "@essential-projects/iam_contracts": "^3.1.0",
         "@process-engine/solutionexplorer.contracts": "1.1.0"
@@ -1241,8 +1298,7 @@
         "@process-engine/solutionexplorer.contracts": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/@process-engine/solutionexplorer.contracts/-/solutionexplorer.contracts-1.1.0.tgz",
-          "integrity": "sha512-mCHX4DplA7MW0OAOIaM3zXgtvUe2C8s/bDqvwZpJcnVD95+t91GlZofmmYFcLDsMdLmOACC0wwKeKU/0WiPClg==",
-          "dev": true
+          "integrity": "sha512-mCHX4DplA7MW0OAOIaM3zXgtvUe2C8s/bDqvwZpJcnVD95+t91GlZofmmYFcLDsMdLmOACC0wwKeKU/0WiPClg=="
         }
       }
     },
@@ -1260,15 +1316,6 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/@process-engine/solutionexplorer.contracts/-/solutionexplorer.contracts-1.1.0.tgz",
           "integrity": "sha512-mCHX4DplA7MW0OAOIaM3zXgtvUe2C8s/bDqvwZpJcnVD95+t91GlZofmmYFcLDsMdLmOACC0wwKeKU/0WiPClg=="
-        },
-        "@process-engine/solutionexplorer.repository.contracts": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/@process-engine/solutionexplorer.repository.contracts/-/solutionexplorer.repository.contracts-4.3.0.tgz",
-          "integrity": "sha512-FcR4i778TNrAJ827RdgSJ4BHlSNGgm4+rLHQT/dafkgtc8xta/NvlvnM+iDuD4Oyi09Zxalt/K/w518WRQhFwA==",
-          "requires": {
-            "@essential-projects/iam_contracts": "^3.1.0",
-            "@process-engine/solutionexplorer.contracts": "1.1.0"
-          }
         }
       }
     },
@@ -1320,29 +1367,6 @@
         "@process-engine/solutionexplorer.contracts": "1.2.0-beta.1",
         "@process-engine/solutionexplorer.repository.contracts": "4.3.0",
         "@process-engine/solutionexplorer.service.contracts": "4.3.0-beta.1"
-      },
-      "dependencies": {
-        "@process-engine/solutionexplorer.contracts": {
-          "version": "1.2.0-beta.1",
-          "resolved": "https://registry.npmjs.org/@process-engine/solutionexplorer.contracts/-/solutionexplorer.contracts-1.2.0-beta.1.tgz",
-          "integrity": "sha512-qprE7VskWXoNeK/3Z7gVfUgEEei95yh413FnDpP0hCtU4Ar1cAD09kqcE3YgcKdqZb1wKA6mgkmnQrsmnSOT8Q=="
-        },
-        "@process-engine/solutionexplorer.repository.contracts": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/@process-engine/solutionexplorer.repository.contracts/-/solutionexplorer.repository.contracts-4.3.0.tgz",
-          "integrity": "sha512-FcR4i778TNrAJ827RdgSJ4BHlSNGgm4+rLHQT/dafkgtc8xta/NvlvnM+iDuD4Oyi09Zxalt/K/w518WRQhFwA==",
-          "requires": {
-            "@essential-projects/iam_contracts": "^3.1.0",
-            "@process-engine/solutionexplorer.contracts": "1.1.0"
-          },
-          "dependencies": {
-            "@process-engine/solutionexplorer.contracts": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/@process-engine/solutionexplorer.contracts/-/solutionexplorer.contracts-1.1.0.tgz",
-              "integrity": "sha512-mCHX4DplA7MW0OAOIaM3zXgtvUe2C8s/bDqvwZpJcnVD95+t91GlZofmmYFcLDsMdLmOACC0wwKeKU/0WiPClg=="
-            }
-          }
-        }
       }
     },
     "@process-engine/solutionexplorer.service.contracts": {
@@ -1352,13 +1376,6 @@
       "requires": {
         "@essential-projects/iam_contracts": "^3.1.0",
         "@process-engine/solutionexplorer.contracts": "1.2.0-beta.1"
-      },
-      "dependencies": {
-        "@process-engine/solutionexplorer.contracts": {
-          "version": "1.2.0-beta.1",
-          "resolved": "https://registry.npmjs.org/@process-engine/solutionexplorer.contracts/-/solutionexplorer.contracts-1.2.0-beta.1.tgz",
-          "integrity": "sha512-qprE7VskWXoNeK/3Z7gVfUgEEei95yh413FnDpP0hCtU4Ar1cAD09kqcE3YgcKdqZb1wKA6mgkmnQrsmnSOT8Q=="
-        }
       }
     },
     "@sindresorhus/is": {
@@ -12810,9 +12827,9 @@
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
     },
     "popper.js": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
-      "integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.0.tgz",
+      "integrity": "sha512-+G+EkOPoE5S/zChTpmBSSDYmhXJ5PsW8eMhH8cP/CQHMFPBG/kC9Y5IIw6qNYgdJ+/COf0ddY2li28iHaZRSjw==",
       "dev": true
     },
     "popsicle": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@process-engine/dynamic_ui_core": "^1.5.0",
     "@process-engine/electron-updater": "1.1.0",
     "@process-engine/management_api_client": "6.1.0",
-    "@process-engine/process_engine_runtime": "9.1.0-beta.4",
+    "@process-engine/process_engine_runtime": "feature~allow_ioc_container_injection",
     "@process-engine/solutionexplorer.repository.filesystem": "4.3.0",
     "@process-engine/solutionexplorer.repository.management_api": "3.2.0",
     "@process-engine/solutionexplorer.service": "4.3.0-beta.1",


### PR DESCRIPTION
## Changes

Provide `sqlitePath` and `logFilePath` to the internal ProcessEngine, which point to the BPMN Studio's own release-channel specific workspace.

## Issues

Closes #1803

PR: #1804

## How to test the changes

- Startup the Studio
- Notice the following output on the console:

![Bildschirmfoto 2019-10-18 um 09 32 02](https://user-images.githubusercontent.com/15343316/67074818-27fa3280-f18a-11e9-88d1-de84359d34b7.png)

- Now start a few ProcessInstances
- Navigate to `/Users/christianwerner/Library/Application Support/bpmn-studio-dev`
- Notice a new folder named `process_engine_logs`
- When you look into the folder, you'll see two subfolders named `logs` and `metrics`, in which the logfiles for your ProcessInstances are stored