### PR TITLE
✨ Add 'Export As' to Menubar

### DIFF
--- a/electron_app/electron.ts
+++ b/electron_app/electron.ts
@@ -632,6 +632,35 @@ function getFileMenu(): MenuItem {
       },
     },
     {
+      label: 'Export Diagram As...',
+      submenu: [
+        {
+          label: 'BPMN',
+          click: (): void => {
+            browserWindow.webContents.send('menubar__epxort_diagram_as', 'BPMN');
+          },
+        },
+        {
+          label: 'SVG',
+          click: (): void => {
+            browserWindow.webContents.send('menubar__epxort_diagram_as', 'SVG');
+          },
+        },
+        {
+          label: 'PNG',
+          click: (): void => {
+            browserWindow.webContents.send('menubar__epxort_diagram_as', 'PNG');
+          },
+        },
+        {
+          label: 'JPEG',
+          click: (): void => {
+            browserWindow.webContents.send('menubar__epxort_diagram_as', 'JPEG');
+          },
+        },
+      ],
+    },
+    {
       type: 'separator',
     },
     {

--- a/src/modules/design/design.ts
+++ b/src/modules/design/design.ts
@@ -213,6 +213,10 @@ export class Design {
 
     if (isRunningInElectron()) {
       this.ipcRenderer.send('menu_show-all-menu-entries');
+
+      this.ipcRenderer.on('menubar__epxort_diagram_as', (event, format) => {
+        this.eventAggregator.publish(`${environment.events.diagramDetail.exportDiagramAs}:${format}`);
+      });
     }
 
     this.eventAggregator.publish(environment.events.statusBar.showDiagramViewButtons);

--- a/src/modules/design/design.ts
+++ b/src/modules/design/design.ts
@@ -122,7 +122,7 @@ export class Design {
 
       if (solutionIsRemoteSolution(this.activeSolutionEntry.uri)) {
         if (isRunningInElectron()) {
-          this.ipcRenderer.send('menu_hide-diagram-entries');
+          this.ipcRenderer.send('menu_hide-save-entries');
         }
 
         this.eventAggregator.publish(environment.events.configPanel.solutionEntryChanged, this.activeSolutionEntry);
@@ -227,7 +227,7 @@ export class Design {
     this.subscriptions.forEach((subscription: Subscription) => subscription.dispose());
 
     if (isRunningInElectron()) {
-      this.ipcRenderer.send('menu_hide-diagram-entries');
+      this.ipcRenderer.send('menu_hide-diagram-related-entries');
     }
   }
 


### PR DESCRIPTION
## Changes

1. Add 'Export As' to Menubar

PR: #1898

## How to test the changes

- Open any diagram
- Use the menubar to export the diagram
- **Notice that the diagram can get exported as BPMN, SVG, PNG & JPEG via the menubar.**

![image](https://user-images.githubusercontent.com/20394992/70528493-9df99500-1b4e-11ea-8b5b-2c03e743e3ac.png)
