### PR TITLE
🐛 Fix Order of Processes in ProcessList

### DIFF
--- a/src/modules/inspect/process-list/process-list.ts
+++ b/src/modules/inspect/process-list/process-list.ts
@@ -252,17 +252,13 @@ export class ProcessList {
         return;
       }
 
-      const sortedProcessInstances: Array<
-        DataModels.Correlations.ProcessInstance
-      > = processInstanceList.processInstances.sort(this.sortProcessInstances);
-
       const processInstanceListWasUpdated: boolean =
-        JSON.stringify(sortedProcessInstances) !== JSON.stringify(this.processInstances);
+        JSON.stringify(processInstanceList.processInstances) !== JSON.stringify(this.processInstances);
 
       this.totalItems = processInstanceList.totalCount + this.stoppedProcessInstances.length;
 
       if (processInstanceListWasUpdated) {
-        this.processInstances = sortedProcessInstances;
+        this.processInstances = processInstanceList.processInstances;
 
         this.updateProcessInstancesToDisplay();
       }
@@ -319,15 +315,6 @@ export class ProcessList {
     return this.updatePromise;
   }
 
-  private sortProcessInstances(
-    firstProcessInstance: DataModels.Correlations.ProcessInstance,
-    secondProcessInstance: DataModels.Correlations.ProcessInstance,
-  ): number {
-    return (
-      Date.parse(secondProcessInstance.createdAt.toString()) - Date.parse(firstProcessInstance.createdAt.toString())
-    );
-  }
-
   private updateProcessInstancesToDisplay(): void {
     this.processInstancesToDisplay = this.processInstances;
 
@@ -342,8 +329,6 @@ export class ProcessList {
         this.processInstancesToDisplay.push(stoppedProcessInstance);
       }
     });
-
-    this.processInstancesToDisplay.sort(this.sortProcessInstances);
 
     this.paginationShowsLoading = false;
   }


### PR DESCRIPTION
## Changes

1. Remove Old Sorting Mechanism

## Issues

Closes #1871 

PR: #1872

## How to test the changes

- Have a look at the ProcessList
- **Notice that the oldest Process is the first entry instead of the 10th oldest.**