### PR TITLE
💄 Harmonize Style of PropertyPanel Elements

### DIFF
--- a/src/modules/design/property-panel/indextabs/extensions/sections/basics/basics.html
+++ b/src/modules/design/property-panel/indextabs/extensions/sections/basics/basics.html
@@ -12,10 +12,10 @@
       <table>
         <tr repeat.for="property of properties" index.bind="$index">
           <td class="key-value-column-left">
-            <input data-fieldIndex="${$index}" focus.one-time="shouldFocus" blur.trigger="inputFieldBlurred($index, $event)" type="text" class="props-input key-value-input" value.bind="newNames[$index]" placeholder="Name" change.delegate="changeName($index)" disabled.bind="!isEditable">
+            <input data-fieldIndex="${$index}" type="text" class="props-input key-value-input" placeholder="Name" focus.one-time="shouldFocus" blur.trigger="inputFieldBlurred($index, $event)" value.bind="newNames[$index]" change.delegate="changeName($index)" disabled.bind="!isEditable">
           </td>
           <td class="key-value-column-right">
-            <input data-fieldIndex="${$index}" type="text" class="props-input key-value-input" blur.trigger="inputFieldBlurred($index, $event)" value.bind="newValues[$index]" placeholder="Value" change.delegate="changeValue($index)" disabled.bind="!isEditable">
+            <input data-fieldIndex="${$index}" type="text" class="props-input key-value-input" placeholder="Value"  blur.trigger="inputFieldBlurred($index, $event)" value.bind="newValues[$index]" change.delegate="changeValue($index)" disabled.bind="!isEditable">
           </td>
           <td>
             <button class="button key-value-delete-button" click.delegate="removeProperty($index)" disabled.bind="!isEditable">

--- a/src/modules/design/property-panel/indextabs/extensions/sections/basics/basics.html
+++ b/src/modules/design/property-panel/indextabs/extensions/sections/basics/basics.html
@@ -12,10 +12,10 @@
       <table>
         <tr repeat.for="property of properties" index.bind="$index">
           <td class="key-value-column-left">
-            <input data-fieldIndex="${$index}" focus.one-time="shouldFocus" blur.trigger="inputFieldBlurred($index, $event)" type="text" class="key-value-input" value.bind="newNames[$index]" placeholder="Name" change.delegate="changeName($index)" disabled.bind="!isEditable">
+            <input data-fieldIndex="${$index}" focus.one-time="shouldFocus" blur.trigger="inputFieldBlurred($index, $event)" type="text" class="props-input key-value-input" value.bind="newNames[$index]" placeholder="Name" change.delegate="changeName($index)" disabled.bind="!isEditable">
           </td>
           <td class="key-value-column-right">
-            <input data-fieldIndex="${$index}" type="text" class="key-value-input" blur.trigger="inputFieldBlurred($index, $event)" value.bind="newValues[$index]" placeholder="Value" change.delegate="changeValue($index)" disabled.bind="!isEditable">
+            <input data-fieldIndex="${$index}" type="text" class="props-input key-value-input" blur.trigger="inputFieldBlurred($index, $event)" value.bind="newValues[$index]" placeholder="Value" change.delegate="changeValue($index)" disabled.bind="!isEditable">
           </td>
           <td>
             <button class="button key-value-delete-button" click.delegate="removeProperty($index)" disabled.bind="!isEditable">

--- a/src/modules/design/property-panel/indextabs/extensions/sections/basics/basics.html
+++ b/src/modules/design/property-panel/indextabs/extensions/sections/basics/basics.html
@@ -9,7 +9,7 @@
       </button>
     </div>
     <div class="panel__content">
-      <table>
+      <table class="property-table">
         <tr repeat.for="property of properties" index.bind="$index">
           <td class="key-value-column-left">
             <input data-fieldIndex="${$index}" type="text" class="props-input key-value-input" placeholder="Name" focus.one-time="shouldFocus" blur.trigger="inputFieldBlurred($index, $event)" value.bind="newNames[$index]" change.delegate="changeName($index)" disabled.bind="!isEditable">

--- a/src/modules/design/property-panel/indextabs/extensions/sections/basics/basics.html
+++ b/src/modules/design/property-panel/indextabs/extensions/sections/basics/basics.html
@@ -11,10 +11,10 @@
     <div class="panel__content">
       <table class="property-table">
         <tr repeat.for="property of properties" index.bind="$index">
-          <td class="key-value-column-left">
+          <td class="property-table-column-left">
             <input data-fieldIndex="${$index}" type="text" class="props-input key-value-input" placeholder="Name" focus.one-time="shouldFocus" blur.trigger="inputFieldBlurred($index, $event)" value.bind="newNames[$index]" change.delegate="changeName($index)" disabled.bind="!isEditable">
           </td>
