### PR TITLE
🐛 Fix Updating Studio after Login

### DIFF
--- a/src/modules/inspect/cronjob-list/cronjob-list.ts
+++ b/src/modules/inspect/cronjob-list/cronjob-list.ts
@@ -88,11 +88,18 @@ export class CronjobList {
 
     this.subscriptions = [
       this.dashboardService.eventAggregator.subscribe(AuthenticationStateEvent.LOGIN, async () => {
-        this.removeRuntimeSubscriptions();
+        const needsToRenewSubscriptions: boolean = processEngineSupportsCronjobEvents(
+          this.activeSolutionEntry.processEngineVersion,
+        );
+        if (needsToRenewSubscriptions) {
+          this.removeRuntimeSubscriptions();
+        }
 
         await this.updateCronjobs();
 
-        this.setRuntimeSubscriptions();
+        if (needsToRenewSubscriptions) {
+          this.setRuntimeSubscriptions();
+        }
       }),
     ];
   }

--- a/src/modules/inspect/process-list/process-list.ts
+++ b/src/modules/inspect/process-list/process-list.ts
@@ -149,9 +149,6 @@ export class ProcessList {
 
         await this.updateProcessInstanceList();
       }),
-      this.dashboardService.eventAggregator.subscribe(AuthenticationStateEvent.LOGOUT, async () => {
-        await this.updateProcessInstanceList();
-      }),
     ];
 
     this.setRuntimeSubscriptions();

