### PR TITLE
✨ Make Open Remote Solution Modal Protocol Sensitive for Supported Protocols

### DIFF
--- a/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.html
+++ b/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.html
@@ -57,8 +57,8 @@
           <div class="input-group-prepend">
             <button class="btn btn-default solution-explorer-panel__protocol-selector dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">${selectedProtocol}</button>
             <div class="dropdown-menu">
-              <a class="dropdown-item" click.delegate="selectProtocol('http://')">http://</a>
-              <a class="dropdown-item" click.delegate="selectProtocol('https://')">https://</a>
+              <a class="dropdown-item" click.delegate="selectProtocol(supportedProtocols.HTTP)">http://</a>
+              <a class="dropdown-item" click.delegate="selectProtocol(supportedProtocols.HTTPS)">https://</a>
             </div>
           </div>
           <input type="text" class="form-control" class.bind="uriIsValid || uriIsEmpty ? '' : 'uri-input--invalid'" value.bind="origin.uriOfRemoteSolutionWithoutProtocol" placeholder="Please provide a URI for the remote ProcessEngine" autofocus>

--- a/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.ts
+++ b/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.ts
@@ -284,6 +284,20 @@ export class SolutionExplorerPanel {
     this.connectionError = undefined;
   }
 
+  public uriOfRemoteSolutionWithoutProtocolChanged(): void {
+    if (this.uriOfRemoteSolutionWithoutProtocol === undefined) {
+      return;
+    }
+
+    for (const protocol of Object.values(SupportedProtocols)) {
+      if (this.uriOfRemoteSolutionWithoutProtocol.startsWith(protocol)) {
+        this.uriOfRemoteSolutionWithoutProtocol = this.uriOfRemoteSolutionWithoutProtocol.replace(protocol, '');
+
+        this.selectProtocol(protocol);
+      }
+    }
+  }
+
   public async openRemoteSolution(): Promise<void> {
     if (!this.uriIsValid || this.uriIsEmpty) {
       return;

--- a/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.ts
+++ b/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.ts
@@ -30,6 +30,11 @@ type RemoteSolutionListEntry = {
   version?: StudioVersion;
 };
 
+enum SupportedProtocols {
+  HTTPS = 'https://',
+  HTTP = 'http://',
+}
+
 /**
  * This component handels:
  *  - Opening files via drag and drop
@@ -54,6 +59,8 @@ export class SolutionExplorerPanel {
   public availableDefaultRemoteSolutions: Array<RemoteSolutionListEntry> = [];
   public isConnecting: boolean = false;
   public connectionError: string;
+
+  public supportedProtocols: typeof SupportedProtocols = SupportedProtocols;
 
   private eventAggregator: EventAggregator;
   private notificationService: NotificationService;
@@ -264,7 +271,7 @@ export class SolutionExplorerPanel {
     this.removeSolutionFromSolutionHistroy(solutionUri);
   }
 
-  public selectProtocol(protocol: string): void {
+  public selectProtocol(protocol: SupportedProtocols | string): void {
     this.selectedProtocol = protocol;
   }
 

--- a/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.ts
+++ b/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.ts
@@ -271,7 +271,7 @@ export class SolutionExplorerPanel {
     this.removeSolutionFromSolutionHistroy(solutionUri);
   }
 
-  public selectProtocol(protocol: SupportedProtocols | string): void {
+  public selectProtocol(protocol: SupportedProtocols): void {
     this.selectedProtocol = protocol;
   }
 
@@ -432,9 +432,13 @@ export class SolutionExplorerPanel {
     const protocolEndIndex: number = remoteSolutionUri.indexOf('//') + 2;
     const protocol: string = remoteSolutionUri.substring(0, protocolEndIndex);
 
+    const protocolKey = Object.keys(SupportedProtocols).find((supportedProtocolKey) => {
+      return SupportedProtocols[supportedProtocolKey] === protocol;
+    });
+
     const uri: string = remoteSolutionUri.substring(protocolEndIndex, remoteSolutionUri.length);
 
-    this.selectProtocol(protocol);
+    this.selectProtocol(SupportedProtocols[protocolKey]);
     this.uriOfRemoteSolutionWithoutProtocol = uri;
   }
 


### PR DESCRIPTION
## Changes

1.  Make Open Remote Solution Modal Protocol Sensitive

## Issues

Closes #1756 

PR: #1896

## How to test the changes

- Open the 'Open Remote Solution Modal'
- Enter 'https://example.com' in the location text field
- **Notice that the 'https://' will disappear and the protocol dropdown will change to 'https://'**
- Enter 'http://example.com' in the location text field
- **Notice that the 'http://' will disappear and the protocol dropdown will change to 'http://'**