### PR TITLE
🔥 Remove Useless Default Authority Input Information

### DIFF
--- a/aurelia_project/environments/dev.ts
+++ b/aurelia_project/environments/dev.ts
@@ -12,7 +12,6 @@ export default {
   },
   openIdConnect: {
     authority: 'http://localhost:5000',
-    defaultAuthority: 'http://localhost:5000',
   },
   processengine: {
     liveExecutionTrackerPollingIntervalInMs: 1000,

--- a/src/modules/config-panel/config-panel.html
+++ b/src/modules/config-panel/config-panel.html
@@ -17,14 +17,6 @@
             - only contains the following characters: a-Z 0-9 - . _ ~ : / ? # [ ] @ ! $ & ' ( ) * + , ; = .
           </div>
         </div>
-        <div class="config-panel__card__alert alert alert-info" if.bind="authority !== defaultAuthority" role="alert">
-          <span>
-            <i class="fa fa-info-circle" aria-hidden="true"></i>
-            The authority has been changed. Click
-            <a class="config-panel__card__alert__link alert-link" click.delegate="setDefaultAuthority()">here</a>
-            to use the default authority, this will change the authority to <code>${defaultAuthority}</code>.
-          </span>
-        </div>
       </div>
     </div>
     <button class="btn btn-default" click.delegate="cancelUpdate()">Cancel</button>

--- a/src/modules/config-panel/config-panel.ts
+++ b/src/modules/config-panel/config-panel.ts
@@ -19,7 +19,6 @@ import {
 export class ConfigPanel {
   public internalSolution: ISolutionEntry;
   public authority: string;
-  public defaultAuthority: string;
   public showRestartModal: boolean;
 
   private router: Router;
@@ -52,7 +51,6 @@ export class ConfigPanel {
 
     this.internalSolution = this.solutionService.getSolutionEntryForUri(internalSolutionUri);
     this.authority = this.internalSolution.authority;
-    this.defaultAuthority = await this.getAuthorityForInternalSolution();
   }
 
   public async updateSettings(): Promise<void> {
@@ -95,10 +93,6 @@ export class ConfigPanel {
 
       this.router.navigateBack();
     }
-  }
-
-  public setDefaultAuthority(): void {
-    this.authority = this.defaultAuthority;
   }
 
   public cancelUpdate(): void {
@@ -147,25 +141,6 @@ export class ConfigPanel {
     }
 
     return iamServiceConfigPath;
-  }
-
-  private async getAuthorityForInternalSolution(): Promise<string> {
-    try {
-      const fetchResponse: any = await this.httpFetchClient.get(
-        `${this.internalSolution.uri}/process_engine/security/authority`,
-      );
-
-      return fetchResponse.result.authority;
-    } catch (error) {
-      const errorIsNotFoundError: boolean = error.code === 404;
-      if (errorIsNotFoundError) {
-        const fetchResponse: any = await this.httpFetchClient.get(`${this.internalSolution.uri}/security/authority`);
-
-        return fetchResponse.result.authority;
-      }
-
-      return undefined;
-    }
   }
 
   public get uriIsValid(): boolean {


### PR DESCRIPTION
## Changes

1. Remove Useless Default Authority Input Information

## Issues

Closes #1883 

PR: #1885

## How to test the changes

- Go to the Config Panel of the internal Remote Solution
- Change the authority
- **Notice that no info box will appear.**