### PR TITLE
✨ Refresh Access Tokens (Electron)

### DIFF
--- a/electron_app/electron-oidc.ts
+++ b/electron_app/electron-oidc.ts
@@ -207,36 +207,6 @@ function logout(
   );
 }
 
-function startSilentRefreshing(
-  authorityUrl: string,
-  config: IOidcConfig,
-  tokenObject: ITokenObject,
-  refreshCallback: Function,
-): void {
-  authoritiesToRefresh.push(authorityUrl);
-
-  silentRefresh(authorityUrl, config, tokenObject, refreshCallback);
-}
-
-function stopSilentRefreshing(authorityUrl: string): void {
-  if (refreshTimeouts.has(authorityUrl)) {
-    refreshTimeouts.get(authorityUrl).cancel();
-    refreshTimeouts.delete(authorityUrl);
-  }
-  if (authoritiesToRefresh.includes(authorityUrl)) {
-    const authorityToRemove = authoritiesToRefresh.findIndex((authority) => authority === authorityUrl);
-    authoritiesToRefresh.splice(authorityToRemove, 0);
-  }
-}
-
-function wait(ms: number): Promise<void> {
-  return new Bluebird.Promise((resolve: Function) => {
-    setTimeout(() => {
-      resolve();
-    }, ms);
-  });
-}
-
 async function silentRefresh(
   authorityUrl: string,
   config: IOidcConfig,
@@ -308,6 +278,36 @@ async function silentRefresh(
     };
 
     redirectCallback(url, authWindow, config, redirectCallbackResolved, redirectCallbackRejected);
+  });
+}
+
+function startSilentRefreshing(
+  authorityUrl: string,
+  config: IOidcConfig,
+  tokenObject: ITokenObject,
+  refreshCallback: Function,
+): void {
+  authoritiesToRefresh.push(authorityUrl);
+
+  silentRefresh(authorityUrl, config, tokenObject, refreshCallback);
+}
+
+function stopSilentRefreshing(authorityUrl: string): void {
+  if (refreshTimeouts.has(authorityUrl)) {
+    refreshTimeouts.get(authorityUrl).cancel();
+    refreshTimeouts.delete(authorityUrl);
+  }
+  if (authoritiesToRefresh.includes(authorityUrl)) {
+    const authorityToRemove = authoritiesToRefresh.findIndex((authority) => authority === authorityUrl);
+    authoritiesToRefresh.splice(authorityToRemove, 0);
+  }
+}
+
+function wait(ms: number): Promise<void> {
+  return new Bluebird.Promise((resolve: Function) => {
+    setTimeout(() => {
+      resolve();
+    }, ms);
   });
 }
 

