### PR TITLE
✨ Show Update Dropdown When Notification was Clicked

### DIFF
--- a/electron_app/electron.ts
+++ b/electron_app/electron.ts
@@ -131,9 +131,9 @@ function initializeApplication(): void {
     createFeedbackZip(feedbackData);
   });
 
-  if (!releaseChannel.isDev() && !process.env.SPECTRON_TESTS) {
-    initializeAutoUpdater();
-  }
+  // if (!releaseChannel.isDev() && !process.env.SPECTRON_TESTS) {
+  initializeAutoUpdater();
+  // }
 
   initializeFileOpenFeature();
   initializeOidc();
@@ -146,9 +146,9 @@ function initializeAutoUpdater(): void {
     const currentVersion = app.getVersion();
     const currentReleaseChannel = new ReleaseChannel(currentVersion);
 
-    const currentVersionIsPrerelease = currentReleaseChannel.isAlpha() || currentReleaseChannel.isBeta();
+    const currentVersionIsPrerelease = currentReleaseChannel.isAlpha() || currentReleaseChannel.isBeta() || true;
     autoUpdater.allowPrerelease = currentVersionIsPrerelease;
-    autoUpdater.channel = currentReleaseChannel.getName();
+    autoUpdater.channel = 'alpha';
 
     const updateCheckResult = await autoUpdater.checkForUpdates();
 

--- a/electron_app/electron.ts
+++ b/electron_app/electron.ts
@@ -131,9 +131,9 @@ function initializeApplication(): void {
     createFeedbackZip(feedbackData);
   });
 
-  // if (!releaseChannel.isDev() && !process.env.SPECTRON_TESTS) {
-  initializeAutoUpdater();
-  // }
+  if (!releaseChannel.isDev() && !process.env.SPECTRON_TESTS) {
+    initializeAutoUpdater();
+  }
 
   initializeFileOpenFeature();
   initializeOidc();
@@ -146,9 +146,9 @@ function initializeAutoUpdater(): void {
     const currentVersion = app.getVersion();
     const currentReleaseChannel = new ReleaseChannel(currentVersion);
 
-    const currentVersionIsPrerelease = currentReleaseChannel.isAlpha() || currentReleaseChannel.isBeta() || true;
+    const currentVersionIsPrerelease = currentReleaseChannel.isAlpha() || currentReleaseChannel.isBeta();
     autoUpdater.allowPrerelease = currentVersionIsPrerelease;
-    autoUpdater.channel = 'alpha';
+    autoUpdater.channel = currentReleaseChannel.getName();
 
     const updateCheckResult = await autoUpdater.checkForUpdates();
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bpmn-studio",
   "description": "An Aurelia application for designing BPMN diagrams, which can also be connected to a process engine to execute these diagrams.",
-  "version": "5.11.0-alpha.24",
+  "version": "5.12.0",
   "author": {
     "name": "process-engine",
     "email": "hello@process-engine.io",

--- a/src/modules/status-bar/status-bar.html
+++ b/src/modules/status-bar/status-bar.html
@@ -17,7 +17,7 @@
             Click here for release notes
           </a>
           <div class="update-dropdown-button-container">
-            <button class="btn-default update-dropdown-cancel-button" click.delegate="hideDropdown()" disabled.bind="updateStarted">Cancel</button>
+            <button class="btn btn-default update-dropdown-cancel-button" click.delegate="hideDropdown()" disabled.bind="updateStarted">Cancel</button>
             <button class="btn btn-primary update-dropdown-update-button" click.delegate="startUpdate()" disabled.bind="updateStarted">Update</button>
           </div>
         </template>

--- a/src/modules/status-bar/status-bar.html
+++ b/src/modules/status-bar/status-bar.html
@@ -5,7 +5,7 @@
   -->
   <div class="status-bar status-bar--system-macos" id="statusBarContainer">
     <div class="status-bar__left-bar" id="statusBarLeft">
-      <a if.bind="updateAvailable" class="update-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <a if.bind="updateAvailable" ref="updateDropdownToggle" class="update-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         <img class="update-button-icon" src="src/resources/images/icon.png" title.bind="isDownloading ? updateProgressData.percent.toString() + '%' : 'Update available.'">
       </a>
       <div class="dropdown-menu update-dropdown" ref="updateDropdown">

--- a/src/modules/status-bar/status-bar.ts
+++ b/src/modules/status-bar/status-bar.ts
@@ -37,6 +37,7 @@ export class StatusBar {
   public updateVersion: string;
   public updateAvailable: boolean = false;
   public updateDropdown: HTMLElement;
+  public updateDropdownToggle: HTMLElement;
   public updateDownloadFinished: boolean = false;
   public updateStarted: boolean = false;
 
@@ -75,7 +76,18 @@ export class StatusBar {
         const message: string =
           'A new update is available.\nPlease click on the BPMN Studio icon in the statusbar to start the download.';
 
-        this.notificationService.showNonDisappearingNotification(NotificationType.INFO, message);
+        const toastrOptions: ToastrOptions = {
+          onclick: (notificationClickEvent: Event) => {
+            notificationClickEvent.stopPropagation();
+
+            const updateDropdownIsHidden: boolean = $(this.updateDropdown).is(':hidden');
+            if (updateDropdownIsHidden) {
+              this.updateDropdownToggle.click();
+            }
+          },
+        };
+
+        this.notificationService.showNonDisappearingNotification(NotificationType.INFO, message, toastrOptions);
       });
 
       this.ipcRenderer.on('update_download_progress', (event: Event, updateProgressData: UpdateProgressData) => {


### PR DESCRIPTION
## Changes

1.  Show Update Dropdown When Notification was Clicked

## Issues

Closes #1788 

PR: #1911

## How to test the changes

- `gco 711360d`
- `npm run electron-start-dev`
- Click on the update notification
- **Notice that the update modal is displayed.**
- Reload
- Click on the BPMN Studio icon in the statusbar (open the update modal)
- Click on the update notification
- **Note that the update modal is still displayed.**