### PR TITLE
🐛 Avoid Changing ElementID on Type Change

### DIFF
--- a/src/modules/design/property-panel/indextabs/general/sections/basics/basics.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/basics/basics.html
@@ -9,7 +9,7 @@
         <tr>
           <th>ID</th>
           <td>
-            <input type="text" class="props-input" value.bind="businessObjInPanel.id & validateOnChange" change.delegate="updateId()" disabled.bind="!isEditable" data-test-property-panel-element-id>
+            <input type="text" class="props-input" value.bind="businessObjInPanelId & validateOnChange" change.delegate="updateId()" disabled.bind="!isEditable" data-test-property-panel-element-id>
           </td>
           <td>
             <template if.bind="validationError">


### PR DESCRIPTION
## Changes

1. Avoid Changing ElementID on Type Change

## Issues

Closes #1915 

PR: #1927

## How to test the changes

- Create a new diagram
- Change the ID of the StartEvent
- Change the type of the StartEvent
- **Notice that the ID stays the same.**
