### PR TITLE
✨ Add Tooltip to Disabled Navigation Button

### DIFF
--- a/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.html
@@ -39,7 +39,7 @@
         </tr>
       </table>
 
-      <button class="navigation-button" disabled.bind="!selectedDiagramName || !isPartOfAllDiagrams(selectedDiagramName)" click.delegate="navigateToCalledDiagram()">Navigate to called process</button>
+      <button class="navigation-button" title.bind="!selectedDiagramName || !isPartOfAllDiagrams(selectedDiagramName) ? 'The called process could not be found.' : ''" disabled.bind="!selectedDiagramName || !isPartOfAllDiagrams(selectedDiagramName)" click.delegate="navigateToCalledDiagram()">Navigate to called process</button>
     </div>
   </div>
 

--- a/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.scss
+++ b/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.scss
@@ -4,7 +4,6 @@
 }
 
 .navigation-button:disabled {
-  pointer-events: none;
   opacity: 0.5;
 }
 


### PR DESCRIPTION
## Changes

1. Add Tooltip to Disabled Navigation Button

PR: #1845

## How to test the changes

- Create a new diagram
- Add a CallActivity
- Write the name of a process that does not exist in the `Process` input
- Hover over the disabled `Navigate to called process` button

<img width="1346" alt="Bildschirmfoto 2019-11-06 um 10 37 42" src="https://user-images.githubusercontent.com/20394992/68287549-2cc44f00-0083-11ea-8606-d386c8a6e08e.png">
