### PR TITLE
 🐛 Fix Switching from UserTask to Another Element

### DIFF
--- a/src/modules/design/property-panel/indextabs/forms/forms.ts
+++ b/src/modules/design/property-panel/indextabs/forms/forms.ts
@@ -18,6 +18,10 @@ export class Forms implements IIndextab {
   }
 
   public activate(model: IPageModel): void {
+    /*
+     * This is necessary because since v1.12.0 of aurelia-templating-resources there is a bug
+     * which triggers the activate function although the form section is already detached.
+     */
     if (model === undefined) {
       return;
     }

--- a/src/modules/design/property-panel/indextabs/forms/forms.ts
+++ b/src/modules/design/property-panel/indextabs/forms/forms.ts
@@ -18,6 +18,10 @@ export class Forms implements IIndextab {
   }
 
   public activate(model: IPageModel): void {
+    if (model === undefined) {
+      return;
+    }
+
     this.elementInPanel = model.elementInPanel;
     this.modeler = model.modeler;
   }


### PR DESCRIPTION
> For some reason, the activate function of the form section is called one more time after detaching the form section. For this reason, an error was triggered which destroyed the PropertyPanel. This seems to be an issue with aurelia-templating-ressources.
> This fixes the updating of the PropertyPanel.

## Changes

1. Fix Switching from UserTask to Another Element

PR: #1899

## How to test the changes

- Open any diagram with a UserTask
- Select the UserTask
- Select another Element
- **Notice that the PropertyPanel gets Updated correctly.**