### PR TITLE
🐛Fix ID Validation

### DIFF
--- a/src/modules/design/property-panel/indextabs/general/sections/basics/basics.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/basics/basics.ts
@@ -231,7 +231,7 @@ export class BasicsSection implements ISection {
         return false;
       }
 
-      const elementHasSameId: boolean = element.businessObject.id === this.businessObjInPanelId;
+      const elementHasSameId: boolean = element.businessObject.id === id;
 
       return elementHasSameId;
     });
@@ -252,14 +252,14 @@ export class BasicsSection implements ISection {
   }
 
   private setValidationRules(): void {
-    ValidationRules.ensure((businessObject: IModdleElement) => businessObject.id)
+    ValidationRules.ensure((basicsSection: BasicsSection) => basicsSection.businessObjInPanelId)
       .displayName('elementId')
       .required()
       .withMessage('ID cannot be blank.')
       .then()
       .satisfies((id: string) => this.formIdIsUnique(id) && this.isProcessIdUnique(id))
       .withMessage('ID already exists.')
-      .on(this.businessObjInPanel);
+      .on(this);
   }
 
   private saveInputHeightOnChange(): void {

--- a/src/modules/design/property-panel/indextabs/general/sections/basics/basics.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/basics/basics.ts
@@ -251,13 +251,18 @@ export class BasicsSection implements ISection {
     return !elementIds.includes(id);
   }
 
+  private isDefinitionIdUnique(id: string): boolean {
+    // eslint-disable-next-line no-underscore-dangle
+    return this.modeler._definitions.id !== id;
+  }
+
   private setValidationRules(): void {
     ValidationRules.ensure((basicsSection: BasicsSection) => basicsSection.businessObjInPanelId)
       .displayName('elementId')
       .required()
       .withMessage('ID cannot be blank.')
       .then()
-      .satisfies((id: string) => this.formIdIsUnique(id) && this.isProcessIdUnique(id))
+      .satisfies((id: string) => this.formIdIsUnique(id) && this.isProcessIdUnique(id) && this.isDefinitionIdUnique(id))
       .withMessage('ID already exists.')
       .on(this);
   }


### PR DESCRIPTION
## Changes

1. Fix ID Validation
2. Consider Definition ID When Validating Element IDs

## Issues

Closes #1931 

PR: #1932

## How to test the changes

- Create a new Diagram
- Copy the ID of the StartEvent
- Change the ID of the EndEvent to the ID of the StartEvent
- **Notice that a red border appears around the input field.**
- Try to change the ID of the EndEvent to 'Definition_1'
- **Notice that a red border appears around the input field.**
