### PR TITLE
💄Use Same Cursor Style for Icon Buttons

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -12,6 +12,10 @@ input:focus {
   outline: none !important;
 }
 
+.button:not(:disabled) {
+  cursor: pointer;
+}
+
 .form-control:focus {
   border-color: #ced4da;
   box-shadow: none;

--- a/src/modules/design/bpmn-io/bpmn-io.scss
+++ b/src/modules/design/bpmn-io/bpmn-io.scss
@@ -135,7 +135,7 @@
     width: 32px;
     height: 32px;
     margin-left: 1px;
-    cursor: default;
+    cursor: pointer;
     font-size: 20px;
     line-height: 24px;
   }

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/inspect-panel.scss
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/inspect-panel.scss
@@ -22,7 +22,6 @@
   display: flex;
   height: 100%;
   border-left: 1px solid #ccc;
-  cursor: default;
 }
 
 .inspect-panel__fullscreen-button > i {

--- a/src/modules/inspect/inspect.scss
+++ b/src/modules/inspect/inspect.scss
@@ -18,7 +18,6 @@
   margin: 0 5px;
   opacity: 0.5;
   text-align: center;
-  cursor: default
 }
 
 .inspect-layout__tool:hover {
@@ -36,7 +35,6 @@
 
 .inspect-layout__tool--disabled:hover {
   opacity: 0.2;
-  cursor: default;
 }
 
 .dashboard__heatmap-container {

--- a/src/modules/live-execution-tracker/live-execution-tracker.scss
+++ b/src/modules/live-execution-tracker/live-execution-tracker.scss
@@ -109,7 +109,7 @@
   margin: 0 5px;
   opacity: 0.5;
   text-align: center;
-  cursor: default
+  cursor: default;
 }
 
 .let__tool:hover {

--- a/src/modules/navbar/navbar.scss
+++ b/src/modules/navbar/navbar.scss
@@ -71,7 +71,6 @@ button {
 }
 
 .menu-tabbed-link:hover {
-  cursor: default;
   text-decoration: inherit;
   -webkit-user-drag: none;
   color: inherit;

--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.scss
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.scss
@@ -33,10 +33,6 @@
   border: none;
 }
 
-.solution-entry__header button:hover {
-  cursor: default;
-}
-
 .solution-entry__solution-icon {
   flex: 0;
   margin-top: 3px;
@@ -116,9 +112,6 @@
   border: none;
 }
 
-.solution-entry__actions button:hover {
-  cursor: default;
-}
 
 .solution-entry__collapse-header {
   max-width: 240px;

--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.scss
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.scss
@@ -67,7 +67,7 @@
 }
 
 .solution-entry__actions_remote-solution {
-  display: none;  
+  display: none;
 }
 
 .login-logout-button {

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.scss
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.scss
@@ -124,7 +124,6 @@
   padding: 0 2px;
   background: transparent;
   border: none;
-  cursor: default;
 }
 
 .toast-message__headline {

--- a/src/modules/status-bar/status-bar.html
+++ b/src/modules/status-bar/status-bar.html
@@ -5,7 +5,7 @@
   -->
   <div class="status-bar status-bar--system-macos" id="statusBarContainer">
     <div class="status-bar__left-bar" id="statusBarLeft">
-      <a if.bind="updateAvailable" class="update-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <a if.bind="true || updateAvailable" class="status-bar__button update-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         <img class="update-button-icon" src="src/resources/images/icon.png" title.bind="isDownloading ? updateProgressData.percent.toString() + '%' : 'Update available.'">
       </a>
       <div class="dropdown-menu update-dropdown" ref="updateDropdown">
@@ -13,7 +13,7 @@
           <div class="update-dropdown-title-container">
             <span class="update-dropdown-title">Version ${updateVersion} available</span>
           </div>
-          <a class="update-dropdown-release-notes"click.delegate="showReleaseNotes()">
+          <a class="update-dropdown-release-notes" click.delegate="showReleaseNotes()">
             Click here for release notes
           </a>
           <div class="update-dropdown-button-container">
@@ -30,31 +30,31 @@
             <div class="progress update-dropdown-progressbar">
               <div class="progress-bar progress-bar-striped progress-bar-animated update-dropdown-progressbar-progress" role="progressbar" css="width: ${updateProgressData.percent}%;">${updateProgressData.percent.toFixed(1)}%</div>
             </div>
-            <button class="btn btn-default update-dropdown-cancel-download-button" title="Abort download." click.delegate="cancelUpdate()">Abort Download</button>
+            <button class="btn-default update-dropdown-cancel-download-button" title="Abort download." click.delegate="cancelUpdate()">Abort Download</button>
           </div>
         </template>
         <template if.bind="updateDownloadFinished">
           <div class="update-dropdown-title-container">
             <span class="update-dropdown-title">Update ready</span>
           </div>
-          <button class="btn btn-primary update-dropdown-install-button" click.delegate="installUpdate()">Install</button>
+          <button class="btn-primary update-dropdown-install-button" click.delegate="installUpdate()">Install</button>
           <span class="update-dropdown-install-text">Would you like to install the update now?<br>Otherwise it will be installed when restarting the BPMN Studio.</span>
         </template>
       </div>
     </div>
     <div class="status-bar__center-bar" id="statusBarCenter">
       <div if.bind="showInspectCorrelationButtons">
-        <a class="status-bar__element" class.bind="showInspectPanel ? 'status-bar__element--active' : ''" click.delegate="toggleInspectPanel()">Inspect Panel</a>
+        <a class="status-bar__element status-bar__button" class.bind="showInspectPanel ? 'status-bar__element--active' : ''" click.delegate="toggleInspectPanel()">Inspect Panel</a>
       </div>
       <div class="center-bar__diff-view-buttons" if.bind="diffIsShown">
-        <a class="status-bar__element status-bar__diff-view" class.bind="currentDiffMode === diffMode.OldVsNew ? 'status-bar__element--active' : ''" click.delegate="changeDiffMode(diffMode.OldVsNew)" title="Compare the ${previousXmlIdentifier === 'Old' ? previousXmlIdentifier.toLowerCase() : previousXmlIdentifier} diagram with the ${currentXmlIdentifier === 'New' ? currentXmlIdentifier.toLowerCase() : currentXmlIdentifier} diagram" id="statusBarOldVsNew">
+        <a class="status-bar__element status-bar__button status-bar__diff-view" class.bind="currentDiffMode === diffMode.OldVsNew ? 'status-bar__element--active' : ''" click.delegate="changeDiffMode(diffMode.OldVsNew)" title="Compare the ${previousXmlIdentifier === 'Old' ? previousXmlIdentifier.toLowerCase() : previousXmlIdentifier} diagram with the ${currentXmlIdentifier === 'New' ? currentXmlIdentifier.toLowerCase() : currentXmlIdentifier} diagram" id="statusBarOldVsNew">
           <div class="identifier">${previousXmlIdentifier}</div> vs. <div class="identifier">${currentXmlIdentifier}</div>
           <i class="fa fa-arrow-right arrow-icon"></i>
         </a>
-        <a class="status-bar__element" class.bind="showChangeList ? 'status-bar__element--active' : ''" click.delegate="toggleChangeList()" title="Toggle visibility of the Change List" id="statusBarChangesLog">
+        <a class="status-bar__element status-bar__button" class.bind="showChangeList ? 'status-bar__element--active' : ''" click.delegate="toggleChangeList()" title="Toggle visibility of the Change List" id="statusBarChangesLog">
           <i class="fas fa-bars"></i>
         </a>
-        <a class="status-bar__element status-bar__diff-view" class.bind="currentDiffMode === diffMode.NewVsOld ? 'status-bar__element--active' : ''" click.delegate="changeDiffMode(diffMode.NewVsOld)" title="Compare the ${currentXmlIdentifier === 'New' ? currentXmlIdentifier.toLowerCase() : currentXmlIdentifier} diagram with the ${previousXmlIdentifier === 'Old' ? previousXmlIdentifier.toLowerCase() : previousXmlIdentifier} diagram" id="statusBarNewVsOld">
+        <a class="status-bar__element status-bar__button status-bar__diff-view" class.bind="currentDiffMode === diffMode.NewVsOld ? 'status-bar__element--active' : ''" click.delegate="changeDiffMode(diffMode.NewVsOld)" title="Compare the ${currentXmlIdentifier === 'New' ? currentXmlIdentifier.toLowerCase() : currentXmlIdentifier} diagram with the ${previousXmlIdentifier === 'Old' ? previousXmlIdentifier.toLowerCase() : previousXmlIdentifier} diagram" id="statusBarNewVsOld">
           <i class="fa fa-arrow-left arrow-icon"></i>
           <div class="identifier">${currentXmlIdentifier}</div> vs. <div class="identifier">${previousXmlIdentifier}</div>
         </a>
@@ -62,16 +62,16 @@
     </div>
     <div class="status-bar__right-bar" id="statusBarRight">
       <template if.bind="showDiagramViewButtons">
-        <a class="status-bar__element" click.delegate="toggleXMLView()" if.bind="!xmlIsShown" data-test-status-bar-xml-view-button>
+        <a class="status-bar__element status-bar__button" click.delegate="toggleXMLView()" if.bind="!xmlIsShown" data-test-status-bar-xml-view-button>
           <i class="fas fa-file-code"></i> Show XML
         </a>
-        <a class="status-bar__element" click.delegate="toggleXMLView()" if.bind="xmlIsShown" data-test-status-bar-disable-xml-view-button>
+        <a class="status-bar__element status-bar__button" click.delegate="toggleXMLView()" if.bind="xmlIsShown" data-test-status-bar-disable-xml-view-button>
           <i class="fas fa-file-code"></i> Show Diagram
         </a>
-        <a class="status-bar__element" click.delegate="toggleDiffView()" if.bind="!diffIsShown" data-test-status-bar-diff-view-button>
+        <a class="status-bar__element status-bar__button" click.delegate="toggleDiffView()" if.bind="!diffIsShown" data-test-status-bar-diff-view-button>
           <i class="fa fa-object-group"></i> Show Diff
         </a>
-        <a class="status-bar__element" click.delegate="toggleDiffView()" if.bind="diffIsShown" data-test-status-bar-disable-diff-view-button>
+        <a class="status-bar__element status-bar__button" click.delegate="toggleDiffView()" if.bind="diffIsShown" data-test-status-bar-disable-diff-view-button>
           <i class="fa fa-object-group"></i> Show Diagram
         </a>
       </template>

--- a/src/modules/status-bar/status-bar.html
+++ b/src/modules/status-bar/status-bar.html
@@ -5,7 +5,7 @@
   -->
   <div class="status-bar status-bar--system-macos" id="statusBarContainer">
     <div class="status-bar__left-bar" id="statusBarLeft">
-      <a if.bind="true || updateAvailable" class="status-bar__button update-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <a if.bind="updateAvailable" class="status-bar__button update-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         <img class="update-button-icon" src="src/resources/images/icon.png" title.bind="isDownloading ? updateProgressData.percent.toString() + '%' : 'Update available.'">
       </a>
       <div class="dropdown-menu update-dropdown" ref="updateDropdown">

--- a/src/modules/status-bar/status-bar.scss
+++ b/src/modules/status-bar/status-bar.scss
@@ -58,6 +58,10 @@
   white-space: nowrap;
 }
 
+.status-bar__button {
+  cursor: pointer;
+}
+
 .status-bar__element--active {
   background-color: #445a65;
   text-decoration: none;


### PR DESCRIPTION
## Changes

1. Use Same Cursor Style for Icon Buttons

## Issues

Closes #1893 

PR: #1895

## How to test the changes

- Hover over some icon buttons
- **Notice that the cursor should always look like this: <img width="40" alt="cursor-pointer" src="https://user-images.githubusercontent.com/20394992/70516996-32a4c880-1b38-11ea-992b-d010ffe3eb38.png">**

> For some reason, it is impossible to specify a cursor style for buttons in the navigation bar.
> This is caused by moving the electron title bar into the  BPMN Studio.