--- a/electron_app/electron-oidc.ts
+++ b/electron_app/electron-oidc.ts
@@ -240,7 +240,7 @@ async function silentRefresh(
 
   authWindow.loadURL(urlToLoad);
 
-  // Reject the Promise when the user closes the new window.
+  // Throw an error, if the user closes the new window.
   authWindow.on('closed', (): void => {
     throw new Error('window was closed by user');
   });

--- a/electron_app/electron-oidc.ts
+++ b/electron_app/electron-oidc.ts
@@ -175,14 +175,7 @@ function logout(
 
   const endSessionUrl = `${authorityUrl}connect/endsession?${queryString.stringify(urlParams)}`;
 
-  if (refreshTimeouts.has(authorityUrl)) {
-    refreshTimeouts.get(authorityUrl).cancel();
-    refreshTimeouts.delete(authorityUrl);
-  }
-  if (authoritiesToRefresh.includes(authorityUrl)) {
-    const authorityToRemove = authoritiesToRefresh.findIndex((authority) => authority === authorityUrl);
-    authoritiesToRefresh.splice(authorityToRemove, 0);
-  }
+  stopSilentRefreshing(authorityUrl);
 
   return new Promise(
     async (resolve: Function): Promise<void> => {
@@ -218,6 +211,17 @@ function startSilentRefreshing(
   authoritiesToRefresh.push(authorityUrl);
 
   silentRefresh(authorityUrl, config, windowParams, tokenObject, refreshCallback);
+}
+
+function stopSilentRefreshing(authorityUrl: string): void {
+  if (refreshTimeouts.has(authorityUrl)) {
+    refreshTimeouts.get(authorityUrl).cancel();
+    refreshTimeouts.delete(authorityUrl);
+  }
+  if (authoritiesToRefresh.includes(authorityUrl)) {
+    const authorityToRemove = authoritiesToRefresh.findIndex((authority) => authority === authorityUrl);
+    authoritiesToRefresh.splice(authorityToRemove, 0);
+  }
 }
 
 function wait(ms: number): Promise<void> {

--- a/electron_app/electron-oidc.ts
+++ b/electron_app/electron-oidc.ts
@@ -209,9 +209,13 @@ async function silentRefresh(
   tokenObject: ITokenObject,
   refreshCallback: Function,
 ): Promise<void> {
-  const timeout = wait(tokenObject.expiresIn * 0.5 * 1000);
-  refreshTimeouts.set(authorityUrl, timeout);
+  // Token refresh factor is set as described at https://github.com/manfredsteyer/angular-oauth2-oidc/blob/master/docs-src/silent-refresh.md#automatically-refreshing-a-token-when-before-it-expires-code-flow-and-implicit-flow
+  const tokenRefreshFactor = 0.75;
+  const secondsInMilisecondsFactor = 1000;
+  const tokenRefreshInterval = tokenObject.expiresIn * tokenRefreshFactor * secondsInMilisecondsFactor;
 
+  const timeout = wait(tokenRefreshInterval);
+  refreshTimeouts.set(authorityUrl, timeout);
   await timeout;
 
   if (!authoritiesToRefresh.includes(authorityUrl)) {

--- a/electron_app/electron-oidc.ts
+++ b/electron_app/electron-oidc.ts
@@ -35,7 +35,7 @@ export default (
     tokenObject: ITokenObject,
     refreshCallback: Function,
   ): void {
-    return startSilentRefreshing(authorityUrl, config, windowParams, tokenObject, refreshCallback);
+    return startSilentRefreshing(authorityUrl, config, tokenObject, refreshCallback);
   }
 
   return {
@@ -210,13 +210,12 @@ function logout(
 function startSilentRefreshing(
   authorityUrl: string,
   config: IOidcConfig,
-  windowParams: BrowserWindowConstructorOptions,
   tokenObject: ITokenObject,
   refreshCallback: Function,
 ): void {
   authoritiesToRefresh.push(authorityUrl);
 
-  silentRefresh(authorityUrl, config, windowParams, tokenObject, refreshCallback);
+  silentRefresh(authorityUrl, config, tokenObject, refreshCallback);
 }
 
 function stopSilentRefreshing(authorityUrl: string): void {
@@ -241,7 +240,6 @@ function wait(ms: number): Promise<void> {
 async function silentRefresh(
   authorityUrl: string,
   config: IOidcConfig,
-  windowParams: BrowserWindowConstructorOptions,
   tokenObject: ITokenObject,
   refreshCallback: Function,
 ): Promise<void> {
@@ -296,7 +294,7 @@ async function silentRefresh(
     const redirectCallbackResolved = (token: ITokenObject): void => {
       refreshCallback(token);
 
-      silentRefresh(authorityUrl, config, windowParams, tokenObject, refreshCallback);
+      silentRefresh(authorityUrl, config, tokenObject, refreshCallback);
     };
 
     const redirectCallbackRejected = (error: Error): void => {

--- a/electron_app/electron-oidc.ts
+++ b/electron_app/electron-oidc.ts
@@ -147,11 +147,7 @@ function redirectCallback(
     const idToken = parameterAsArray[0].split('=')[1];
     const accessToken = parameterAsArray[1].split('=')[1];
 
-    const expiresIn = parameterAsArray
-      .find((parameter) => {
-        return parameter.startsWith('expires_in=');
-      })
-      .split('=')[1];
+    const expiresIn = parameterAsArray.find((parameter) => parameter.startsWith('expires_in=')).split('=')[1];
 
     const tokenObject = {
       idToken,
@@ -268,13 +264,11 @@ async function silentRefresh(
     };
 
     const redirectCallbackRejected = (error: Error): void => {
-      if (error.message === 'User is no longer logged in.') {
-        stopSilentRefreshing(authorityUrl);
-
-        return;
+      if (error.message !== 'User is no longer logged in.') {
+        throw error;
       }
 
-      throw error;
+      stopSilentRefreshing(authorityUrl);
     };
 
     redirectCallback(url, authWindow, config, redirectCallbackResolved, redirectCallbackRejected);

--- a/electron_app/electron.ts
+++ b/electron_app/electron.ts
@@ -31,7 +31,7 @@ import ReleaseChannel from '../src/services/release-channel-service/release-chan
 import {solutionIsRemoteSolution} from '../src/services/solution-is-remote-solution-module/solution-is-remote-solution.module';
 import {version as CurrentStudioVersion} from '../package.json';
 import {getPortListByVersion} from '../src/services/default-ports-module/default-ports.module';
-import {FeedbackData} from '../src/contracts';
+import {FeedbackData, ITokenObject} from '../src/contracts';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import electron = require('electron');
@@ -241,7 +241,12 @@ function initializeOidc(): void {
 
   ipcMain.on('oidc-login', (event, authorityUrl) => {
     electronOidcInstance.getTokenObject(authorityUrl).then(
-      (token) => {
+      async (token) => {
+        const refreshCallback: Function = (tokenObject: ITokenObject) => {
+          event.sender.send(`oidc-silent_refresh-${authorityUrl}`, tokenObject);
+        };
+
+        electronOidcInstance.startSilentRefreshing(authorityUrl, token, refreshCallback);
         event.sender.send('oidc-login-reply', token);
       },
       (err) => {

--- a/src/contracts/authentication/IAuthenticationService.ts
+++ b/src/contracts/authentication/IAuthenticationService.ts
@@ -4,7 +4,7 @@ import {ILoginResult} from './ILoginResult';
 import {IUserIdentity} from './IUserIdentity';
 
 export interface IAuthenticationService {
-  login(authority: string): Promise<ILoginResult>;
+  login(authority: string, refreshCallback: Function): Promise<ILoginResult>;
   logout(authority: string, identity: IIdentity): Promise<void>;
   isLoggedIn(authority: string, identity: IIdentity): Promise<boolean>;
   getUserIdentity(authrotiy: string, identity: IIdentity): Promise<IUserIdentity>;

--- a/src/contracts/authentication/ITokenObject.ts
+++ b/src/contracts/authentication/ITokenObject.ts
@@ -2,4 +2,5 @@ export interface ITokenObject {
   idToken: string;
   accessToken: string;
   userId?: string;
+  expiresIn: number;
 }

--- a/src/services/authentication-service/web.oidc-authentication-service.ts
+++ b/src/services/authentication-service/web.oidc-authentication-service.ts
@@ -2,9 +2,9 @@ import {EventAggregator} from 'aurelia-event-aggregator';
 import {inject} from 'aurelia-framework';
 import {OpenIdConnect} from 'aurelia-open-id-connect';
 import {Router} from 'aurelia-router';
+import {User} from 'oidc-client';
 
 import {IIdentity} from '@essential-projects/iam_contracts';
-import {User} from 'oidc-client';
 
 import {
   AuthenticationStateEvent,


### PR DESCRIPTION
## Changes

1. Refresh Access Tokens via Silent Refresh in Electron

## Issues

Closes #1831

PR: #1916

## How to test the changes

### Preparation

- Start your identity server
- Navigate to your identity server using your browser (`http://localhost:5000/`)
- Click on `Click here to manage your users and IdentityServer configuration.`
- Go to Clients
- Select `BPMN Studio` from the list
- Go to `Advanced`
- Set `ACCESS TOKEN LIFETIME (SECONDS)` to 20

### Testing

- Log in to any PE using that identity server
- Open up the developer console
- Go to the `Network` tab
- Click on any request
- Try to remember the last characters of the authorization token
- Wait >10 seconds
- Click on a new request
- **Notice that the authorization token changed.**
- Open another version of BPMN Studio (e.g. stable) & log in to any PE using the same authority  & wait until the process models cannot be loaded anymore **or wait some time (>5 minutes)**
- **Notice that the development version of the BPMN Studio can still load Process Models even though the initial access token is not working anymore.**