-          <td class="key-value-column-right">
+          <td class="property-table-column-right">
             <input data-fieldIndex="${$index}" type="text" class="props-input key-value-input" placeholder="Value"  blur.trigger="inputFieldBlurred($index, $event)" value.bind="newValues[$index]" change.delegate="changeValue($index)" disabled.bind="!isEditable">
           </td>
           <td>

--- a/src/modules/design/property-panel/indextabs/extensions/sections/basics/basics.scss
+++ b/src/modules/design/property-panel/indextabs/extensions/sections/basics/basics.scss
@@ -2,12 +2,12 @@
   border-collapse: separate;
 }
 
-.key-value-column-left {
+.property-table-column-left {
   width: 30%;
   padding-right: 3px;
 }
 
-.key-value-column-right {
+.property-table-column-right {
   width: 70%;
   padding-left: 3px;
 }

--- a/src/modules/design/property-panel/indextabs/extensions/sections/basics/basics.scss
+++ b/src/modules/design/property-panel/indextabs/extensions/sections/basics/basics.scss
@@ -1,9 +1,15 @@
+.property-table {
+  border-collapse: separate;
+}
+
 .key-value-column-left {
   width: 30%;
+  padding-right: 3px;
 }
 
 .key-value-column-right {
   width: 70%;
+  padding-left: 3px;
 }
 
 .key-value-input {

--- a/src/modules/design/property-panel/indextabs/general/sections/basics/basics.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/basics/basics.html
@@ -22,11 +22,9 @@
             <input type="text" class="props-input" value.bind="businessObjInPanel.name" change.delegate="updateName()" disabled.bind="!isEditable" data-test-property-panel-element-name>
           </td>
         </tr>
-      </table>
-      <table class="props-table-docs">
         <tr>
+          <th>Docs <a class="docs-enlarge-link" click.delegate="showModal = true"><small class="docs-enlarge-text">Enlarge</small></a></th>
           <td>
-              Docs <a class="docs-enlarge-link" click.delegate="showModal = true"><small class="docs-enlarge-text">Enlarge</small></a>
             <textarea type="text" ref="docsInput" class="props-input-textarea" value.bind="elementDocumentation" change.delegate="updateDocumentation()" disabled.bind="!isEditable" aria-multiline="true"></textarea>
           </td>
         </tr>

--- a/src/modules/design/property-panel/indextabs/general/sections/basics/basics.scss
+++ b/src/modules/design/property-panel/indextabs/general/sections/basics/basics.scss
@@ -22,6 +22,7 @@
 .props-input-textarea {
   width: 100%;
   height: 25px;
+  max-height: 200px;
   min-height: 25px;
   padding-bottom: 5px;
   margin-top: 5px;

--- a/src/modules/design/property-panel/indextabs/general/sections/basics/basics.scss
+++ b/src/modules/design/property-panel/indextabs/general/sections/basics/basics.scss
@@ -51,6 +51,7 @@
 }
 
 .docs-enlarge-link {
+  display: block;
   cursor: pointer;
   color: #007bff !important;
 }

--- a/src/modules/design/property-panel/indextabs/general/sections/basics/basics.scss
+++ b/src/modules/design/property-panel/indextabs/general/sections/basics/basics.scss
@@ -27,6 +27,7 @@
   margin-top: 5px;
   background: transparent;
   border: none;
+  outline: none;
   border-bottom: 1px solid #e9e9e9;
   font-weight: 400;
   color: #5c5c5c;

--- a/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.html
@@ -16,7 +16,6 @@
             </div>
           </td>
         </tr>
-
         <tr>
           <th>StartEvent</th>
           <td>
@@ -28,7 +27,6 @@
             </div>
           </td>
         </tr>
-
         <tr show.bind="selectedStartEvent">
           <th>Payload
             <a class="payload-enlarge-link" click.delegate="showModal = true"><small class="payload-enlarge-link">Enlarge</small>
@@ -38,7 +36,6 @@
           </td>
         </tr>
       </table>
-
       <button class="navigation-button" title.bind="!selectedDiagramName || !isPartOfAllDiagrams(selectedDiagramName) ? 'The called process could not be found.' : ''" disabled.bind="!selectedDiagramName || !isPartOfAllDiagrams(selectedDiagramName)" click.delegate="navigateToCalledDiagram()">Navigate to called process</button>
     </div>
   </div>

--- a/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.html
@@ -34,7 +34,7 @@
             <a class="payload-enlarge-link" click.delegate="showModal = true"><small class="payload-enlarge-link">Enlarge</small>
           </th>
           <td>
-            <textarea ref="payloadInput" class="props-textarea name-input" value.bind="payload" disabled.bind="!isEditable"></textarea>
+            <textarea ref="payloadInput" class="props-input-textarea name-input" value.bind="payload" disabled.bind="!isEditable"></textarea>
           </td>
         </tr>
       </table>

--- a/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.html
@@ -36,7 +36,7 @@
           </td>
         </tr>
       </table>
-      <button class="navigation-button" title.bind="!selectedDiagramName || !isPartOfAllDiagrams(selectedDiagramName) ? 'The called process could not be found.' : ''" disabled.bind="!selectedDiagramName || !isPartOfAllDiagrams(selectedDiagramName)" click.delegate="navigateToCalledDiagram()">Navigate to called process</button>
+      <button class="btn btn-default btn-sm navigation-button" title.bind="!selectedDiagramName || !isPartOfAllDiagrams(selectedDiagramName) ? 'The called process could not be found.' : ''" disabled.bind="!selectedDiagramName || !isPartOfAllDiagrams(selectedDiagramName)" click.delegate="navigateToCalledDiagram()">Navigate to called process</button>
     </div>
   </div>
 

--- a/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.html
@@ -9,7 +9,7 @@
           <th>Process</th>
           <td>
             <div class="called-process-selection">
-              <input class="called-process-selection__input " type="text" list="diagrams" value.bind="selectedDiagramName" change.delegate="updateCalledDiagram()" disabled.bind="!isEditable"}>
+              <input class="called-process-selection__input props-input" type="text" list="diagrams" value.bind="selectedDiagramName" change.delegate="updateCalledDiagram()" disabled.bind="!isEditable"}>
                 <datalist id="diagrams">
                   <option repeat.for="diagram of allDiagrams" value="${diagram.name}">
                 </datalist>
@@ -21,7 +21,7 @@
           <th>StartEvent</th>
           <td>
             <div class="called-process-selection">
-            <input class="called-process-selection__input" type="text" list="start-events" value.bind="selectedStartEvent" change.delegate="selectedStartEventChanged" disabled.bind="!isEditable">
+            <input class="called-process-selection__input props-input" type="text" list="start-events" value.bind="selectedStartEvent" change.delegate="selectedStartEventChanged" disabled.bind="!isEditable">
               <datalist id="start-events">
                 <option repeat.for="startEvent of startEvents" value="${startEvent.id}">
               </datalist>

--- a/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.scss
+++ b/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.scss
@@ -1,10 +1,12 @@
 .navigation-button {
   width: 100%;
   margin-top: 10px;
+  background: #f7f7f7;;
 }
 
 .navigation-button:disabled {
   opacity: 0.5;
+  background: #d6d6d6;
 }
 
 .called-process-selection {

--- a/src/modules/design/property-panel/indextabs/general/sections/message-event/message-event.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/message-event/message-event.html
@@ -23,12 +23,10 @@
             </select>
           </td>
         </tr>
-      </table>
-      <table show.bind="selectedId" class="props-table">
-        <tr>
-          <th class="name-property">Name</th>
+        <tr show.bind="selectedId">
+          <th>Name</th>
           <td>
-            <input type="text" class="props-input name-input" value.bind="selectedMessage.name" change.delegate="updateName()" disabled.bind="!isEditable">
+            <input type="text" class="props-input" value.bind="selectedMessage.name" change.delegate="updateName()" disabled.bind="!isEditable">
           </td>
         </tr>
       </table>

--- a/src/modules/design/property-panel/indextabs/general/sections/message-event/message-event.scss
+++ b/src/modules/design/property-panel/indextabs/general/sections/message-event/message-event.scss
@@ -1,7 +1,0 @@
-.name-property {
-  padding-right: 29px !important;
-}
-
-.name-input {
-  padding-left: 5px;
-}

--- a/src/modules/design/property-panel/indextabs/general/sections/pool/pool.scss
+++ b/src/modules/design/property-panel/indextabs/general/sections/pool/pool.scss
@@ -1,7 +1,3 @@
-.props-input:disabled {
-  color: darkgray;
-}
-
 .process-id-checkbox {
   margin-left: 10px;
 }

--- a/src/modules/design/property-panel/indextabs/general/sections/script-task/script-task.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/script-task/script-task.html
@@ -10,7 +10,7 @@
             <a class="script-task-enlarge-link" click.delegate="showModal = true"><small class="script-task-enlarge-text">Enlarge</small>
           </th>
           <td>
-            <textarea class="props-textarea name-input" ref="scriptInput" value.bind="businessObjInPanel.script" change.delegate="updateScript()" disabled.bind="!isEditable"></textarea>
+            <textarea class="props-input-textarea name-input" ref="scriptInput" value.bind="businessObjInPanel.script" change.delegate="updateScript()" disabled.bind="!isEditable"></textarea>
           </td>
         </tr>
       </table>

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.html
@@ -14,7 +14,7 @@
         <tr>
           <th>Payload<a class="payload-enlarge-link" click.delegate="showModal = true"><small class="payload-enlarge-text">Enlarge</small></a></th>
           <td>
-            <textarea class="props-textarea name-input" ref="payloadInput" value.bind="selectedPayload" change.delegate="payloadChanged()" disabled.bind="!model.isEditable"></textarea>
+            <textarea class="props-input-textarea name-input" ref="payloadInput" value.bind="selectedPayload" change.delegate="payloadChanged()" disabled.bind="!model.isEditable"></textarea>
           </td>
         </tr>
     </div>

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/components/http-service-task/http-service-task.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/components/http-service-task/http-service-task.html
@@ -31,7 +31,7 @@
           <th>Body</th>
           <td>
             <textarea
-              class="props-textarea name-input"
+              class="props-input-textarea name-input"
               value.bind="selectedHttpBody"
               change.delegate="selectedHttpParamsChanged()"
               disabled.bind="!selectedHttpUrl || !model.isEditable"></textarea>

--- a/src/modules/design/property-panel/indextabs/general/sections/signal-event/signal-event.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/signal-event/signal-event.html
@@ -23,12 +23,10 @@
             </select>
           </td>
         </tr>
-      </table>
-      <table show.bind="selectedId" class="props-table">
-        <tr>
-          <th class="name-property">Name</th>
+        <tr show.bind="selectedId">
+          <th>Name</th>
           <td>
-            <input type="text" class="props-input name-input" value.bind="selectedSignal.name" change.delegate="updateName()" disabled.bind="!isEditable">
+            <input type="text" class="props-input" value.bind="selectedSignal.name" change.delegate="updateName()" disabled.bind="!isEditable">
           </td>
         </tr>
       </table>

--- a/src/modules/design/property-panel/indextabs/general/sections/signal-event/signal-event.scss
+++ b/src/modules/design/property-panel/indextabs/general/sections/signal-event/signal-event.scss
@@ -1,7 +1,1 @@
-.name-property {
-  padding-right: 13px !important;
-}
 
-.name-input {
-  padding-left: 5px;
-}

--- a/src/modules/design/property-panel/styles/sections.scss
+++ b/src/modules/design/property-panel/styles/sections.scss
@@ -56,6 +56,16 @@
   opacity: 0.5;
 }
 
+.props-input::-webkit-calendar-picker-indicator {
+  opacity: 0.5;
+}
+
+.props-input::-webkit-calendar-picker-indicator:hover {
+  cursor: pointer;
+  opacity: 1;
+  background: inherit;
+}
+
 .props-select {
   padding-right: 22px;
   border-radius: 0;

--- a/src/modules/design/property-panel/styles/sections.scss
+++ b/src/modules/design/property-panel/styles/sections.scss
@@ -71,7 +71,7 @@
   border-radius: 0;
   -webkit-appearance: none;
   -webkit-border-radius: 0px;
-  background-image: url("data:image/svg+xml;utf8,<svg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='24' height='24' viewBox='0 0 24 24'><path fill='#444' d='M7.406 7.828l4.594 4.594 4.594-4.594 1.406 1.406-6 6-6-6z'></path></svg>");
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 448 512' width='14' height='14'><path d='M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z'/></svg>");
   background-position: 100% 50%;
   background-repeat: no-repeat;
   outline: none;

--- a/src/modules/design/property-panel/styles/sections.scss
+++ b/src/modules/design/property-panel/styles/sections.scss
@@ -67,24 +67,6 @@
   outline: none;
 }
 
-.props-textarea {
-  width: 100%;
-  min-height: 2em;
-  max-height: 200px;
-  padding-bottom: 5px;
-  padding-right: 17px;
-  margin-top: 5px;
-  background: transparent;
-  border: 1px solid #e9e9e9;
-  font-weight: 400;
-  color: #5c5c5c;
-  resize: vertical;
-}
-
-.props-textarea:disabled {
-  opacity: 0.5;
-}
-
 .props-table--clear-button {
   top: 2px;
   right: 15px;


### PR DESCRIPTION
## Changes

1. Remove Outline from 'props-input-textarea'
2. Unify Style of Textareas
3. Adjust Style of Property Inputs
4. Improve Readability
5. Remove Unneeded CSS
6. Adjust Style of Inputs with Datalist
7. Remove Unneeded Newlines
8. Improve Style of Navigate Button
9. Add Spacing Between Property Name & Value

PR: #1874

## How to test the changes

- Have a look at the property panel