### PR TITLE
💄 Improve displaying stopped processes

### DIFF
--- a/src/modules/inspect/process-list/process-list.html
+++ b/src/modules/inspect/process-list/process-list.html
@@ -5,7 +5,7 @@
     <div class="process-list-container" id="processListContainer">
       <h4 class="process-list-header">Processes</h4>
       <template if.bind="processInstancesToDisplay && processInstancesToDisplay.length > 0 && initialLoadingFinished">
-        <h6 class="process-list-total-count">Total: ${totalItems}</h6>
+        <h6 class="process-list-total-count">Total: ${activeProcessInstanceCount}</h6>
         <table class="table table-striped table-bordered">
           <tr>
             <th>Started At</th>

--- a/src/modules/inspect/process-list/process-list.scss
+++ b/src/modules/inspect/process-list/process-list.scss
@@ -1,5 +1,5 @@
 .process-list__last-table-cell {
-  width: 1%;
+  width: 320px;
   white-space: nowrap;
 }
 

--- a/src/modules/inspect/process-list/process-list.ts
+++ b/src/modules/inspect/process-list/process-list.ts
@@ -23,6 +23,7 @@ export class ProcessList {
   @bindable() public activeSolutionEntry: ISolutionEntry;
   public pageSize: number = 10;
   public totalItems: number;
+  public activeProcessInstanceCount: number;
   public paginationSize: number = 10;
   public initialLoadingFinished: boolean = false;
   public processInstancesToDisplay: Array<DataModels.Correlations.ProcessInstance> = [];
@@ -276,6 +277,7 @@ export class ProcessList {
         JSON.stringify(processInstanceList.processInstances) !== JSON.stringify(this.processInstances);
 
       this.totalItems = processInstanceList.totalCount + this.stoppedProcessInstances.length;
+      this.activeProcessInstanceCount = processInstanceList.totalCount;
 
       if (processInstanceListWasUpdated) {
         this.processInstances = processInstanceList.processInstances;


### PR DESCRIPTION
## Changes

1. Set Constant Width for Last Table Column
2. Display Amount of Active ProcessInstances as Total Amount

## Issues

Closes #1773 

PR: #1897

## How to test the changes

- Go to the Dashboard view
- Stop some processes
- **Notice that the 'Total' count will decrease.**
- Stop all processes on one page
- **Notice that the last column will keep its width.**