### PR TITLE
🐛 Fix Selecting CallActivities

### DIFF
--- a/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.ts
@@ -262,6 +262,11 @@ export class CallActivitySection implements ISection {
 
     const propertiesElement = this.getPropertiesElement();
 
+    const propertiesElementExists: boolean = propertiesElement !== undefined;
+    if (!propertiesElementExists) {
+      return undefined;
+    }
+
     const payloadProperty = propertiesElement.values.find((value: IPropertiesElement) => value.name === 'payload');
     return payloadProperty ? payloadProperty.value : undefined;
   }

--- a/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.ts
@@ -102,6 +102,10 @@ export class CallActivitySection implements ISection {
   }
 
   public selectedStartEventChanged(newValue, oldValue): void {
+    if (newValue === undefined || oldValue === undefined) {
+      return;
+    }
+
     this.publishDiagramChange();
 
     const noExtensionsElements =

--- a/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.ts
@@ -243,7 +243,6 @@ export class CallActivitySection implements ISection {
     const propertiesElement = this.getPropertiesElement();
 
     const propertiesElementExists: boolean = propertiesElement !== undefined;
-
     if (!propertiesElementExists) {
       return undefined;
     }

--- a/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.ts
@@ -247,7 +247,13 @@ export class CallActivitySection implements ISection {
       return undefined;
     }
 
-    return propertiesElement.values.find((value: IPropertiesElement) => value.name === 'startEventId').value;
+    const startEventIdProperty: IProperty = propertiesElement.values.find(
+      (value: IPropertiesElement) => value.name === 'startEventId',
+    );
+
+    const startEventIdIsConfigured: boolean = startEventIdProperty !== undefined;
+
+    return startEventIdIsConfigured ? startEventIdProperty.value : undefined;
   }
 
   private getPayload(): string | undefined {


### PR DESCRIPTION
## Changes

1. Avoid Setting Edited Flag When Selecting CallActivity
2. Fix Selecting CallActivity Without PropertiesElement
3. Fix Selecting CallActivity With Removed StartEventId

## Issues

Closes #1842
Closes #1843

PR: #1844

## How to test the changes

#1842
- Select a CallActivity with a configured `StartEventId`
- Clear the `StartEventId` input
- Select another element
- Select the CallActivity
- **Notice that the CallActivity section will still appear in the PropertyPanel.**

#1843 
- Create a new diagram called `a.bpmn`
- Create a new diagram called `b.bpmn`
- Add a CallActivity to `b.bpmn` and select `a` as `Process`
- Save the diagram
- Click on another element
- Click on the CallActivity
- Click on another element
- Click on the CallActivity
- **Notice that the `edited` flag won't appear.**