### PR TITLE
🐛 Fix Navigating to Inspect Process Instance via Let 'Bug' Overlay

### DIFF
--- a/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.ts
+++ b/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.ts
@@ -237,10 +237,6 @@ export class DiagramViewer {
       return;
     }
 
-    if (!this.activeDiagram) {
-      this.noCorrelationsFound = true;
-    }
-
     this.diagramViewer.clear();
     this.xmlIsNotSelected = true;
     this.noCorrelationsFound = false;

--- a/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.ts
+++ b/src/modules/inspect/inspect-correlation/components/diagram-viewer/diagram-viewer.ts
@@ -233,7 +233,6 @@ export class DiagramViewer {
 
   public activeDiagramChanged(): void {
     const diagramViewerIsNotSet: boolean = this.diagramViewer === undefined;
-
     if (diagramViewerIsNotSet) {
       return;
     }

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/components/correlation-list/correlation-list.ts
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/components/correlation-list/correlation-list.ts
@@ -139,17 +139,19 @@ export class CorrelationList {
   private convertCorrelationsIntoTableData(
     correlations: Array<DataModels.Correlations.Correlation>,
   ): Array<ICorrelationTableEntry> {
-    return correlations.map((correlation: DataModels.Correlations.Correlation) => {
-      const formattedStartedDate: string = getBeautifiedDate(correlation.createdAt);
+    return correlations.map(this.convertCorrelationIntoTableData);
+  }
 
-      const tableEntry: ICorrelationTableEntry = {
-        startedAt: formattedStartedDate,
-        state: correlation.state,
-        correlationId: correlation.id,
-      };
+  private convertCorrelationIntoTableData(correlation: DataModels.Correlations.Correlation): ICorrelationTableEntry {
+    const formattedStartedDate: string = getBeautifiedDate(correlation.createdAt);
 
-      return tableEntry;
-    });
+    const tableEntry: ICorrelationTableEntry = {
+      startedAt: formattedStartedDate,
+      state: correlation.state,
+      correlationId: correlation.id,
+    };
+
+    return tableEntry;
   }
 
   public changeSortSettings(property: CorrelationListSortProperty): void {
@@ -173,7 +175,7 @@ export class CorrelationList {
 
     this.correlationToSelectTableEntry = correlationAlreadyExistInList
       ? correlationFromTableData
-      : this.convertCorrelationsIntoTableData([this.correlationToSelect])[0];
+      : this.convertCorrelationIntoTableData(this.correlationToSelect);
 
     this.selectCorrelation(this.correlationToSelectTableEntry);
   }

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/components/correlation-list/correlation-list.ts
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/components/correlation-list/correlation-list.ts
@@ -143,10 +143,8 @@ export class CorrelationList {
   }
 
   private convertCorrelationIntoTableData(correlation: DataModels.Correlations.Correlation): ICorrelationTableEntry {
-    const formattedStartedDate: string = getBeautifiedDate(correlation.createdAt);
-
     const tableEntry: ICorrelationTableEntry = {
-      startedAt: formattedStartedDate,
+      startedAt: getBeautifiedDate(correlation.createdAt),
       state: correlation.state,
       correlationId: correlation.id,
     };

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/components/correlation-list/correlation-list.ts
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/components/correlation-list/correlation-list.ts
@@ -169,11 +169,8 @@ export class CorrelationList {
       },
     );
 
-    const correlationAlreadyExistInList = correlationFromTableData !== undefined;
-
-    this.correlationToSelectTableEntry = correlationAlreadyExistInList
-      ? correlationFromTableData
-      : this.convertCorrelationIntoTableData(this.correlationToSelect);
+    this.correlationToSelectTableEntry =
+      correlationFromTableData || this.convertCorrelationIntoTableData(this.correlationToSelect);
 
     this.selectCorrelation(this.correlationToSelectTableEntry);
   }

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/components/correlation-list/correlation-list.ts
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/components/correlation-list/correlation-list.ts
@@ -67,6 +67,39 @@ export class CorrelationList {
     this.correlationToSelectTableEntry = undefined;
   }
 
+  public correlationToSelectChanged(
+    newValue: DataModels.Correlations.Correlation,
+    oldValue: DataModels.Correlations.Correlation,
+  ): void {
+    if (this.correlationToSelect === undefined) {
+      return;
+    }
+
+    const correlationToSelectDidNotChange = oldValue && newValue && newValue.id === oldValue.id;
+    if (correlationToSelectDidNotChange) {
+      return;
+    }
+
+    const correlationFromTableData: ICorrelationTableEntry = this.sortedTableData.find(
+      (correlation: ICorrelationTableEntry) => {
+        return correlation.correlationId === this.correlationToSelect.id;
+      },
+    );
+
+    const correlationAlreadyExistInList = correlationFromTableData !== undefined;
+    if (correlationAlreadyExistInList) {
+      this.correlationToSelectTableEntry = correlationFromTableData;
+    } else {
+      const correlationToSelectTableEntry: Array<ICorrelationTableEntry> = this.convertCorrelationsIntoTableData([
+        this.correlationToSelect,
+      ]);
+
+      this.correlationToSelectTableEntry = correlationToSelectTableEntry[0];
+    }
+
+    this.selectCorrelation(this.correlationToSelectTableEntry);
+  }
+
   public correlationsChanged(): void {
     if (!this.activeDiagram) {
       return;
@@ -80,28 +113,6 @@ export class CorrelationList {
       const firstTableEntry: ICorrelationTableEntry = this.sortedTableData[0];
 
       this.selectCorrelation(firstTableEntry);
-    }
-
-    const correlationToSelectExists: boolean = this.correlationToSelect !== undefined;
-    if (correlationToSelectExists) {
-      const instanceAlreadyExistInList: ICorrelationTableEntry = this.sortedTableData.find(
-        (correlation: ICorrelationTableEntry) => {
-          return correlation.correlationId === this.correlationToSelect.id;
-        },
-      );
-
-      if (instanceAlreadyExistInList) {
-        this.correlationToSelectTableEntry = undefined;
-      } else {
-        const correlationToSelectTableEntry: Array<ICorrelationTableEntry> = this.convertCorrelationsIntoTableData([
-          this.correlationToSelect,
-        ]);
-
-        this.correlationToSelectTableEntry = correlationToSelectTableEntry[0];
-        this.selectCorrelation(this.correlationToSelectTableEntry);
-      }
-
-      this.correlationToSelect = undefined;
     }
 
     this.paginationShowsLoading = false;

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/components/correlation-list/correlation-list.ts
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/components/correlation-list/correlation-list.ts
@@ -67,37 +67,12 @@ export class CorrelationList {
     this.correlationToSelectTableEntry = undefined;
   }
 
-  public correlationToSelectChanged(
-    newValue: DataModels.Correlations.Correlation,
-    oldValue: DataModels.Correlations.Correlation,
-  ): void {
-    if (this.correlationToSelect === undefined) {
+  public correlationToSelectChanged(): void {
+    if (this.correlationToSelect === undefined || this.sortedTableData === undefined) {
       return;
     }
 
-    const correlationToSelectDidNotChange = oldValue && newValue && newValue.id === oldValue.id;
-    if (correlationToSelectDidNotChange) {
-      return;
-    }
-
-    const correlationFromTableData: ICorrelationTableEntry = this.sortedTableData.find(
-      (correlation: ICorrelationTableEntry) => {
-        return correlation.correlationId === this.correlationToSelect.id;
-      },
-    );
-
-    const correlationAlreadyExistInList = correlationFromTableData !== undefined;
-    if (correlationAlreadyExistInList) {
-      this.correlationToSelectTableEntry = correlationFromTableData;
-    } else {
-      const correlationToSelectTableEntry: Array<ICorrelationTableEntry> = this.convertCorrelationsIntoTableData([
-        this.correlationToSelect,
-      ]);
-
-      this.correlationToSelectTableEntry = correlationToSelectTableEntry[0];
-    }
-
-    this.selectCorrelation(this.correlationToSelectTableEntry);
+    this.selectCorrelationToSelect();
   }
 
   public correlationsChanged(): void {
@@ -109,7 +84,9 @@ export class CorrelationList {
     this.sortTableData();
 
     const tableDataIsExisiting: boolean = this.sortedTableData.length > 0;
-    if (tableDataIsExisiting) {
+    if (tableDataIsExisiting && this.correlationToSelect) {
+      this.selectCorrelationToSelect();
+    } else if (tableDataIsExisiting) {
       const firstTableEntry: ICorrelationTableEntry = this.sortedTableData[0];
 
       this.selectCorrelation(firstTableEntry);
@@ -183,6 +160,22 @@ export class CorrelationList {
     this.sortSettings.sortProperty = property;
 
     this.sortTableData();
+  }
+
+  private selectCorrelationToSelect(): void {
+    const correlationFromTableData: ICorrelationTableEntry = this.sortedTableData.find(
+      (correlation: ICorrelationTableEntry) => {
+        return correlation.correlationId === this.correlationToSelect.id;
+      },
+    );
+
+    const correlationAlreadyExistInList = correlationFromTableData !== undefined;
+
+    this.correlationToSelectTableEntry = correlationAlreadyExistInList
+      ? correlationFromTableData
+      : this.convertCorrelationsIntoTableData([this.correlationToSelect])[0];
+
+    this.selectCorrelation(this.correlationToSelectTableEntry);
   }
 
   private sortTableData(): void {

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/components/process-instance-list/process-instance-list.html
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/components/process-instance-list/process-instance-list.html
@@ -24,7 +24,7 @@
         </tr>
       </thead>
       <tbody class="process-instance-table__body">
-        <tr if.bind="processInstanceToSelectTableEntry" dblclick.delegate="showLogViewer()" class="process-instance-table__table-row process-instance-table__table-row--instance-to-select" class.bind="processInstanceToSelectTableEntry.processInstanceId === selectedTableEntry.processInstanceId ? 'process-instance-table__selected-entry': ''" click.delegate="selectProcessInstance(processInstanceToSelectTableEntry)">
+        <tr if.bind="showProcessInstanceToSelect" dblclick.delegate="showLogViewer()" class="process-instance-table__table-row process-instance-table__table-row--instance-to-select" class.bind="processInstanceToSelectTableEntry.processInstanceId === selectedTableEntry.processInstanceId ? 'process-instance-table__selected-entry': ''" click.delegate="selectProcessInstance(processInstanceToSelectTableEntry)">
           <td class="process-instance-table__table-entry">${processInstanceToSelectTableEntry.startedAt}</td>
           <td class="process-instance-table__table-entry process-instance-table__table-entry--state">${processInstanceToSelectTableEntry.state}</td>
           <td class="process-instance-table__table-entry">${processInstanceToSelectTableEntry.user}</td>

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/components/process-instance-list/process-instance-list.html
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/components/process-instance-list/process-instance-list.html
@@ -27,7 +27,8 @@
         <tr if.bind="processInstanceToSelectTableEntry" dblclick.delegate="showLogViewer()" class="process-instance-table__table-row process-instance-table__table-row--instance-to-select" class.bind="processInstanceToSelectTableEntry.processInstanceId === selectedTableEntry.processInstanceId ? 'process-instance-table__selected-entry': ''" click.delegate="selectProcessInstance(processInstanceToSelectTableEntry)">
           <td class="process-instance-table__table-entry">${processInstanceToSelectTableEntry.startedAt}</td>
           <td class="process-instance-table__table-entry process-instance-table__table-entry--state">${processInstanceToSelectTableEntry.state}</td>
-          <td if.bind="false" class="process-instance-table__table-entry">${processInstanceToSelectTableEntry.user}</td>
+          <td class="process-instance-table__table-entry">${processInstanceToSelectTableEntry.user}</td>
+          <td class="process-instance-table__table-entry">${processInstanceToSelectTableEntry.processModelId}</td>
           <td class="process-instance-table__table-entry">${processInstanceToSelectTableEntry.processInstanceId}</td>
         </tr>
         <tr dblclick.delegate="showLogViewer()" class="process-instance-table__table-row" repeat.for="tableEntry of sortedTableData" class.bind="tableEntry.processInstanceId === selectedTableEntry.processInstanceId ? 'process-instance-table__selected-entry': ''" click.delegate="selectProcessInstance(tableEntry)">

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/components/process-instance-list/process-instance-list.ts
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/components/process-instance-list/process-instance-list.ts
@@ -97,23 +97,25 @@ export class ProcessInstanceList {
 
     const processInstanceToSelectExists: boolean = this.processInstanceToSelect !== undefined;
     if (processInstanceToSelectExists) {
-      const instanceAlreadyExistInList: ProcessInstanceTableEntry = this.sortedTableData.find(
+      const processInstanceFromTableData: ProcessInstanceTableEntry = this.sortedTableData.find(
         (processInstance: ProcessInstanceTableEntry) => {
           return processInstance.processInstanceId === this.processInstanceToSelect.processInstanceId;
         },
       );
 
-      if (instanceAlreadyExistInList) {
-        this.processInstanceToSelectTableEntry = undefined;
+      const procesInstanceAlreadyExistsInTableData = processInstanceFromTableData;
+
+      if (procesInstanceAlreadyExistsInTableData) {
+        this.processInstanceToSelectTableEntry = processInstanceFromTableData;
       } else {
         const processInstanceToSelectTableEntry: Array<ProcessInstanceTableEntry> = this.convertProcessInstancesIntoTableData(
           [this.processInstanceToSelect],
         );
 
         this.processInstanceToSelectTableEntry = processInstanceToSelectTableEntry[0];
-        this.selectProcessInstance(this.processInstanceToSelectTableEntry);
       }
 
+      this.selectProcessInstance(this.processInstanceToSelectTableEntry);
       this.processInstanceToSelect = undefined;
     }
 

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/components/process-instance-list/process-instance-list.ts
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/components/process-instance-list/process-instance-list.ts
@@ -116,7 +116,7 @@ export class ProcessInstanceList {
       const processInstanceAlreadyExistsInTableData = processInstanceFromTableData;
       this.processInstanceToSelectTableEntry = processInstanceAlreadyExistsInTableData
         ? processInstanceFromTableData
-        : this.convertProcessInstancesIntoTableData([this.processInstanceToSelect])[0];
+        : this.convertProcessInstanceIntoTableData(this.processInstanceToSelect);
 
       this.selectProcessInstance(this.processInstanceToSelectTableEntry);
     }
@@ -178,19 +178,21 @@ export class ProcessInstanceList {
   private convertProcessInstancesIntoTableData(
     processInstances: Array<DataModels.Correlations.ProcessInstance>,
   ): Array<ProcessInstanceTableEntry> {
-    return processInstances.map((processInstance: DataModels.Correlations.ProcessInstance) => {
-      const formattedStartedDate: string = getBeautifiedDate(processInstance.createdAt);
+    return processInstances.map(this.convertProcessInstanceIntoTableData);
+  }
 
-      const tableEntry: ProcessInstanceTableEntry = {
-        startedAt: formattedStartedDate,
-        state: processInstance.state,
-        user: processInstance.identity.userId,
-        processModelId: processInstance.processModelId,
-        processInstanceId: processInstance.processInstanceId,
-      };
+  private convertProcessInstanceIntoTableData(
+    processInstance: DataModels.Correlations.ProcessInstance,
+  ): ProcessInstanceTableEntry {
+    const tableEntry: ProcessInstanceTableEntry = {
+      startedAt: getBeautifiedDate(processInstance.createdAt),
+      state: processInstance.state,
+      user: processInstance.identity.userId,
+      processModelId: processInstance.processModelId,
+      processInstanceId: processInstance.processInstanceId,
+    };
 
-      return tableEntry;
-    });
+    return tableEntry;
   }
 
   private sortTableData(): void {

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/components/process-instance-list/process-instance-list.ts
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/components/process-instance-list/process-instance-list.ts
@@ -98,9 +98,7 @@ export class ProcessInstanceList {
       const firstTableEntry: ProcessInstanceTableEntry = this.sortedTableData[0];
 
       const processInstanceToSelect: ProcessInstanceTableEntry =
-        firstProcessInstanceFromCorrectProcessModel !== undefined
-          ? firstProcessInstanceFromCorrectProcessModel
-          : firstTableEntry;
+        firstProcessInstanceFromCorrectProcessModel || firstTableEntry;
 
       this.selectProcessInstance(processInstanceToSelect);
     }
@@ -113,10 +111,8 @@ export class ProcessInstanceList {
         },
       );
 
-      const processInstanceAlreadyExistsInTableData = processInstanceFromTableData;
-      this.processInstanceToSelectTableEntry = processInstanceAlreadyExistsInTableData
-        ? processInstanceFromTableData
-        : this.convertProcessInstanceIntoTableData(this.processInstanceToSelect);
+      this.processInstanceToSelectTableEntry =
+        processInstanceFromTableData || this.convertProcessInstanceIntoTableData(this.processInstanceToSelect);
 
       this.selectProcessInstance(this.processInstanceToSelectTableEntry);
     }

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/components/process-instance-list/process-instance-list.ts
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/components/process-instance-list/process-instance-list.ts
@@ -113,17 +113,10 @@ export class ProcessInstanceList {
         },
       );
 
-      const procesInstanceAlreadyExistsInTableData = processInstanceFromTableData;
-
-      if (procesInstanceAlreadyExistsInTableData) {
-        this.processInstanceToSelectTableEntry = processInstanceFromTableData;
-      } else {
-        const processInstanceToSelectTableEntry: Array<ProcessInstanceTableEntry> = this.convertProcessInstancesIntoTableData(
-          [this.processInstanceToSelect],
-        );
-
-        this.processInstanceToSelectTableEntry = processInstanceToSelectTableEntry[0];
-      }
+      const processInstanceAlreadyExistsInTableData = processInstanceFromTableData;
+      this.processInstanceToSelectTableEntry = processInstanceAlreadyExistsInTableData
+        ? processInstanceFromTableData
+        : this.convertProcessInstancesIntoTableData([this.processInstanceToSelect])[0];
 
       this.selectProcessInstance(this.processInstanceToSelectTableEntry);
     }

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/components/process-instance-list/process-instance-list.ts
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/components/process-instance-list/process-instance-list.ts
@@ -59,6 +59,7 @@ export class ProcessInstanceList {
 
   public selectProcessInstance(selectedTableEntry: ProcessInstanceTableEntry): void {
     this.selectedProcessInstance = this.getProcessInstanceForTableEntry(selectedTableEntry);
+
     this.selectedTableEntry = selectedTableEntry;
   }
 

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/components/process-instance-list/process-instance-list.ts
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/components/process-instance-list/process-instance-list.ts
@@ -126,7 +126,6 @@ export class ProcessInstanceList {
       }
 
       this.selectProcessInstance(this.processInstanceToSelectTableEntry);
-      this.processInstanceToSelect = undefined;
     }
 
     this.paginationShowsLoading = false;

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/components/process-instance-list/process-instance-list.ts
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/components/process-instance-list/process-instance-list.ts
@@ -28,6 +28,7 @@ export class ProcessInstanceList {
   @bindable public activeDiagram: IDiagram;
   @bindable public sortedTableData: Array<ProcessInstanceTableEntry>;
   @bindable public paginationShowsLoading: boolean;
+  @bindable public selectedCorrelation: DataModels.Correlations.Correlation;
 
   public pagination: Pagination;
 
@@ -61,6 +62,14 @@ export class ProcessInstanceList {
     this.selectedProcessInstance = this.getProcessInstanceForTableEntry(selectedTableEntry);
 
     this.selectedTableEntry = selectedTableEntry;
+  }
+
+  public get showProcessInstanceToSelect(): boolean {
+    return (
+      this.processInstanceToSelect !== undefined &&
+      this.processInstanceToSelectTableEntry !== undefined &&
+      this.selectedCorrelation.id === this.processInstanceToSelect.correlationId
+    );
   }
 
   public activeDiagramChanged(): void {

--- a/src/modules/inspect/inspect-correlation/components/inspect-panel/inspect-panel.html
+++ b/src/modules/inspect/inspect-correlation/components/inspect-panel/inspect-panel.html
@@ -32,7 +32,7 @@
     </div>
     <div class="inspect-panel__body">
       <correlation-list show.bind="showCorrelationList" active-diagram.bind="activeDiagram" correlations.to-view="correlations"  selected-correlation.from-view="selectedCorrelation" correlation-to-select.to-view="correlationToSelect" total-count.bind="totalCorrelationCount"></correlation-list>
-      <process-instance-list show.bind="showProcessInstanceList" active-diagram.bind="activeDiagram" process-instances.to-view="processInstances" selected-process-instance.from-view="selectedProcessInstance" process-instance-to-select.to-view="processInstanceToSelect" total-count.bind="totalProcessInstanceCount"></process-instance-list>
+      <process-instance-list show.bind="showProcessInstanceList" active-diagram.bind="activeDiagram" process-instances.to-view="processInstances" selected-correlation.to-view="selectedCorrelation" selected-process-instance.from-view="selectedProcessInstance" process-instance-to-select.to-view="processInstanceToSelect" total-count.bind="totalProcessInstanceCount"></process-instance-list>
       <log-viewer if.bind="showLogViewer" active-solution-entry.bind="activeSolutionEntry" process-instance.to-view="selectedProcessInstance"></log-viewer>
     </div>
   </div>

--- a/src/modules/inspect/inspect-correlation/inspect-correlation.html
+++ b/src/modules/inspect/inspect-correlation/inspect-correlation.html
@@ -21,7 +21,7 @@
       <div class="inspect-correlation__bottom-panel" css="height: ${bottomPanelHeight}px;"
             class.bind="inspectPanelFullscreen ? 'inspect-correlation__bottom-panel--fullscreen' : ''"
             show.bind="showInspectPanel">
-        <inspect-panel view-model.ref="inspectPanel" active-solution-entry.bind="activeSolutionEntry" active-diagram.bind="activeDiagram" process-instances.bind="processInstances" correlations.bind="correlations" selected-process-instance.from-view="selectedProcessInstance" selected-correlation.from-view="selectedCorrelation" fullscreen.two-way="inspectPanelFullscreen" log.bind="log" process-instance-to-select.to-view="processInstanceToSelect" total-process-instance-count.bind="totalProcessInstanceCount"  total-correlation-count.bind="totalCorrelationCount"></inspect-panel>
+        <inspect-panel view-model.ref="inspectPanel" active-solution-entry.bind="activeSolutionEntry" active-diagram.bind="activeDiagram" process-instances.bind="processInstances" correlations.bind="correlations" selected-process-instance.from-view="selectedProcessInstance" selected-correlation.from-view="selectedCorrelation" fullscreen.two-way="inspectPanelFullscreen" log.bind="log" process-instance-to-select.bind="processInstanceToSelect" correlation-to-select.to-view="correlationToSelect" total-process-instance-count.to-view="totalProcessInstanceCount"  total-correlation-count.bind="totalCorrelationCount"></inspect-panel>
       </div>
     </div>
 </template>

--- a/src/modules/inspect/inspect-correlation/inspect-correlation.ts
+++ b/src/modules/inspect/inspect-correlation/inspect-correlation.ts
@@ -292,20 +292,22 @@ export class InspectCorrelation {
   }
 
   public async activeDiagramChanged(): Promise<void> {
-    if (this.viewIsAttached) {
-      this.correlationOffset = 0;
-      this.processInstanceOffset = 0;
-
-      this.processInstanceIdToSelect = undefined;
-      this.processInstanceToSelect = undefined;
-      this.correlationToSelect = undefined;
-
-      this.selectedProcessInstance = undefined;
-      this.selectedCorrelation = undefined;
-
-      this.updateProcessInstances();
-      this.updateCorrelations();
+    if (!this.viewIsAttached) {
+      return;
     }
+
+    this.correlationOffset = 0;
+    this.processInstanceOffset = 0;
+
+    this.processInstanceIdToSelect = undefined;
+    this.processInstanceToSelect = undefined;
+    this.correlationToSelect = undefined;
+
+    this.selectedProcessInstance = undefined;
+    this.selectedCorrelation = undefined;
+
+    this.updateProcessInstances();
+    this.updateCorrelations();
   }
 
   public selectedCorrelationChanged(): void {

--- a/src/modules/inspect/inspect-correlation/inspect-correlation.ts
+++ b/src/modules/inspect/inspect-correlation/inspect-correlation.ts
@@ -211,7 +211,6 @@ export class InspectCorrelation {
       if (noCorrelationSelected) {
         this.processInstances = [];
         this.totalProcessInstanceCount = 0;
-        this.eventAggregator.publish(environment.events.inspectCorrelation.noCorrelationsFound, true);
 
         return;
       }

--- a/src/modules/inspect/inspect-correlation/inspect-correlation.ts
+++ b/src/modules/inspect/inspect-correlation/inspect-correlation.ts
@@ -184,7 +184,7 @@ export class InspectCorrelation {
   private async updateProcessInstances(): Promise<void> {
     if (this.processInstanceIdToSelect) {
       try {
-        this.processInstanceToSelect = await this.inspectCorrelationService.getProcessInstanceById(
+        const processInstanceToSelect = await this.inspectCorrelationService.getProcessInstanceById(
           this.activeSolutionEntry.identity,
           this.processInstanceIdToSelect,
           this.activeDiagram.id,
@@ -192,8 +192,10 @@ export class InspectCorrelation {
 
         this.correlationToSelect = await this.inspectCorrelationService.getCorrelationById(
           this.activeSolutionEntry.identity,
-          this.processInstanceToSelect.correlationId,
+          processInstanceToSelect.correlationId,
         );
+
+        this.processInstanceToSelect = processInstanceToSelect;
       } catch (error) {
         this.notificationService.showNotification(
           NotificationType.ERROR,

--- a/src/modules/inspect/inspect-correlation/inspect-correlation.ts
+++ b/src/modules/inspect/inspect-correlation/inspect-correlation.ts
@@ -157,6 +157,28 @@ export class InspectCorrelation {
     if (shouldDisplaySpecificInspectPanelTab) {
       this.inspectPanel.changeTab(this.inspectPanelTabToShow);
     }
+
+    if (this.processInstanceIdToSelect) {
+      try {
+        const processInstanceToSelect = await this.inspectCorrelationService.getProcessInstanceById(
+          this.activeSolutionEntry.identity,
+          this.processInstanceIdToSelect,
+          this.activeDiagram.id,
+        );
+
+        this.correlationToSelect = await this.inspectCorrelationService.getCorrelationById(
+          this.activeSolutionEntry.identity,
+          processInstanceToSelect.correlationId,
+        );
+
+        this.processInstanceToSelect = processInstanceToSelect;
+      } catch (error) {
+        this.notificationService.showNotification(
+          NotificationType.ERROR,
+          'The requested ProcessInstance to select could not be found.',
+        );
+      }
+    }
   }
 
   private async updateCorrelations(): Promise<void> {
@@ -182,28 +204,6 @@ export class InspectCorrelation {
   }
 
   private async updateProcessInstances(): Promise<void> {
-    if (this.processInstanceIdToSelect) {
-      try {
-        const processInstanceToSelect = await this.inspectCorrelationService.getProcessInstanceById(
-          this.activeSolutionEntry.identity,
-          this.processInstanceIdToSelect,
-          this.activeDiagram.id,
-        );
-
-        this.correlationToSelect = await this.inspectCorrelationService.getCorrelationById(
-          this.activeSolutionEntry.identity,
-          processInstanceToSelect.correlationId,
-        );
-
-        this.processInstanceToSelect = processInstanceToSelect;
-      } catch (error) {
-        this.notificationService.showNotification(
-          NotificationType.ERROR,
-          'The requested ProcessInstance to select could not be found.',
-        );
-      }
-    }
-
     let processInstanceList;
 
     try {

--- a/src/modules/inspect/inspect.ts
+++ b/src/modules/inspect/inspect.ts
@@ -184,19 +184,26 @@ export class Inspect {
 
     const diagramIsSet: boolean = diagramName !== undefined;
     if (diagramIsSet) {
+      let newActiveDiagram: IDiagram;
+
       const activeSolutionIsOpenSolution: boolean = solutionUriToUse === 'about:open-diagrams';
       if (activeSolutionIsOpenSolution) {
         const persistedDiagrams: Array<IDiagram> = this.solutionService.getOpenDiagrams();
 
-        this.activeDiagram = persistedDiagrams.find((diagram: IDiagram) => {
+        newActiveDiagram = persistedDiagrams.find((diagram: IDiagram) => {
           return diagram.name === diagramName;
         });
       } else {
         try {
-          this.activeDiagram = await this.activeSolutionEntry.service.loadDiagram(diagramName);
+          newActiveDiagram = await this.activeSolutionEntry.service.loadDiagram(diagramName);
         } catch {
           // If loading the diagram failed, do nothing
         }
+      }
+
+      const activeDiagramChanged: boolean = this.activeDiagram?.uri !== newActiveDiagram.uri;
+      if (activeDiagramChanged) {
+        this.activeDiagram = newActiveDiagram;
       }
     }
   }

--- a/src/modules/task-dynamic-ui/task-dynamic-ui.ts
+++ b/src/modules/task-dynamic-ui/task-dynamic-ui.ts
@@ -197,9 +197,7 @@ export class TaskDynamicUi {
   }
 
   private async setDynamicUIWrapperUserTask(): Promise<void> {
-    const dynamicUiWrapperNotExisting: boolean = this.dynamicUiWrapper === undefined;
-
-    if (dynamicUiWrapperNotExisting) {
+    if (this.dynamicUiWrapper === undefined || this.dynamicUiWrapper === null) {
       return;
     }
 
@@ -207,9 +205,7 @@ export class TaskDynamicUi {
   }
 
   private async setDynamicUIWrapperManualTask(): Promise<void> {
-    const dynamicUiWrapperNotExisting: boolean = this.dynamicUiWrapper === undefined;
-
-    if (dynamicUiWrapperNotExisting) {
+    if (this.dynamicUiWrapper === undefined || this.dynamicUiWrapper === null) {
       return;
     }
 


### PR DESCRIPTION
## Changes

1. Fix Selecting Correlation After Navigating to InspectProcessInstance via LET 'Bug' Overlay
2. Avoid 'Cannot set property 'currentUserTask' of null' Error Message

## Issues

Closes #1922

PR: #1923

## How to test the changes

- Run a process that runs into an error
- Click on the 'Bug' overlay (<img src="https://user-images.githubusercontent.com/20394992/72264724-7b5e0e80-361b-11ea-8d67-6e91dab07123.png" width="20px">)
- **Notice that the Inspect Correlation view gets displayed and the Log Viewer is opened.**
- Click on the 'Process Instance List' tab
- **Notice that the currently selected ProcessInstance is marked with a border.**
- Click on the 'Correlation List' tab
- **Notice that the currently selected Correlation is marked with a border.**


