### PR TITLE
🐛 Fix Switching From Inspect to Design View

### DIFF
--- a/src/modules/design/design.ts
+++ b/src/modules/design/design.ts
@@ -387,7 +387,7 @@ export class Design {
         !diagram.uri.startsWith('about:open-diagrams') && !diagram.uri.startsWith('http');
 
       if (diagramIsSavedOnLocalSolution) {
-        diagram.xml = fs.readFileSync(diagramUri, 'utf8');
+        diagram.xml = fs.readFileSync(diagram.uri, 'utf8');
       }
 
       this.activeDiagram = diagram;


### PR DESCRIPTION
## Changes

1. Fix Switching From Inspect to Design View

## Issues

Closes #1807

PR: #1808

## How to test the changes

- Open a diagram
- Click on `Inspect`
- Click on `Design`
- **Notice that the BPMN Studio will navigate back to design**
