### PR TITLE
♻️ Refactor Cursor Styles

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -3,13 +3,14 @@
   <require from="dist/web/@fortawesome/fontawesome-free/css/all.css"></require>
   <require from="toastr/build/toastr.min.css"></require>
   <require from="./app.css"></require>
+  <require from="./electron.css"></require>
   <require from="./modules/navbar/navbar"></require>
   <require from="./modules/solution-explorer/solution-explorer-panel/solution-explorer-panel"></require>
   <require from="./modules/status-bar/status-bar"></require>
   <require from="./modules/deploy-modals/deploy-modals"></require>
   <require from="./modules/feedback-modal/feedback-modal"></require>
 
-  <div class="bpmn-studio-layout">
+  <div class="bpmn-studio-layout" class.bind="isRunningInElectron ? 'electron' : ''">
     <nav-bar></nav-bar>
     <feedback-modal></feedback-modal>
 

--- a/src/app.scss
+++ b/src/app.scss
@@ -12,14 +12,6 @@ input:focus {
   outline: none !important;
 }
 
-.button:not(:disabled) {
-  cursor: pointer;
-}
-
-.btn:disabled {
-  cursor: default;
-}
-
 .form-control:focus {
   border-color: #ced4da;
   box-shadow: none;

--- a/src/app.scss
+++ b/src/app.scss
@@ -51,7 +51,6 @@ router-view {
 .button {
   color: #333;
   opacity: 0.5;
-  cursor: default;
 }
 
 .button:hover {
@@ -100,7 +99,6 @@ router-view {
 }
 
 .dropdown-item {
-   cursor: pointer !important;
    background-color: transparent !important;
    color: black !important;
    user-select: none;

--- a/src/app.ts
+++ b/src/app.ts
@@ -22,6 +22,7 @@ Bluebird.Promise.config({cancellation: true});
 @inject(OpenIdConnect, 'NotificationService', EventAggregator)
 export class App {
   public showSolutionExplorer: boolean = false;
+  public isRunningInElectron: boolean = isRunningInElectron();
 
   private openIdConnect: OpenIdConnect | any;
   private notificationService: NotificationService;

--- a/src/electron.scss
+++ b/src/electron.scss
@@ -1,19 +1,9 @@
-.electron button {
-  cursor: default;
-}
-
-.electron button:not(:disabled) {
-  cursor: default;
-}
-
-.electron a.tool {
-  cursor: default;
-}
-
-.electron .dropdown {
-  cursor: default;
-}
-
-.electron .dropdown-item {
-  cursor: default;
+.electron {
+  button,
+  button:not(:disabled),
+  a.tool,
+  .dropdown,
+  .dropdown-item {
+    cursor: default;
+  }
 }

--- a/src/electron.scss
+++ b/src/electron.scss
@@ -1,0 +1,19 @@
+.electron button {
+  cursor: default;
+}
+
+.electron button:not(:disabled) {
+  cursor: default;
+}
+
+.electron a.tool {
+  cursor: default;
+}
+
+.electron .dropdown {
+  cursor: default;
+}
+
+.electron .dropdown-item {
+  cursor: default;
+}

--- a/src/modules/config-panel/config-panel.scss
+++ b/src/modules/config-panel/config-panel.scss
@@ -14,18 +14,9 @@
   margin-bottom: 20px;
 }
 
-.use-internal-processengine {
-  cursor: pointer;
-  text-decoration: underline;
-}
-
 .config-panel__card__alert {
   margin-top: 10px;
   margin-bottom: 0;
-}
-
-.config-panel__card__alert__link {
-  cursor: pointer;
 }
 
 .uri-input--invalid {

--- a/src/modules/design/bpmn-io/bpmn-io.scss
+++ b/src/modules/design/bpmn-io/bpmn-io.scss
@@ -135,7 +135,7 @@
     width: 32px;
     height: 32px;
     margin-left: 1px;
-    cursor: pointer;
+    cursor: default;
     font-size: 20px;
     line-height: 24px;
   }

--- a/src/modules/design/bpmn-io/bpmn-io.scss
+++ b/src/modules/design/bpmn-io/bpmn-io.scss
@@ -135,7 +135,6 @@
     width: 32px;
     height: 32px;
     margin-left: 1px;
-    cursor: default;
     font-size: 20px;
     line-height: 24px;
   }
@@ -206,11 +205,9 @@
 .bpmn-js-bpmnlint-button {
   // Overwriting existing style of the plugin
   top: unset;
-
   bottom: 20px;
   left: 55px;
   height: 30px;
-  cursor: default;
   pointer-events: none;
 }
 

--- a/src/modules/design/design.scss
+++ b/src/modules/design/design.scss
@@ -66,12 +66,10 @@ bpmn-diff-view {
   padding: 2px;
   text-align: center;
   opacity: 0.2 !important;
-  cursor: default;
 }
 
 .design-layout__tool--disabled:hover {
   opacity: 0.2;
-  cursor: default;
 }
 
 .design-modal__textarea {

--- a/src/modules/design/diagram-tools-right/diagram-tools-right.scss
+++ b/src/modules/design/diagram-tools-right/diagram-tools-right.scss
@@ -15,20 +15,8 @@
   text-align: center;
 }
 
-.tool--disabled {
-  cursor: default;
-}
-
-.tool--disabled:hover {
-  cursor: default;
-}
-
 .open .tool {
   box-shadow: none !important; //Overwrite Bootstrap btn-group class combination
-}
-
-.color-dropdown {
-  cursor: default;
 }
 
 /*
@@ -62,7 +50,6 @@
   display: inline-block;
   margin: 0;
   overflow: hidden;
-  cursor: pointer;
   background: 0;
   border: 0;
   color: #333;

--- a/src/modules/design/property-panel/indextabs/general/sections/basics/basics.scss
+++ b/src/modules/design/property-panel/indextabs/general/sections/basics/basics.scss
@@ -53,7 +53,6 @@
 
 .docs-enlarge-link {
   display: block;
-  cursor: pointer;
   color: #007bff !important;
 }
 

--- a/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.scss
+++ b/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.scss
@@ -31,7 +31,6 @@
 
 .payload-enlarge-link {
   display: block;
-  cursor: pointer;
   color: #007bff !important;
 }
 

--- a/src/modules/design/property-panel/indextabs/general/sections/script-task/script-task.scss
+++ b/src/modules/design/property-panel/indextabs/general/sections/script-task/script-task.scss
@@ -1,6 +1,5 @@
 .script-task-enlarge-link {
   display: block;
-  cursor: pointer;
   color: #007bff !important;
 }
 

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.scss
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.scss
@@ -1,6 +1,5 @@
 .payload-enlarge-link {
   display: block;
-  cursor: pointer;
   color: #007bff !important;
 }
 

--- a/src/modules/design/property-panel/styles/sections.scss
+++ b/src/modules/design/property-panel/styles/sections.scss
@@ -91,14 +91,12 @@
 
 .add-context-button:disabled {
   pointer-events: none;
-  cursor: default;
   opacity: 0.2;
   color: inherit;
 }
 
 .remove-context-button:disabled {
   pointer-events: none;
-  cursor: default;
   opacity: 0.2;
   color: inherit;
 }

--- a/src/modules/design/property-panel/styles/sections.scss
+++ b/src/modules/design/property-panel/styles/sections.scss
@@ -61,7 +61,7 @@
 }
 
 .props-input::-webkit-calendar-picker-indicator:hover {
-  cursor: pointer;
+  cursor: default;
   opacity: 1;
   background: inherit;
 }

--- a/src/modules/feedback-modal/feedback-modal.scss
+++ b/src/modules/feedback-modal/feedback-modal.scss
@@ -1,14 +1,9 @@
-.feedback-modal__checkbox {
-  cursor: pointer;
-}
-
 .feedback-modal__checkbox-label {
   margin-left: 5px;
 }
 
 .feedback-modal__solution-title {
   user-select: none;
-  cursor: pointer;
 }
 
 .feedback-modal__text-input {
@@ -54,8 +49,4 @@
 
 .feedback-modal__solution-hide-icon {
   width: 10px;
-}
-
-.feedback-modal__help-icon {
-  cursor: help;
 }

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/components/correlation-list/correlation-list.scss
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/components/correlation-list/correlation-list.scss
@@ -14,7 +14,6 @@
 .correlation-table__headlines {
   display: flex;
   width: 100%;
-  cursor: pointer;
 }
 
 .correlation-table__headline {
@@ -48,7 +47,6 @@
 .correlation-table__table-row {
   display: flex;
   width: 100%;
-  cursor: pointer;
 }
 
 .correlation-table__table-row--instance-to-select {

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/components/log-viewer/log-viewer.scss
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/components/log-viewer/log-viewer.scss
@@ -15,7 +15,6 @@
 .log-table__headlines {
   display: flex;
   width: 100%;
-  cursor: default;
 }
 
 .log-table__headline {
@@ -37,7 +36,6 @@
 .log-table__table-row {
   display: flex;
   width: 100%;
-  cursor: pointer;
 }
 
 .log-table__table-entry {

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/components/process-instance-list/process-instance-list.scss
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/components/process-instance-list/process-instance-list.scss
@@ -14,7 +14,6 @@
 .process-instance-table__headlines {
   display: flex;
   width: 100%;
-  cursor: pointer;
 }
 
 .process-instance-table__headline {
@@ -48,7 +47,6 @@
 .process-instance-table__table-row {
   display: flex;
   width: 100%;
-  cursor: pointer;
 }
 
 .process-instance-table__table-row--instance-to-select {

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/inspect-panel.scss
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/inspect-panel.scss
@@ -22,6 +22,7 @@
   display: flex;
   height: 100%;
   border-left: 1px solid #ccc;
+  cursor: default;
 }
 
 .inspect-panel__fullscreen-button > i {

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/inspect-panel.scss
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/inspect-panel.scss
@@ -22,7 +22,6 @@
   display: flex;
   height: 100%;
   border-left: 1px solid #ccc;
-  cursor: default;
 }
 
 .inspect-panel__fullscreen-button > i {
@@ -48,7 +47,6 @@
 }
 
 .inspect-panel__disabled-tab {
-  cursor: default;
   color: #ccc;
 }
 

--- a/src/modules/inspect/inspect.scss
+++ b/src/modules/inspect/inspect.scss
@@ -18,7 +18,6 @@
   margin: 0 5px;
   opacity: 0.5;
   text-align: center;
-  cursor: default
 }
 
 .inspect-layout__tool:hover {
@@ -31,12 +30,10 @@
 
 .inspect-layout__tool--disabled {
   opacity: 0.2 !important;
-  cursor: default;
 }
 
 .inspect-layout__tool--disabled:hover {
   opacity: 0.2;
-  cursor: default;
 }
 
 .dashboard__heatmap-container {

--- a/src/modules/inspect/inspect.scss
+++ b/src/modules/inspect/inspect.scss
@@ -18,6 +18,7 @@
   margin: 0 5px;
   opacity: 0.5;
   text-align: center;
+  cursor: default
 }
 
 .inspect-layout__tool:hover {
@@ -35,6 +36,7 @@
 
 .inspect-layout__tool--disabled:hover {
   opacity: 0.2;
+  cursor: default;
 }
 
 .dashboard__heatmap-container {

--- a/src/modules/inspect/token-viewer/token-viewer.scss
+++ b/src/modules/inspect/token-viewer/token-viewer.scss
@@ -54,7 +54,6 @@
   width: 100%;
   padding: 10px;
   margin-bottom: -20px;
-  cursor: default;
   user-select: none;
 }
 
@@ -80,7 +79,6 @@
   right: 0;
   bottom: 0;
   left: 0;
-  cursor: pointer;
   background-color: #ccc;
   border-radius: 17px;
   transition: .2s;

--- a/src/modules/live-execution-tracker/live-execution-tracker.scss
+++ b/src/modules/live-execution-tracker/live-execution-tracker.scss
@@ -34,16 +34,11 @@
   height: 100%;
 }
 
-.let__overlay-button {
-  cursor: pointer;
-}
-
 .let__overlay-button-icon {
   position: absolute;
   top: 9px;
   left: 14px;
   pointer-events: none;
-  cursor: pointer;
   opacity: 0.4;
 }
 
@@ -74,7 +69,6 @@
 .let__close-modal-button {
   position: absolute;
   right: 20px;
-  cursor: pointer;
 }
 
 .let__close-dynamic-ui-modal-button {
@@ -109,7 +103,6 @@
   margin: 0 5px;
   opacity: 0.5;
   text-align: center;
-  cursor: default
 }
 
 .let__tool:hover {

--- a/src/modules/live-execution-tracker/live-execution-tracker.scss
+++ b/src/modules/live-execution-tracker/live-execution-tracker.scss
@@ -109,7 +109,7 @@
   margin: 0 5px;
   opacity: 0.5;
   text-align: center;
-  cursor: default;
+  cursor: default
 }
 
 .let__tool:hover {

--- a/src/modules/navbar/navbar.scss
+++ b/src/modules/navbar/navbar.scss
@@ -71,7 +71,6 @@ button {
 }
 
 .menu-tabbed-link:hover {
-  cursor: default;
   text-decoration: inherit;
   -webkit-user-drag: none;
   color: inherit;
@@ -85,7 +84,6 @@ button {
 .menu-bar__dashboard-dropdown {
   top: 40px;
   padding: 0;
-  cursor: pointer;
   background-color: #f7f7f7;
   border-top: none;
   border-top-left-radius: 0;
@@ -96,10 +94,6 @@ button {
 .menu-bar__menu-center--action-button {
   background-color: inherit;
   border: none;
-}
-
-.menu-bar__menu-center--action-button:disabled {
-  cursor: default;
 }
 
 .process-details-dropdown-menu {

--- a/src/modules/navbar/navbar.scss
+++ b/src/modules/navbar/navbar.scss
@@ -71,6 +71,7 @@ button {
 }
 
 .menu-tabbed-link:hover {
+  cursor: default;
   text-decoration: inherit;
   -webkit-user-drag: none;
   color: inherit;

--- a/src/modules/pagination/pagination.scss
+++ b/src/modules/pagination/pagination.scss
@@ -1,14 +1,11 @@
 .bpmn-studio-pagination {
-  cursor: pointer;
   user-select: none;
 }
 
 .pagination-button--disabled {
-  cursor: default;
   opacity: 0.7;
 }
 
 .pagination-button--loading {
-  cursor: default;
   opacity: 0.4;
 }

--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.scss
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.scss
@@ -62,7 +62,7 @@
 }
 
 .solution-entry__actions_remote-solution {
-  display: none;  
+  display: none;
 }
 
 .login-logout-button {

--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.scss
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.scss
@@ -20,7 +20,6 @@
   padding: 2.5px 5px;
   padding-bottom: 2px;
   color: darkgray;
-  cursor: pointer;
 }
 
 .solution-entry__header:hover {
@@ -31,10 +30,6 @@
   padding: 0 2px;
   background: transparent;
   border: none;
-}
-
-.solution-entry__header button:hover {
-  cursor: default;
 }
 
 .solution-entry__solution-icon {
@@ -114,10 +109,6 @@
   padding: 0 2px;
   background: transparent;
   border: none;
-}
-
-.solution-entry__actions button:hover {
-  cursor: default;
 }
 
 .solution-entry__collapse-header {

--- a/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.scss
+++ b/src/modules/solution-explorer/solution-explorer-list/solution-explorer-list.scss
@@ -33,6 +33,10 @@
   border: none;
 }
 
+.solution-entry__header button:hover {
+  cursor: default;
+}
+
 .solution-entry__solution-icon {
   flex: 0;
   margin-top: 3px;
@@ -63,7 +67,7 @@
 }
 
 .solution-entry__actions_remote-solution {
-  display: none;
+  display: none;  
 }
 
 .login-logout-button {
@@ -112,6 +116,9 @@
   border: none;
 }
 
+.solution-entry__actions button:hover {
+  cursor: default;
+}
 
 .solution-entry__collapse-header {
   max-width: 240px;

--- a/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.scss
+++ b/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.scss
@@ -91,7 +91,6 @@ solution-explorer-panel {
   margin-bottom: -1px;
   overflow: hidden;
   color: darkgray;
-  cursor: pointer;
   border-bottom: 1px solid #ccc;
   user-select: none;
 }

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.scss
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.scss
@@ -124,6 +124,7 @@
   padding: 0 2px;
   background: transparent;
   border: none;
+  cursor: default;
 }
 
 .toast-message__headline {

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.scss
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.scss
@@ -67,7 +67,6 @@
 .diagram-entry {
   display: flex;
   padding: 2.5px 5px 2.5px 22px;
-  cursor: pointer;
 }
 
 .diagram-entry--highlight {
@@ -124,7 +123,6 @@
   padding: 0 2px;
   background: transparent;
   border: none;
-  cursor: default;
 }
 
 .toast-message__headline {

--- a/src/modules/start-page/start-page.scss
+++ b/src/modules/start-page/start-page.scss
@@ -28,10 +28,6 @@
   padding: 0 250px;
 }
 
-.start-page__quick-start:hover {
-  cursor: default;
-}
-
 .quick-start__item {
   display: flex;
   flex-direction: row;
@@ -49,7 +45,6 @@
 }
 
 .quick-start__topic:hover {
-  cursor: pointer;
   text-decoration: underline;
 }
 

--- a/src/modules/status-bar/status-bar.html
+++ b/src/modules/status-bar/status-bar.html
@@ -5,7 +5,7 @@
   -->
   <div class="status-bar status-bar--system-macos" id="statusBarContainer">
     <div class="status-bar__left-bar" id="statusBarLeft">
-      <a if.bind="updateAvailable" class="status-bar__button update-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <a if.bind="updateAvailable" class="update-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         <img class="update-button-icon" src="src/resources/images/icon.png" title.bind="isDownloading ? updateProgressData.percent.toString() + '%' : 'Update available.'">
       </a>
       <div class="dropdown-menu update-dropdown" ref="updateDropdown">
@@ -13,7 +13,7 @@
           <div class="update-dropdown-title-container">
             <span class="update-dropdown-title">Version ${updateVersion} available</span>
           </div>
-          <a class="update-dropdown-release-notes" click.delegate="showReleaseNotes()">
+          <a class="update-dropdown-release-notes"click.delegate="showReleaseNotes()">
             Click here for release notes
           </a>
           <div class="update-dropdown-button-container">
@@ -44,17 +44,17 @@
     </div>
     <div class="status-bar__center-bar" id="statusBarCenter">
       <div if.bind="showInspectCorrelationButtons">
-        <a class="status-bar__element status-bar__button" class.bind="showInspectPanel ? 'status-bar__element--active' : ''" click.delegate="toggleInspectPanel()">Inspect Panel</a>
+        <a class="status-bar__element" class.bind="showInspectPanel ? 'status-bar__element--active' : ''" click.delegate="toggleInspectPanel()">Inspect Panel</a>
       </div>
       <div class="center-bar__diff-view-buttons" if.bind="diffIsShown">
-        <a class="status-bar__element status-bar__button status-bar__diff-view" class.bind="currentDiffMode === diffMode.OldVsNew ? 'status-bar__element--active' : ''" click.delegate="changeDiffMode(diffMode.OldVsNew)" title="Compare the ${previousXmlIdentifier === 'Old' ? previousXmlIdentifier.toLowerCase() : previousXmlIdentifier} diagram with the ${currentXmlIdentifier === 'New' ? currentXmlIdentifier.toLowerCase() : currentXmlIdentifier} diagram" id="statusBarOldVsNew">
+        <a class="status-bar__element status-bar__diff-view" class.bind="currentDiffMode === diffMode.OldVsNew ? 'status-bar__element--active' : ''" click.delegate="changeDiffMode(diffMode.OldVsNew)" title="Compare the ${previousXmlIdentifier === 'Old' ? previousXmlIdentifier.toLowerCase() : previousXmlIdentifier} diagram with the ${currentXmlIdentifier === 'New' ? currentXmlIdentifier.toLowerCase() : currentXmlIdentifier} diagram" id="statusBarOldVsNew">
           <div class="identifier">${previousXmlIdentifier}</div> vs. <div class="identifier">${currentXmlIdentifier}</div>
           <i class="fa fa-arrow-right arrow-icon"></i>
         </a>
-        <a class="status-bar__element status-bar__button" class.bind="showChangeList ? 'status-bar__element--active' : ''" click.delegate="toggleChangeList()" title="Toggle visibility of the Change List" id="statusBarChangesLog">
+        <a class="status-bar__element" class.bind="showChangeList ? 'status-bar__element--active' : ''" click.delegate="toggleChangeList()" title="Toggle visibility of the Change List" id="statusBarChangesLog">
           <i class="fas fa-bars"></i>
         </a>
-        <a class="status-bar__element status-bar__button status-bar__diff-view" class.bind="currentDiffMode === diffMode.NewVsOld ? 'status-bar__element--active' : ''" click.delegate="changeDiffMode(diffMode.NewVsOld)" title="Compare the ${currentXmlIdentifier === 'New' ? currentXmlIdentifier.toLowerCase() : currentXmlIdentifier} diagram with the ${previousXmlIdentifier === 'Old' ? previousXmlIdentifier.toLowerCase() : previousXmlIdentifier} diagram" id="statusBarNewVsOld">
+        <a class="status-bar__element status-bar__diff-view" class.bind="currentDiffMode === diffMode.NewVsOld ? 'status-bar__element--active' : ''" click.delegate="changeDiffMode(diffMode.NewVsOld)" title="Compare the ${currentXmlIdentifier === 'New' ? currentXmlIdentifier.toLowerCase() : currentXmlIdentifier} diagram with the ${previousXmlIdentifier === 'Old' ? previousXmlIdentifier.toLowerCase() : previousXmlIdentifier} diagram" id="statusBarNewVsOld">
           <i class="fa fa-arrow-left arrow-icon"></i>
           <div class="identifier">${currentXmlIdentifier}</div> vs. <div class="identifier">${previousXmlIdentifier}</div>
         </a>
@@ -62,16 +62,16 @@
     </div>
     <div class="status-bar__right-bar" id="statusBarRight">
       <template if.bind="showDiagramViewButtons">
-        <a class="status-bar__element status-bar__button" click.delegate="toggleXMLView()" if.bind="!xmlIsShown" data-test-status-bar-xml-view-button>
+        <a class="status-bar__element" click.delegate="toggleXMLView()" if.bind="!xmlIsShown" data-test-status-bar-xml-view-button>
           <i class="fas fa-file-code"></i> Show XML
         </a>
-        <a class="status-bar__element status-bar__button" click.delegate="toggleXMLView()" if.bind="xmlIsShown" data-test-status-bar-disable-xml-view-button>
+        <a class="status-bar__element" click.delegate="toggleXMLView()" if.bind="xmlIsShown" data-test-status-bar-disable-xml-view-button>
           <i class="fas fa-file-code"></i> Show Diagram
         </a>
-        <a class="status-bar__element status-bar__button" click.delegate="toggleDiffView()" if.bind="!diffIsShown" data-test-status-bar-diff-view-button>
+        <a class="status-bar__element" click.delegate="toggleDiffView()" if.bind="!diffIsShown" data-test-status-bar-diff-view-button>
           <i class="fa fa-object-group"></i> Show Diff
         </a>
-        <a class="status-bar__element status-bar__button" click.delegate="toggleDiffView()" if.bind="diffIsShown" data-test-status-bar-disable-diff-view-button>
+        <a class="status-bar__element" click.delegate="toggleDiffView()" if.bind="diffIsShown" data-test-status-bar-disable-diff-view-button>
           <i class="fa fa-object-group"></i> Show Diagram
         </a>
       </template>

--- a/src/modules/status-bar/status-bar.html
+++ b/src/modules/status-bar/status-bar.html
@@ -13,7 +13,7 @@
           <div class="update-dropdown-title-container">
             <span class="update-dropdown-title">Version ${updateVersion} available</span>
           </div>
-          <a class="update-dropdown-release-notes"click.delegate="showReleaseNotes()">
+          <a class="update-dropdown-release-notes" click.delegate="showReleaseNotes()">
             Click here for release notes
           </a>
           <div class="update-dropdown-button-container">

--- a/src/modules/status-bar/status-bar.scss
+++ b/src/modules/status-bar/status-bar.scss
@@ -10,7 +10,6 @@
   width: 100%;
   height: 22px;
   padding: 0 5px;
-  cursor: default;
   background-color: #3f51b5;
   background-color: #9c27b0;
   background-color: #607d8b;
@@ -93,7 +92,6 @@
 .update-button {
   width: 15px;
   height: 15px;
-  cursor: pointer;
   line-height: 15px;
 }
 
@@ -168,5 +166,4 @@
 
 .update-dropdown-release-notes {
   display: block;
-  cursor: pointer;
 }

--- a/src/modules/status-bar/status-bar.scss
+++ b/src/modules/status-bar/status-bar.scss
@@ -58,10 +58,6 @@
   white-space: nowrap;
 }
 
-.status-bar__button {
-  cursor: pointer;
-}
-
 .status-bar__element--active {
   background-color: #445a65;
   text-decoration: none;

--- a/src/modules/think/diagram-list/diagram-list.scss
+++ b/src/modules/think/diagram-list/diagram-list.scss
@@ -30,7 +30,6 @@
 .process-name-table-entry {
   height: 50px;
   overflow: hidden;
-  cursor: pointer;
   text-overflow: ellipsis;
   white-space: nowrap;
 }


### PR DESCRIPTION
## Changes

1. Undo Previous Cursor Style Changes
2. Remove Unused CSS Classes
3. Remove No Longer Needed Cursor Styles
4. Add Stylesheet for Electron
5. Avoid Using Pointer Style

PR: #1901

## How to test the changes

- Hover over any icon buttons you can find
- **Notice that the cursor should always look like the default cursor.**