### PR TITLE
✨ Add InternalProcessEngine Logs to Feedback Modal

### DIFF
--- a/electron_app/electron.ts
+++ b/electron_app/electron.ts
@@ -1253,6 +1253,12 @@ async function getPathToSaveTo(defaultFilename): Promise<string> {
 }
 
 function addFolderToZip(zipFolder, folderName, folderPath): void {
+  if (!fs.existsSync(folderPath)) {
+    zipFolder.file(`${folderName} does not exist.`, '', {base64: true});
+
+    return;
+  }
+
   const folderInZip = zipFolder.folder(folderName);
 
   const filesAndFoldersInFolder: Array<fs.Dirent> = getNamesOfFilesAndFoldersInFolder(folderPath);

--- a/electron_app/electron.ts
+++ b/electron_app/electron.ts
@@ -974,8 +974,8 @@ async function startInternalProcessEngine(): Promise<any> {
   // TODO: Check if the ProcessEngine instance is now run on the UI thread.
   // See issue https://github.com/process-engine/bpmn-studio/issues/312
   try {
-    const sqlitePath = getDatabaseFolder();
-    const logFilepath = getLogFolder();
+    const sqlitePath = getProcessEngineDatabaseFolder();
+    const logFilepath = getProcessEngineLogFolder();
 
     const startupArgs = {
       sqlitePath: sqlitePath,
@@ -1005,7 +1005,7 @@ async function startInternalProcessEngine(): Promise<any> {
   }
 }
 
-function getLogFolder(): string {
+function getProcessEngineLogFolder(): string {
   return path.join(getConfigFolder(), getProcessEngineLogFolderName());
 }
 
@@ -1013,7 +1013,7 @@ function getProcessEngineLogFolderName(): string {
   return 'process_engine_logs';
 }
 
-function getDatabaseFolder(): string {
+function getProcessEngineDatabaseFolder(): string {
   return path.join(getConfigFolder(), getProcessEngineDatabaseFolderName());
 }
 
@@ -1257,7 +1257,7 @@ async function getPathToSaveTo(defaultFilename): Promise<string> {
 async function addDatabaseToZip(zipFolder): Promise<void> {
   const databaseZipFolder = zipFolder.folder(getProcessEngineDatabaseFolderName());
 
-  const databaseFolderName: string = getDatabaseFolder();
+  const databaseFolderName: string = getProcessEngineDatabaseFolder();
 
   const databaseFiles: Array<string> = await getFilenamesOfFilesInFolder(databaseFolderName);
 

--- a/electron_app/electron.ts
+++ b/electron_app/electron.ts
@@ -1145,25 +1145,25 @@ async function exportDatabases(): Promise<void> {
 async function createFeedbackZip(feedbackData: FeedbackData): Promise<void> {
   const zip = new JSZip();
 
-  const zipFolder = zip.folder('feedback');
+  const feedbackFolder = zip.folder('feedback');
 
   if (feedbackData.attachInternalDatabases) {
-    addFolderToZip(zipFolder, getProcessEngineDatabaseFolderName(), getProcessEngineDatabaseFolder());
+    addFolderToZip(feedbackFolder, getProcessEngineDatabaseFolderName(), getProcessEngineDatabaseFolder());
   }
 
   const bugsProvided: boolean = feedbackData.bugs.trim() !== '';
   if (bugsProvided) {
-    zipFolder.file('Bugs.txt', feedbackData.bugs);
+    feedbackFolder.file('Bugs.txt', feedbackData.bugs);
   }
 
   const suggestionsProvided: boolean = feedbackData.suggestions.trim() !== '';
   if (suggestionsProvided) {
-    zipFolder.file('Suggestions.txt', feedbackData.suggestions);
+    feedbackFolder.file('Suggestions.txt', feedbackData.suggestions);
   }
 
   const diagramsProvided: boolean = feedbackData.diagrams.length > 0;
   if (diagramsProvided) {
-    const diagramFolder = zipFolder.folder('diagrams');
+    const diagramFolder = feedbackFolder.folder('diagrams');
 
     feedbackData.diagrams.forEach((diagram) => {
       let diagramSolution: string = '';

--- a/electron_app/electron.ts
+++ b/electron_app/electron.ts
@@ -1148,7 +1148,11 @@ async function createFeedbackZip(feedbackData: FeedbackData): Promise<void> {
   const feedbackFolder = zip.folder('feedback');
 
   if (feedbackData.attachInternalDatabases) {
-    addFolderToZip(feedbackFolder, getProcessEngineDatabaseFolderName(), getProcessEngineDatabaseFolder());
+    addFolderToZip(processEngineFolder, getProcessEngineDatabaseFolderName(), getProcessEngineDatabaseFolder());
+  }
+
+  if (feedbackData.attachProcessEngineLogs) {
+    addFolderToZip(processEngineFolder, getProcessEngineLogFolderName(), getProcessEngineLogFolder());
   }
 
   const bugsProvided: boolean = feedbackData.bugs.trim() !== '';

--- a/electron_app/electron.ts
+++ b/electron_app/electron.ts
@@ -1148,10 +1148,14 @@ async function createFeedbackZip(feedbackData: FeedbackData): Promise<void> {
   const feedbackFolder = zip.folder('feedback');
 
   if (feedbackData.attachInternalDatabases) {
+    const processEngineFolder = feedbackFolder.folder('InternalProcessEngine');
+
     addFolderToZip(processEngineFolder, getProcessEngineDatabaseFolderName(), getProcessEngineDatabaseFolder());
   }
 
   if (feedbackData.attachProcessEngineLogs) {
+    const processEngineFolder = feedbackFolder.folder('InternalProcessEngine');
+
     addFolderToZip(processEngineFolder, getProcessEngineLogFolderName(), getProcessEngineLogFolder());
   }
 

--- a/src/contracts/feedback/FeedbackData.ts
+++ b/src/contracts/feedback/FeedbackData.ts
@@ -6,4 +6,5 @@ export type FeedbackData = {
   diagrams: Array<IDiagram>;
   additionalDiagramInformation: string;
   attachInternalDatabases: boolean;
+  attachProcessEngineLogs: boolean;
 };

--- a/src/modules/feedback-modal/feedback-modal.html
+++ b/src/modules/feedback-modal/feedback-modal.html
@@ -21,6 +21,11 @@
       <i class="fas fa-info-circle feedback-modal__help-icon" title="If you have a problem with deployed diagrams, attaching the databases is probably helpful."></i>
     </div>
     <div>
+      <input type="checkbox" class="feedback-modal__checkbox" checked.bind="attachProcessEngineLogs"/>
+      <span class="feedback-modal__checkbox-label">Attach the logs of the internal ProcessEngine</span>
+      <i class="fas fa-info-circle feedback-modal__help-icon" title="If you have a problem with the internal ProcessEngine, attaching its logs is probable helpful."></i>
+    </div>
+    <div>
       <input type="checkbox" class="feedback-modal__checkbox" checked.bind="showProcessModelSelection"/>
       <span class="feedback-modal__checkbox-label">Attach diagrams</span>
       <div if.bind="showProcessModelSelection" class="feedback-modal__diagram-selection">

--- a/src/modules/feedback-modal/feedback-modal.ts
+++ b/src/modules/feedback-modal/feedback-modal.ts
@@ -1,9 +1,7 @@
 import {bindable, inject} from 'aurelia-framework';
 import {IDiagram, ISolution} from '@process-engine/solutionexplorer.contracts';
-import {EventAggregator} from 'aurelia-event-aggregator';
 import {SolutionService} from '../../services/solution-service/solution.service';
 import {FeedbackData, ISolutionEntry} from '../../contracts';
-import environment from '../../environment';
 import {isRunningInElectron} from '../../services/is-running-in-electron-module/is-running-in-electron.module';
 import {solutionIsRemoteSolution} from '../../services/solution-is-remote-solution-module/solution-is-remote-solution.module';
 

--- a/src/modules/feedback-modal/feedback-modal.ts
+++ b/src/modules/feedback-modal/feedback-modal.ts
@@ -44,7 +44,14 @@ export class FeedbackModal {
   }
 
   public get disableCreateButton(): boolean {
-    return this.bugs.trim() === '' && this.suggestions.trim() === '' && this.additionalDiagramInformation.trim() === '';
+    return (
+      this.bugs.trim() === '' &&
+      this.suggestions.trim() === '' &&
+      this.additionalDiagramInformation.trim() === '' &&
+      !this.attachInternalDatabases &&
+      !this.attachProcessEngineLogs &&
+      Object.keys(this.selectedDiagrams).length === 0
+    );
   }
 
   public showFeedbackModalChanged(): void {

--- a/src/modules/feedback-modal/feedback-modal.ts
+++ b/src/modules/feedback-modal/feedback-modal.ts
@@ -24,6 +24,7 @@ export class FeedbackModal {
   public selectedDiagrams: ISelectedDiagramList = {};
   public additionalDiagramInformation: string = '';
   public attachInternalDatabases: boolean = false;
+  public attachProcessEngineLogs: boolean = false;
 
   public solutions: Array<ISolution>;
   public showSolutionList: IShowSolutionList = {};
@@ -80,6 +81,7 @@ export class FeedbackModal {
       diagrams: diagramsToAttach,
       additionalDiagramInformation: this.additionalDiagramInformation,
       attachInternalDatabases: this.attachInternalDatabases,
+      attachProcessEngineLogs: this.attachProcessEngineLogs,
     };
 
     this.ipcRenderer.send('create-feedback-zip', feedbackData);


### PR DESCRIPTION
## Changes

1. Harmonize Function Names
2. Adjust Adding Files And Folders to Zip
3. Improve Variable Naming
4. Add InternalProcessEngine Logs to Feedback Modal
5.  Improve Folder Structure of Feedback Zip

## Issues

Closes #1913 

PR: #1919

## How to test the changes

- Open the feedback modal
- Fill some input fields
- Check the checkbox about PE logs
- Save the feedback.zip somewhere
- Extract the feedback.zip
- **Notice that the feedback.zip includes the logs of the InternalProcesEngine.**