### PR TITLE
🐛 Fix `Process` Input of Call Activities

### DIFF
--- a/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.html
@@ -22,7 +22,7 @@
             <div class="called-process-selection">
             <input class="called-process-selection__input props-input" type="text" list="start-events" value.bind="selectedStartEvent" change.delegate="selectedStartEventChanged" disabled.bind="!isEditable">
               <datalist id="start-events">
-                <option repeat.for="startEvent of startEvents" value="${startEvent.id}">
+                <option repeat.for="startEventIdWithDiagramName of startEventIdsWithDiagramNames" value="${startEventIdWithDiagramName.startEventId}">Filename: ${startEventIdWithDiagramName.diagramName}</option>
               </datalist>
             </div>
           </td>

--- a/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.html
@@ -6,7 +6,7 @@
     <div class="panel__content">
       <table class="props-table">
         <tr>
-          <th>Process</th>
+          <th>Process ID</th>
           <td>
             <div class="called-process-selection">
               <input class="called-process-selection__input props-input" type="text" list="diagrams" value.bind="selectedDiagramName" change.delegate="updateCalledDiagram()" disabled.bind="!isEditable"}>

--- a/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.html
@@ -9,10 +9,10 @@
           <th>Process ID</th>
           <td>
             <div class="called-process-selection">
-              <input class="called-process-selection__input props-input" type="text" list="diagrams" value.bind="selectedDiagramName" change.delegate="updateCalledDiagram()" disabled.bind="!isEditable"}>
-                <datalist id="diagrams">
-                  <option repeat.for="diagram of allDiagrams" value="${getProcessIdByDiagramName(diagram.name)}">Filename: ${diagram.name}</option>
-                </datalist>
+              <input class="called-process-selection__input props-input" type="text" list="diagrams" value.bind="selectedProcessId" change.delegate="updateCalledDiagram()" disabled.bind="!isEditable"}>
+              <datalist id="diagrams">
+                <option repeat.for="diagramNameWithProcessId of diagramNamesWithProcessIds" value="${diagramNameWithProcessId.processId}">Filename: ${diagramNameWithProcessId.diagramName}</option>
+              </datalist>
             </div>
           </td>
         </tr>
@@ -36,7 +36,8 @@
           </td>
         </tr>
       </table>
-      <button class="btn btn-default btn-sm navigation-button" title.bind="!selectedDiagramName || !isPartOfAllDiagrams(selectedDiagramName) ? 'The called process could not be found.' : ''" disabled.bind="!selectedDiagramName || !isPartOfAllDiagrams(selectedDiagramName)" click.delegate="navigateToCalledDiagram()">Navigate to called process</button>
+
+      <button class="btn btn-default btn-sm navigation-button" title.bind="!selectedProcessId || !isPartOfAllDiagrams(selectedProcessId) ? 'The called process could not be found.' : ''" disabled.bind="!selectedProcessId || !isPartOfAllDiagrams(selectedProcessId)" click.delegate="navigateToCalledDiagram()">Navigate to called process</button>
     </div>
   </div>
 

--- a/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.html
@@ -51,4 +51,23 @@
       <button type="button" class="btn btn-primary" data-dismiss="modal" click.delegate="showModal = false">Okay</button>
     </template>
   </modal>
+
+
+  <modal if.bind="showChooseDiagramModal" header-text="Choose Diagram">
+    <template replace-part="modal-body">
+      Multiple diagrams were found with that Process ID.
+      Which diagram would you like to see?
+      <select class="props-input props-select" value.bind="callActivitySection.selectedDiagramName">
+          <option model.bind="null">-Choose Diagram-</option>
+          <option repeat.for="diagramName of diagramNamesToSelectFrom"
+                  model="${diagramName}">
+            ${diagramName}
+          </option>
+        </select>
+    </template>
+    <template replace-part="modal-footer">
+      <button type="button" class="btn btn-default" data-dismiss="modal" id="cancelNavigationModal">Cancel</button>
+      <button type="button" class="btn btn-primary" data-dismiss="modal" id="confirmNavigationModal" disabled.bind="!callActivitySection.selectedDiagramName">Navigate</button>
+    </template>
+  </modal>
 </template>

