### PR TITLE
♻️Improve notification on update error

### DIFF
--- a/electron_app/electron.ts
+++ b/electron_app/electron.ts
@@ -180,8 +180,8 @@ function initializeAutoUpdater(): void {
 
     console.log(`CurrentVersion: ${currentVersion}, CurrentVersionIsPrerelease: ${currentVersionIsPrerelease}`);
 
-    autoUpdater.addListener('error', () => {
-      appReadyEvent.sender.send('update_error');
+    autoUpdater.addListener('error', (error) => {
+      appReadyEvent.sender.send('update_error', error.message);
     });
 
     autoUpdater.addListener('download-progress', (progressObj) => {

--- a/src/modules/status-bar/status-bar.ts
+++ b/src/modules/status-bar/status-bar.ts
@@ -65,8 +65,8 @@ export class StatusBar {
     if (isRunningInElectron()) {
       this.ipcRenderer = (window as any).nodeRequire('electron').ipcRenderer;
 
-      this.ipcRenderer.on('update_error', () => {
-        notificationService.showNotification(NotificationType.INFO, 'Update Error!');
+      this.ipcRenderer.on('update_error', (event: Event, message: string) => {
+        console.error('Update Error:', message);
       });
 
       this.ipcRenderer.on('update_available', (event: Event, version: string) => {

--- a/src/modules/status-bar/status-bar.ts
+++ b/src/modules/status-bar/status-bar.ts
@@ -71,7 +71,7 @@ export class StatusBar {
         const targetHref: string = `<a href="javascript:nodeRequire('open')('https://github.com/process-engine/bpmn-studio/releases/tag/v${this.updateVersion}')" style="text-decoration: underline;">click here</a>`;
         notificationService.showNonDisappearingNotification(
           NotificationType.WARNING,
-          `<h4>Update Error!</h4> The error log can be found on the DevTools console tab. <br>To update the BPMN Studio manually ${targetHref}.`,
+          `<h4>Update Error!</h4>The automatic update has failed!<br>To update BPMN Studio manually, ${targetHref}.`,
         );
       });
 

--- a/src/modules/status-bar/status-bar.ts
+++ b/src/modules/status-bar/status-bar.ts
@@ -67,6 +67,12 @@ export class StatusBar {
 
       this.ipcRenderer.on('update_error', (event: Event, message: string) => {
         console.error('Update Error:', message);
+
+        const targetHref: string = `<a href="javascript:nodeRequire('open')('https://github.com/process-engine/bpmn-studio/releases/tag/v${this.updateVersion}')" style="text-decoration: underline;">click here</a>`;
+        notificationService.showNonDisappearingNotification(
+          NotificationType.WARNING,
+          `<h4>Update Error!</h4> The error log can be found on the DevTools console tab. <br>To update the BPMN Studio manually ${targetHref}.`,
+        );
       });
 
       this.ipcRenderer.on('update_available', (event: Event, version: string) => {


### PR DESCRIPTION
## Changes

1. Log the error message to the console
2. Improve notification text and add a link to the GitHub release

<img width="363" alt="Bildschirmfoto 2020-01-13 um 13 14 06" src="https://user-images.githubusercontent.com/17065920/72255700-b1919300-3607-11ea-8151-adb17bded54a.png">

## Issues

Closes #1921 

PR: #1925 

## How to test the changes

- checkout the branch
- decrease the version in the package.json
- `npm run electron-build-macos`
- run the built app
- try to update the studio