--- a/src/modules/inspect/process-list/process-list.ts
+++ b/src/modules/inspect/process-list/process-list.ts
@@ -45,6 +45,7 @@ export class ProcessList {
   private dashboardServiceSubscriptions: Array<RuntimeSubscription> = [];
 
   private updatePromise: any;
+  private identitiyUsedForSubscriptions: IIdentity;
 
   constructor(
     dashboardService: IDashboardService,
@@ -72,7 +73,7 @@ export class ProcessList {
 
     const previousActiveSolutionEntryExists: boolean = previousActiveSolutionEntry !== undefined;
     if (previousActiveSolutionEntryExists) {
-      this.removeRuntimeSubscriptions(previousActiveSolutionEntry);
+      this.removeRuntimeSubscriptions();
     }
 
     this.processInstances = [];
@@ -144,6 +145,8 @@ export class ProcessList {
 
     this.subscriptions = [
       this.dashboardService.eventAggregator.subscribe(AuthenticationStateEvent.LOGIN, async () => {
+        this.removeRuntimeSubscriptions();
+
         await this.updateProcessInstanceList();
       }),
       this.dashboardService.eventAggregator.subscribe(AuthenticationStateEvent.LOGOUT, async () => {
@@ -160,6 +163,8 @@ export class ProcessList {
         subscription.dispose();
       }
     }
+
+    this.removeRuntimeSubscriptions();
   }
 
   public async stopProcessInstance(processInstance: DataModels.Correlations.ProcessInstance): Promise<void> {
@@ -211,6 +216,13 @@ export class ProcessList {
   }
 
   private async setRuntimeSubscriptions(): Promise<void> {
+    const subscriptionsExist: boolean = this.dashboardServiceSubscriptions.length > 0;
+    if (subscriptionsExist) {
+      this.removeRuntimeSubscriptions();
+    }
+
+    this.identitiyUsedForSubscriptions = this.activeSolutionEntry.identity;
+
     this.dashboardServiceSubscriptions = await Promise.all([
       this.dashboardService.onProcessStarted(this.activeSolutionEntry.identity, async () => {
         await this.updateProcessInstanceList();
@@ -227,9 +239,9 @@ export class ProcessList {
     ]);
   }
 
-  private removeRuntimeSubscriptions(solutionEntry: ISolutionEntry): void {
+  private removeRuntimeSubscriptions(): void {
     for (const subscription of this.dashboardServiceSubscriptions) {
-      this.dashboardService.removeSubscription(solutionEntry.identity, subscription);
+      this.dashboardService.removeSubscription(this.identitiyUsedForSubscriptions, subscription);
     }
 
     this.dashboardServiceSubscriptions = [];

--- a/src/modules/inspect/process-list/process-list.ts
+++ b/src/modules/inspect/process-list/process-list.ts
@@ -151,7 +151,10 @@ export class ProcessList {
       }),
     ];
 
-    this.setRuntimeSubscriptions();
+    const subscriptionNeedsToBeSet: boolean = this.dashboardServiceSubscriptions.length === 0;
+    if (subscriptionNeedsToBeSet) {
+      this.setRuntimeSubscriptions();
+    }
   }
 
   public detached(): void {

--- a/src/modules/inspect/process-list/process-list.ts
+++ b/src/modules/inspect/process-list/process-list.ts
@@ -148,6 +148,8 @@ export class ProcessList {
         this.removeRuntimeSubscriptions();
 
         await this.updateProcessInstanceList();
+
+        this.setRuntimeSubscriptions();
       }),
     ];
 

--- a/src/modules/inspect/task-list/task-list.ts
+++ b/src/modules/inspect/task-list/task-list.ts
@@ -82,9 +82,6 @@ export class TaskList {
 
         await this.updateTasks();
       }),
-      this.dashboardService.eventAggregator.subscribe(AuthenticationStateEvent.LOGOUT, async () => {
-        await this.updateTasks();
-      }),
     ];
 
     await this.updateTasks();

--- a/src/modules/inspect/task-list/task-list.ts
+++ b/src/modules/inspect/task-list/task-list.ts
@@ -90,7 +90,10 @@ export class TaskList {
 
     this.isAttached = true;
 
-    this.setRuntimeSubscriptions();
+    const subscriptionNeedsToBeSet: boolean = this.dashboardServiceSubscriptions.length === 0;
+    if (subscriptionNeedsToBeSet) {
+      this.setRuntimeSubscriptions();
+    }
   }
 
   public detached(): void {

--- a/src/modules/inspect/task-list/task-list.ts
+++ b/src/modules/inspect/task-list/task-list.ts
@@ -7,6 +7,7 @@ import * as Bluebird from 'bluebird';
 import {ForbiddenError, UnauthorizedError, isError} from '@essential-projects/errors_ts';
 import {Subscription as RuntimeSubscription} from '@essential-projects/event_aggregator_contracts';
 
+import {IIdentity} from '@essential-projects/iam_contracts';
 import {AuthenticationStateEvent, ISolutionEntry, ISolutionService} from '../../../contracts/index';
 import environment from '../../../environment';
 import {IDashboardService, TaskList as SuspendedTaskList, TaskListEntry} from '../dashboard/contracts/index';
@@ -45,6 +46,7 @@ export class TaskList {
   private isAttached: boolean = false;
 
   private updatePromise: any;
+  private identitiyUsedForSubscriptions: IIdentity;
 
   constructor(dashboardService: IDashboardService, router: Router, solutionService: ISolutionService) {
     this.dashboardService = dashboardService;
@@ -76,6 +78,8 @@ export class TaskList {
 
     this.subscriptions = [
       this.dashboardService.eventAggregator.subscribe(AuthenticationStateEvent.LOGIN, async () => {
+        this.removeRuntimeSubscriptions();
+
         await this.updateTasks();
       }),
       this.dashboardService.eventAggregator.subscribe(AuthenticationStateEvent.LOGOUT, async () => {
@@ -97,7 +101,7 @@ export class TaskList {
 
     this.isAttached = false;
 
-    this.removeRuntimeSubscriptions(this.activeSolutionEntry);
+    this.removeRuntimeSubscriptions();
   }
 
   public goBack(): void {
@@ -129,7 +133,7 @@ export class TaskList {
     }
 
     if (previousActiveSolutioEntry) {
-      this.removeRuntimeSubscriptions(previousActiveSolutioEntry);
+      this.removeRuntimeSubscriptions();
     }
 
     this.tasks = [];
@@ -193,6 +197,13 @@ export class TaskList {
   }
 
   private async setRuntimeSubscriptions(): Promise<void> {
+    const subscriptionsExist: boolean = this.dashboardServiceSubscriptions.length > 0;
+    if (subscriptionsExist) {
+      this.removeRuntimeSubscriptions();
+    }
+
+    this.identitiyUsedForSubscriptions = this.activeSolutionEntry.identity;
+
     this.dashboardServiceSubscriptions = await Promise.all([
       this.dashboardService.onEmptyActivityFinished(this.activeSolutionEntry.identity, async () => {
         await this.updateTasks();
@@ -218,9 +229,9 @@ export class TaskList {
     ]);
   }
 
-  private removeRuntimeSubscriptions(solutionEntry: ISolutionEntry): void {
+  private removeRuntimeSubscriptions(): void {
     for (const subscription of this.dashboardServiceSubscriptions) {
-      this.dashboardService.removeSubscription(solutionEntry.identity, subscription);
+      this.dashboardService.removeSubscription(this.identitiyUsedForSubscriptions, subscription);
     }
 
     this.dashboardServiceSubscriptions = [];

--- a/src/modules/inspect/task-list/task-list.ts
+++ b/src/modules/inspect/task-list/task-list.ts
@@ -81,6 +81,8 @@ export class TaskList {
         this.removeRuntimeSubscriptions();
 
         await this.updateTasks();
+
+        this.setRuntimeSubscriptions();
       }),
     ];
 

--- a/src/modules/think/diagram-list/diagram-list.ts
+++ b/src/modules/think/diagram-list/diagram-list.ts
@@ -68,7 +68,11 @@ export class DiagramList {
   }
 
   private async updateDiagramList(): Promise<void> {
-    const solution: ISolution = await this.activeSolutionEntry.service.loadSolution();
-    this.allDiagrams = solution.diagrams;
+    try {
+      const solution: ISolution = await this.activeSolutionEntry.service.loadSolution();
+      this.allDiagrams = solution.diagrams;
+    } catch (error) {
+      // Do nothing
+    }
   }
 }

--- a/src/modules/think/diagram-list/diagram-list.ts
+++ b/src/modules/think/diagram-list/diagram-list.ts
@@ -15,7 +15,7 @@ export class DiagramList {
   private eventAggregator: EventAggregator;
   private router: Router;
   private subscriptions: Array<Subscription>;
-  private pollingTimeout: NodeJS.Timer | number;
+  private pollingTimeout: NodeJS.Timer;
   private isAttached: boolean = false;
 
   constructor(eventAggregator: EventAggregator, router: Router) {

--- a/src/modules/think/diagram-list/diagram-list.ts
+++ b/src/modules/think/diagram-list/diagram-list.ts
@@ -33,9 +33,6 @@ export class DiagramList {
       this.eventAggregator.subscribe(AuthenticationStateEvent.LOGIN, () => {
         this.updateDiagramList();
       }),
-      this.eventAggregator.subscribe(AuthenticationStateEvent.LOGOUT, () => {
-        this.updateDiagramList();
-      }),
     ];
   }
 

--- a/src/modules/think/diagram-list/diagram-list.ts
+++ b/src/modules/think/diagram-list/diagram-list.ts
@@ -42,7 +42,7 @@ export class DiagramList {
   public detached(): void {
     this.isAttached = false;
 
-    clearTimeout(this.pollingTimeout as NodeJS.Timer);
+    this.stopPolling();
 
     for (const subscription of this.subscriptions) {
       subscription.dispose();
@@ -57,6 +57,10 @@ export class DiagramList {
         this.startPolling();
       }
     }, environment.processengine.processDefListPollingIntervalInMs);
+  }
+
+  private stopPolling(): void {
+    clearTimeout(this.pollingTimeout);
   }
 
   public showDetails(diagramName: string): void {


### PR DESCRIPTION
## Changes

1. Fix Publishing Login Event
2.  Fix Updating Think after Login
3.  Fix Updating ProcessList after Login
4.  Fix Updating TaskList after Login
5.  Fix Updating CronjobList after Login
6. Fix Removing Subscriptions in TaskList
7. Fix Removing Subscriptions in ProcessList
8. Fix Removing Subscriptions in CronjobList

## Issues

Closes #1829

PR: #1832

## How to test the changes

- Connect to a BPMN Studio with GodToken disabled
- Go to Inspect View
- Login
- **Notice that the ProcessList will show the active ProcessInstances**

> Same for TaskList, CronjobList & Think View