### PR TITLE
🐛 Fix Opening Removed Open Diagrams

### DIFF
--- a/src/modules/design/design.ts
+++ b/src/modules/design/design.ts
@@ -369,7 +369,9 @@ export class Design {
         !persistedActiveDiagram.uri.startsWith('about:open-diagrams') && !diagramIsSavedOnRemoteSolution;
 
       if (diagramIsSavedOnLocalSolution) {
-        persistedActiveDiagram.xml = fs.readFileSync(persistedActiveDiagram.uri, 'utf8');
+        if (fs.existsSync(persistedActiveDiagram.uri)) {
+          persistedActiveDiagram.xml = fs.readFileSync(persistedActiveDiagram.uri, 'utf8');
+        }
       } else if (diagramIsSavedOnRemoteSolution) {
         const uri = persistedActiveDiagram.uri.substring(0, persistedActiveDiagram.uri.lastIndexOf('/'));
 


### PR DESCRIPTION
## Changes

1. Fix Opening Removed Open Diagrams

## Issues

Closes #1876 

PR: #1880

## How to test the changes

- Open a diagram from a solution
- Open another diagram
- Remove the first opened diagram via the filesystem
- **Notice that the diagram can get opened via the solution explorer**
- **Notice that the removed diagram can get closed via the close button.**