### PR TITLE
🐛 Fix Broken Icon

### DIFF
--- a/src/modules/design/diagram-tools-right/diagram-tools-right.html
+++ b/src/modules/design/diagram-tools-right/diagram-tools-right.html
@@ -14,12 +14,12 @@
           <li class="dropdown-item" click.delegate="setColorOrange()"><a><i class="fas fa-stop orange"></i> Orange</a></li>
           <li class="dropdown-item fill-colorpicker--border" ref="colorPickerFill">
             <a show.bind="colorPickerLoaded" click.delegate="setPickedColor()">
-              <i class="fas fa-stop" css="color: ${fillColor ? fillColor : 'white'};"></i> Fill color <i class="fas fa-eyedropper fill-colorpicker__eyedropper"></i>
+              <i class="fas fa-stop" css="color: ${fillColor ? fillColor : 'white'};"></i> Fill color <i class="fas fa-eye-dropper fill-colorpicker__eyedropper"></i>
             </a>
           </li>
           <li class="dropdown-item border-colorpicker--border" ref="colorPickerBorder">
             <a show.bind="colorPickerLoaded" click.delegate="setPickedColor()">
-              <i class="fas fa-stop" css="color: ${borderColor ? borderColor : 'black'};"></i> Border color <i class="fas fa-eyedropper border-colorpicker__eyedropper"></i>
+              <i class="fas fa-stop" css="color: ${borderColor ? borderColor : 'black'};"></i> Border color <i class="fas fa-eye-dropper border-colorpicker__eyedropper"></i>
             </a>
           </li>
           <li class="dropdown-item"><a click.delegate="removeColor()"><i class="fas fa-stop none"></i> None</a></li>


### PR DESCRIPTION
## Changes

1. Fix Broken Icon

PR: #1822

## How to test the changes

- Open a diagram
- Click on any element
- Open the color selection
- **Notice that the color picker buttons have an eye dropper icon.**

![image](https://user-images.githubusercontent.com/20394992/67619122-f1f72700-f7f7-11e9-9eb4-63cc58a1198b.png)
