### PR TITLE
🚸 Avoid Navigating after Deploying via Context Menu

### DIFF
--- a/src/contracts/diagram/DeployResult.ts
+++ b/src/contracts/diagram/DeployResult.ts
@@ -1,0 +1,7 @@
+import {IDiagram} from '@process-engine/solutionexplorer.contracts';
+import {ISolutionEntry} from '../solution-explorer';
+
+export type DeployResult = {
+  diagram: IDiagram;
+  solution: ISolutionEntry;
+};

--- a/src/contracts/diagram/index.ts
+++ b/src/contracts/diagram/index.ts
@@ -2,3 +2,4 @@ export * from './IDiagramState';
 export * from './IDiagramStateList';
 export * from './IDiagramStateListEntry';
 export * from './DiagramStateChange';
+export * from './DeployResult';

--- a/src/modules/design/diagram-detail/diagram-detail.ts
+++ b/src/modules/design/diagram-detail/diagram-detail.ts
@@ -14,7 +14,13 @@ import {
 import {DataModels} from '@process-engine/management_api_contracts';
 import {IDiagram} from '@process-engine/solutionexplorer.contracts';
 
-import {IElementRegistry, ISolutionEntry, IUserInputValidationRule, NotificationType} from '../../../contracts/index';
+import {
+  DeployResult,
+  IElementRegistry,
+  ISolutionEntry,
+  IUserInputValidationRule,
+  NotificationType,
+} from '../../../contracts/index';
 
 import environment from '../../../environment';
 import {NotificationService} from '../../../services/notification-service/notification.service';
@@ -464,7 +470,16 @@ export class DiagramDetail {
   private async deployDiagram(): Promise<void> {
     const xml: string | undefined = this.diagramHasChanged ? await this.bpmnio.getXML() : undefined;
 
-    this.deployDiagramService.deployDiagram(this.activeSolutionEntry, this.activeDiagram, xml);
+    const deployResult: DeployResult = await this.deployDiagramService.deployDiagram(
+      this.activeSolutionEntry,
+      this.activeDiagram,
+      xml,
+    );
+
+    this.router.navigateToRoute('design', {
+      diagramName: deployResult.diagram.name,
+      solutionUri: deployResult.solution.uri,
+    });
   }
 
   /**

--- a/src/services/deploy-diagram-service/deploy-diagram.service.ts
+++ b/src/services/deploy-diagram-service/deploy-diagram.service.ts
@@ -8,7 +8,6 @@ import * as bundle from '@process-engine/bpmn-js-custom-bundle';
 import {IModdleElement} from '@process-engine/bpmn-elements_contracts';
 import environment from '../../environment';
 import {SolutionService} from '../solution-service/solution.service';
-import {SaveDiagramService} from '../save-diagram-service/save-diagram.service';
 import {
   DeployResult,
   IBpmnModdle,
@@ -19,14 +18,13 @@ import {
 } from '../../contracts/index';
 import {NotificationService} from '../notification-service/notification.service';
 
-@inject(EventAggregator, 'SolutionService', SaveDiagramService, Router, 'NotificationService')
+@inject(EventAggregator, 'SolutionService', Router, 'NotificationService')
 export class DeployDiagramService {
   private router: Router;
   private eventAggregator: EventAggregator;
   private notificationService: NotificationService;
 
   private solutionService: SolutionService;
-  private saveDiagramService: SaveDiagramService;
 
   private modeler: IBpmnModeler;
   private moddle: IBpmnModdle;
@@ -34,13 +32,11 @@ export class DeployDiagramService {
   constructor(
     eventAggregator: EventAggregator,
     solutionService: SolutionService,
-    saveDiagramService: SaveDiagramService,
     router: Router,
     notificationService: NotificationService,
   ) {
     this.eventAggregator = eventAggregator;
     this.solutionService = solutionService;
-    this.saveDiagramService = saveDiagramService;
     this.router = router;
     this.notificationService = notificationService;
 

--- a/src/services/deploy-diagram-service/deploy-diagram.service.ts
+++ b/src/services/deploy-diagram-service/deploy-diagram.service.ts
@@ -93,11 +93,6 @@ export class DeployDiagramService {
 
       const deployedDiagram: IDiagram = await solutionToDeployTo.service.loadDiagram(processModelId);
 
-      this.router.navigateToRoute('design', {
-        diagramName: deployedDiagram.name,
-        solutionUri: solutionToDeployTo.uri,
-      });
-
       this.notificationService.showNotification(
         NotificationType.SUCCESS,
         'Diagram was successfully uploaded to the connected ProcessEngine.',


### PR DESCRIPTION
## Changes

1. Avoid Navigating after Deploying via Context Menu
2. Remove Unneeded Code

## Issues

Closes #1852 

PR: #1868

## How to test the changes

- Open a solution
- Right click any diagram
- Click 'Deploy'
- **Notice that the diagram gets deployed but not shown**

- Open a diagram
- Click on the deploy button
- **Notice that the BPMN Studio still navigates to the diagram when deploying via the deploy button.**