### PR TITLE
🐛 Fix Refreshing Diagrams in Solution Explorer on Login

### DIFF
--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.ts
@@ -11,12 +11,13 @@ import {IDiagram} from '@process-engine/solutionexplorer.contracts';
 import {ISolutionExplorerService} from '@process-engine/solutionexplorer.service.contracts';
 
 import {
+  AuthenticationStateEvent,
   IAuthenticationService,
   ILoginResult,
   ISolutionEntry,
   ISolutionService,
   IUserIdentity,
-} from '../../../contracts';
+} from '../../../contracts/index';
 import {OpenDiagramsSolutionExplorerService} from '../../../services/solution-explorer-services/open-diagrams-solution-explorer.service';
 import {SolutionExplorerServiceFactory} from '../../../services/solution-explorer-services/solution-explorer-service-factory';
 import {SolutionExplorerSolution} from '../solution-explorer-solution/solution-explorer-solution';
@@ -390,6 +391,8 @@ export class SolutionExplorerList {
 
     await solutionEntry.service.openSolution(solutionEntry.uri, solutionEntry.identity);
     this.solutionService.persistSolutionsInLocalStorage();
+
+    this.eventAggregator.publish(AuthenticationStateEvent.LOGIN);
   }
 
   public async logout(solutionEntry: ISolutionEntry): Promise<void> {

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -107,7 +107,7 @@ export class SolutionExplorerSolution {
     currentDiagramInputValue: undefined,
   };
 
-  private refreshTimeoutTask: NodeJS.Timer | number;
+  private refreshTimeoutTask: NodeJS.Timer;
 
   private diagramValidationRegExpList: Array<RegExp> = [/^[a-z0-9]/i, /^[._ -]/i, /^[äöüß]/i];
 

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -14,6 +14,7 @@ import {ISolutionExplorerService} from '@process-engine/solutionexplorer.service
 import {IIdentity} from '@essential-projects/iam_contracts';
 import {IResponse} from '@essential-projects/http_contracts';
 import {
+  AuthenticationStateEvent,
   IDiagramCreationService,
   IDiagramState,
   IDiagramStateList,
@@ -314,11 +315,17 @@ export class SolutionExplorerSolution {
       // In the future we can maybe display a small icon indicating the error.
       if (isError(error, UnauthorizedError)) {
         this.notificationService.showNotification(NotificationType.ERROR, 'You need to login to list process models.');
+
+        this.sortedDiagramsOfSolutions = [];
+        this.openedSolution = undefined;
       } else if (isError(error, ForbiddenError)) {
         this.notificationService.showNotification(
           NotificationType.ERROR,
           "You don't have the required permissions to list process models.",
         );
+
+        this.sortedDiagramsOfSolutions = [];
+        this.openedSolution = undefined;
       } else {
         this.openedSolution.diagrams = undefined;
         this.fontAwesomeIconClass = 'fa-bolt';

--- a/src/services/authentication-service/electron.oidc-authentication-service.ts
+++ b/src/services/authentication-service/electron.oidc-authentication-service.ts
@@ -69,8 +69,6 @@ export class ElectronOidcAuthenticationService implements IAuthenticationService
             idToken: tokenObject.idToken,
           };
 
-          this.eventAggregator.publish(AuthenticationStateEvent.LOGIN);
-
           ipcRenderer.removeAllListeners('oidc-login-reply');
 
           resolve(loginResult);


### PR DESCRIPTION
## Changes

1. Fix Publishing Login Event
2. Clear Diagrams in SolutionExplorer When Not Authorized
3. Stop Polling When Unauthorized

## Issues

Closes #1828 

PR: #1833

## How to test the changes

- Connect to a BPMN Studio with GodToken disabled
- Login
- Deploy some processes
- Logout
- **Notice that the SolutionExplorer will no longer show any diagrams.**
- **Notice that the 'You don't have the required permissions to list process models.' error message will no longer get spammed.**