### PR TITLE
🐛 Fix Starting Runtime on Windows

### DIFF
--- a/electron_app/electron.ts
+++ b/electron_app/electron.ts
@@ -1025,11 +1025,16 @@ async function startRuntime(): Promise<void> {
     const sqlitePath = getProcessEngineDatabaseFolder();
     const logFilepath = getProcessEngineLogFolder();
 
-    runtimeProcess = fork(
+    const pathToRuntime = path.join(
+      __dirname,
+      '..',
+      '..',
+      '..',
       './node_modules/@process-engine/process_engine_runtime/bin/index.js',
-      [`--sqlitePath=${sqlitePath}`, `--logFilePath=${logFilepath}`],
-      {stdio: 'pipe'},
     );
+    runtimeProcess = fork(pathToRuntime, [`--sqlitePath=${sqlitePath}`, `--logFilePath=${logFilepath}`], {
+      stdio: 'pipe',
+    });
 
     runtimeProcess.stdout.on('data', (data) => process.stdout.write(data));
     runtimeProcess.stderr.on('data', (data) => {

--- a/electron_app/electron.ts
+++ b/electron_app/electron.ts
@@ -1030,7 +1030,11 @@ async function startRuntime(): Promise<void> {
       '..',
       '..',
       '..',
-      './node_modules/@process-engine/process_engine_runtime/bin/index.js',
+      'node_modules',
+      '@process-engine',
+      'process_engine_runtime',
+      'bin',
+      'index.js',
     );
     runtimeProcess = fork(pathToRuntime, [`--sqlitePath=${sqlitePath}`, `--logFilePath=${logFilepath}`], {
       stdio: 'pipe',


### PR DESCRIPTION
## Changes

1.  Fix Starting Runtime on Windows

PR: #1928

## How to test the changes

### 1

- Build the BPMN Studio on windows
- Install the BPMN Studio
- Run the BPMN Studio
- **Notice that the Runtime has started successfully.**

### 2

- Do the same on macOS

### 3

- Run the BPMN Studio via `npm run electron-start-dev`
- **Notice that the Runtime has started successfully.**