--- a/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.html
@@ -29,7 +29,7 @@
         </tr>
         <tr show.bind="selectedStartEvent">
           <th>Payload
-            <a class="payload-enlarge-link" click.delegate="showModal = true"><small class="payload-enlarge-link">Enlarge</small>
+            <a class="payload-enlarge-link" click.delegate="showPayloadModal = true"><small class="payload-enlarge-link">Enlarge</small>
           </th>
           <td>
             <textarea ref="payloadInput" class="props-input-textarea name-input" value.bind="payload" disabled.bind="!isEditable"></textarea>
@@ -41,14 +41,13 @@
     </div>
   </div>
 
-
-  <modal show.bind="showModal"
+  <modal show.bind="showPayloadModal"
          header-text="Editing: Payload">
     <template replace-part="modal-body" autofocus>
       <textarea class="form-control script-task" value.bind="payload" rows="10" aria-multiline="true" autofocus wrap="soft" disabled.bind="!isEditable"></textarea>
     </template>
     <template replace-part="modal-footer">
-      <button type="button" class="btn btn-primary" data-dismiss="modal" click.delegate="showModal = false">Okay</button>
+      <button type="button" class="btn btn-primary" data-dismiss="modal" click.delegate="showPayloadModal = false">Okay</button>
     </template>
   </modal>
 

--- a/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.html
@@ -11,7 +11,7 @@
             <div class="called-process-selection">
               <input class="called-process-selection__input props-input" type="text" list="diagrams" value.bind="selectedDiagramName" change.delegate="updateCalledDiagram()" disabled.bind="!isEditable"}>
                 <datalist id="diagrams">
-                  <option repeat.for="diagram of allDiagrams" value="${getProcessIdByDiagramName(diagram.name)}"></option>
+                  <option repeat.for="diagram of allDiagrams" value="${getProcessIdByDiagramName(diagram.name)}">Filename: ${diagram.name}</option>
                 </datalist>
             </div>
           </td>

--- a/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.html
@@ -11,7 +11,7 @@
             <div class="called-process-selection">
               <input class="called-process-selection__input props-input" type="text" list="diagrams" value.bind="selectedDiagramName" change.delegate="updateCalledDiagram()" disabled.bind="!isEditable"}>
                 <datalist id="diagrams">
-                  <option repeat.for="diagram of allDiagrams" value="${diagram.name}">
+                  <option repeat.for="diagram of allDiagrams" value="${getProcessIdByDiagramName(diagram.name)}"></option>
                 </datalist>
             </div>
           </td>

--- a/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.ts
@@ -16,6 +16,8 @@ import {IBpmnModdle, IPageModel, ISection} from '../../../../../../../contracts'
 import environment from '../../../../../../../environment';
 import {GeneralService} from '../../service/general.service';
 
