### PR TITLE
🐛 Fix Renaming Unopened Diagrams

### DIFF
--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -1222,7 +1222,11 @@ export class SolutionExplorerSolution {
         this.diagramRenamingState.currentDiagramInputValue,
       );
 
-      this.openDiagramStateService.setDiagramChange(this.currentlyRenamingDiagram.uri, {change: 'rename'});
+      const diagramHasState: boolean =
+        this.openDiagramStateService.loadDiagramState(this.currentlyRenamingDiagram.uri) !== null;
+      if (diagramHasState) {
+        this.openDiagramStateService.setDiagramChange(this.currentlyRenamingDiagram.uri, {change: 'rename'});
+      }
     } catch (error) {
       this.notificationService.showNotification(NotificationType.WARNING, error.message);
 


### PR DESCRIPTION
## Changes

1. Fix Renaming Unopened Diagrams

## Issues

Closes #1810

PR: #1811

## How to test the changes

- Open a solution
- Rename a diagram that is not shown in `Open Diagrams`
- **Notice that the renaming was successful.**
