### PR TITLE
🐛 Fix Exporting Diagrams on Windows

### DIFF
--- a/electron_app/electron.ts
+++ b/electron_app/electron.ts
@@ -421,11 +421,9 @@ function createMainWindow(): void {
     browserWindow.webContents.session.on('will-download', (event, downloadItem) => {
       const defaultFilename = downloadItem.getFilename();
 
-      const fileTypeIndex = defaultFilename.lastIndexOf('.') + 1;
-      const fileExtension = defaultFilename.substring(fileTypeIndex);
-
+      const fileExtension = path.extname(defaultFilename);
       const fileExtensionIsBPMN = fileExtension === 'bpmn';
-      const fileType = fileExtensionIsBPMN ? 'BPMN (.bpmn)' : `Image (.${fileExtension})`;
+      const fileType = fileExtensionIsBPMN ? 'BPMN (.bpmn)' : `Image (${fileExtension})`;
 
       downloadItem.setSaveDialogOptions({
         defaultPath: defaultFilename,

--- a/electron_app/electron.ts
+++ b/electron_app/electron.ts
@@ -418,7 +418,7 @@ function createMainWindow(): void {
 
   const platformIsWindows = process.platform === 'win32';
   if (platformIsWindows) {
-    browserWindow.webContents.session.on('will-download', async (event, downloadItem) => {
+    browserWindow.webContents.session.on('will-download', (event, downloadItem) => {
       const defaultFilename = downloadItem.getFilename();
 
       const fileTypeIndex = defaultFilename.lastIndexOf('.') + 1;
@@ -427,7 +427,7 @@ function createMainWindow(): void {
       const fileExtensionIsBPMN = fileExtension === 'bpmn';
       const fileType = fileExtensionIsBPMN ? 'BPMN (.bpmn)' : `Image (.${fileExtension})`;
 
-      const saveDialogResult = await dialog.showSaveDialog({
+      downloadItem.setSaveDialogOptions({
         defaultPath: defaultFilename,
         filters: [
           {
@@ -440,14 +440,6 @@ function createMainWindow(): void {
           },
         ],
       });
-
-      if (saveDialogResult.canceled) {
-        downloadItem.cancel();
-
-        return;
-      }
-
-      downloadItem.setSavePath(saveDialogResult.filePath);
     });
   }
 }


### PR DESCRIPTION
## Changes

1. Fix Exporting Diagrams on Windows

## Issues

Closes #1912 

PR: #1934

## How to test the changes

- Open a diagram
- Click on the export button (<img width="20px" src="https://user-images.githubusercontent.com/20394992/72507356-0883ac00-3844-11ea-870a-41fb6dfce119.png"/>)
- **Notice that only one dialog is opened.**