+const ProcessIdRegex: RegExp = /(?<=process id=").*?(?=")/;
+
 @inject(GeneralService, Router, EventAggregator)
 export class CallActivitySection implements ISection {
   public path: string = '/sections/call-activity/call-activity';
@@ -184,6 +186,20 @@ export class CallActivitySection implements ISection {
     this.businessObjInPanel.calledElement = this.selectedDiagramName;
 
     this.publishDiagramChange();
+  }
+
+  public getProcessIdByDiagramName(diagramName: string): string {
+    const diagram: IDiagram = this.getDiagramByName(diagramName);
+
+    const processId: string = diagram.xml.match(ProcessIdRegex)[0];
+
+    return processId;
+  }
+
+  private getDiagramByName(name: string): IDiagram {
+    return this.allDiagrams.find((diagram: IDiagram): boolean => {
+      return diagram.name === name;
+    });
   }
 
   private getPropertiesElement(): IPropertiesElement {

--- a/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.ts
@@ -40,6 +40,7 @@ export class CallActivitySection implements ISection {
   @observable public payload: string;
   public payloadInput: HTMLTextAreaElement;
   public diagramNamesWithProcessIds: Array<DiagramNameWithProcessId> = [];
+  public showPayloadModal: boolean;
 
   public callActivitySection: CallActivitySection = this;
 

--- a/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.ts
@@ -23,12 +23,17 @@ type DiagramNameWithProcessId = {
   processId: string;
 };
 
+type StartEventIdWithDiagramName = {
+  diagramName: string;
+  startEventId: string;
+};
+
 @inject(GeneralService, Router, EventAggregator)
 export class CallActivitySection implements ISection {
   public path: string = '/sections/call-activity/call-activity';
   public canHandleElement: boolean = false;
   @observable public allDiagrams: Array<IDiagram>;
-  public startEvents: Array<IShape>;
+  public startEventIdsWithDiagramNames: Array<StartEventIdWithDiagramName>;
   public previouslySelectedDiagram: string;
   public selectedProcessId: string;
   @observable public selectedStartEvent: string;
@@ -57,19 +62,20 @@ export class CallActivitySection implements ISection {
     await this.getAllDiagrams();
 
     this.previouslySelectedDiagram = this.businessObjInPanel.calledElement;
-    this.selectedDiagramName = this.businessObjInPanel.calledElement;
+    this.selectedProcessId = this.businessObjInPanel.calledElement;
 
-    if (this.selectedDiagramName) {
+    const processIdIsSelected: boolean = this.selectedProcessId !== undefined;
+    if (processIdIsSelected) {
       try {
-        this.startEvents = await this.generalService.getAllStartEventsForDiagram(this.selectedDiagramName);
+        this.startEventIdsWithDiagramNames = await this.getAllStartEventsForProcessId(this.selectedProcessId);
       } catch (error) {
-        this.startEvents = [];
+        this.startEventIdsWithDiagramNames = [];
       }
 
       this.selectedStartEvent = this.getSelectedStartEvent();
 
-      if (this.selectedStartEvent === undefined && this.startEvents.length > 0) {
-        this.selectedStartEvent = this.startEvents[0].id;
+      if (this.selectedStartEvent === undefined && this.startEventIdsWithDiagramNames.length > 0) {
+        this.selectedStartEvent = this.startEventIdsWithDiagramNames[0].startEventId;
       }
 
       this.payload = this.getPayload();
@@ -209,9 +215,9 @@ export class CallActivitySection implements ISection {
 
   public async updateCalledDiagram(): Promise<void> {
     try {
-      this.startEvents = await this.generalService.getAllStartEventsForDiagram(this.selectedDiagramName);
+      this.startEventIdsWithDiagramNames = await this.getAllStartEventsForProcessId(this.selectedProcessId);
     } catch (error) {
-      this.startEvents = [];
+      this.startEventIdsWithDiagramNames = [];
     }
 
     this.businessObjInPanel.calledElement = this.selectedProcessId;

--- a/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.ts
@@ -12,7 +12,7 @@ import {
 } from '@process-engine/bpmn-elements_contracts';
 import {IDiagram} from '@process-engine/solutionexplorer.contracts';
 
-import {IBpmnModdle, IPageModel, ISection, IEventFunction} from '../../../../../../../contracts';
+import {IBpmnModdle, IEventFunction, IPageModel, ISection} from '../../../../../../../contracts';
 import environment from '../../../../../../../environment';
 import {GeneralService} from '../../service/general.service';
 


### PR DESCRIPTION
## Changes

1. Use ProcessId Instead of Diagram Name for `Process` Input of CallActivities
2. Improve `Process ID` Input Label

## Issues

Closes #1855 

PR: #1865

## How to test the changes

- Open a diagram with a CallActivity
- Click on the CallActivity
- Select a `called process` via the `Process ID` Input
- **Notice that the list includes the Process IDs instead of the filenames**
- **Notice that one can filter the Process IDs via the filenames by entering `Filename: `**

<img width="314" alt="Bildschirmfoto 2019-11-11 um 15 38 43" src="https://user-images.githubusercontent.com/20394992/68595239-58877080-0499-11ea-917c-11294b4772dc.png">
