### PR TITLE
🐛 Fix Saving After Canceling Saving Dialog

### DIFF
--- a/src/modules/design/diagram-detail/diagram-detail.ts
+++ b/src/modules/design/diagram-detail/diagram-detail.ts
@@ -120,7 +120,15 @@ export class DiagramDetail {
         this.handleFormValidateEvents(event);
       }),
       this.eventAggregator.subscribe(environment.events.diagramDetail.saveDiagram, async () => {
-        await this.saveDiagram();
+        try {
+          await this.saveDiagram();
+        } catch (error) {
+          if (error.message === 'No path was selected.') {
+            return;
+          }
+
+          throw error;
+        }
 
         this.eventAggregator.publish(environment.events.diagramDetail.saveDiagramDone);
       }),
@@ -284,7 +292,7 @@ export class DiagramDetail {
 
     await this.bpmnio.saveDiagramState(this.activeDiagramUri);
 
-    this.saveDiagramService.saveDiagram(this.activeSolutionEntry, this.activeDiagram, xml);
+    await this.saveDiagramService.saveDiagram(this.activeSolutionEntry, this.activeDiagram, xml);
 
     this.bpmnio.saveCurrentXML();
     this.diagramHasChanged = false;

--- a/src/services/save-diagram-service/save-diagram.service.ts
+++ b/src/services/save-diagram-service/save-diagram.service.ts
@@ -118,7 +118,15 @@ export class SaveDiagramService {
     this.isSaving = true;
 
     const pathIsSet: boolean = path !== undefined;
-    const pathToSaveTo: string = pathIsSet ? path : await this.getPathToSaveTo();
+
+    let pathToSaveTo: string;
+    try {
+      pathToSaveTo = pathIsSet ? path : await this.getPathToSaveTo();
+    } catch (error) {
+      this.isSaving = false;
+
+      throw error;
+    }
 
     const diagramIsUnsaved: boolean = diagramToSave.uri.startsWith('about:open-diagrams');
     if (diagramIsUnsaved) {
@@ -209,9 +217,11 @@ export class SaveDiagramService {
   private async getPathToSaveTo(): Promise<string> {
     return new Promise((resolve: Function, reject: Function): void => {
       this.ipcRenderer.once('save_diagram_as', async (event: Event, savePath: string) => {
-        const noFileSelected: boolean = savePath === null;
-        if (noFileSelected) {
-          reject(new Error('No file was selected.'));
+        const noPathSelected: boolean = savePath === null;
+        if (noPathSelected) {
+          reject(new Error('No path was selected.'));
+
+          return;
         }
 
         resolve(savePath);


### PR DESCRIPTION
## Changes

1. Fix Saving After Canceling Saving Dialog

PR: #1837

## How to test the changes

- Create a new diagram
- Hit CMD+S
- Cancel the saving dialog
- Hit CMD+S
- **Notice that the saving dialog gets displayed.**