### PR TITLE
✨ Refresh Access Tokens (Web)

### DIFF
--- a/src/services/authentication-service/web.oidc-authentication-service.ts
+++ b/src/services/authentication-service/web.oidc-authentication-service.ts
@@ -74,7 +74,6 @@ export class WebOidcAuthenticationService implements IAuthenticationService {
     };
 
     this.openIdConnect.observeUser(async (user: User) => {
-      console.log(user);
       const refreshedIamIdentity: IIdentity = {
         token: user.access_token,
         userId: signinResult.id_token,


### PR DESCRIPTION
## Changes

1. Refresh Access Tokens via Silent Refresh in Web

## Issues

Closes #1831

PR: #1926

## How to test the changes

### Preparation

- Start your identity server
- Navigate to your identity server using your browser (`http://localhost:5000/`)
- Click on `Click here to manage your users and IdentityServer configuration.`
- Go to Clients
- Select `BPMN Studio` from the list
- Go to `Advanced`
- Set `ACCESS TOKEN LIFETIME (SECONDS)` to 20

### Testing

- Log in to any PE using that identity server
- Open up the developer console
- Go to the `Network` tab
- Click on any request
- Try to remember the last characters of the authorization token
- Wait >20 seconds
- Click on a new request
- **Notice that the authorization token changed.**
- Open another version of BPMN Studio (e.g. stable) & log in to any PE using the same authority  & wait until the process models cannot be loaded anymore **or wait some time (>5 minutes)**
- **Notice that the development version of the BPMN Studio can still load Process Models even though the initial access token is not working anymore.**