### PR TITLE
🐛 Fix Umlauts in Exported Files

### DIFF
--- a/aurelia_project/aurelia.json
+++ b/aurelia_project/aurelia.json
@@ -196,7 +196,6 @@
             "path": "../node_modules/proxy-polyfill"
           },
           "ms",
-          "downloadjs",
           "eventemitter2",
           "velocity-animate",
           "tether",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bpmn-studio",
-  "version": "5.12.0-alpha.12",
+  "version": "5.12.0-alpha.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5771,12 +5771,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
       "integrity": "sha512-fmrwR04lsniq/uSr8yikThDTrM7epXHBAAjH9TbeH3rEA8tdCO7mRzB9hdmdGyJCxF8KERo9CITcm3kGuoyMhg=="
-    },
-    "downloadjs": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/downloadjs/-/downloadjs-1.4.7.tgz",
-      "integrity": "sha1-9p+W+UDg0FU9rCkROYZaPNAQHjw=",
-      "dev": true
     },
     "duplexer": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
     "cross-env": "^6.0.3",
     "debounce": "^1.2.0",
     "debug": "^4.1.1",
-    "downloadjs": "1.4.7",
     "electron": "7.1.8",
     "electron-builder": "21.2.0",
     "electron-rebuild": "^1.8.8",

--- a/src/modules/design/bpmn-io/repositories/diagram-export.repository.ts
+++ b/src/modules/design/bpmn-io/repositories/diagram-export.repository.ts
@@ -1,7 +1,8 @@
+import {download} from '../../../../services/download-service/download.service';
 import {IDiagramExportRepositoryContracts} from '../../../../contracts/exportRepository';
 
 export class DiagramExportRepository implements IDiagramExportRepositoryContracts {
   public exportDiagram(fileContent: string, outputName: string, mimeType: string): void {
-    // download(fileContent, outputName, mimeType);
+    download(fileContent, outputName, mimeType);
   }
 }

--- a/src/modules/design/bpmn-io/repositories/diagram-export.repository.ts
+++ b/src/modules/design/bpmn-io/repositories/diagram-export.repository.ts
@@ -1,8 +1,7 @@
-import download from 'downloadjs';
 import {IDiagramExportRepositoryContracts} from '../../../../contracts/exportRepository';
 
 export class DiagramExportRepository implements IDiagramExportRepositoryContracts {
   public exportDiagram(fileContent: string, outputName: string, mimeType: string): void {
-    download(fileContent, outputName, mimeType);
+    // download(fileContent, outputName, mimeType);
   }
 }

--- a/src/services/download-service/download.service.ts
+++ b/src/services/download-service/download.service.ts
@@ -62,14 +62,7 @@ export function download(data, strFileName, strMimeType): XMLHttpRequest | boole
     }
   } else if (/([\x80-\xff])/.test(payload)) {
     // not data url, is it a string with special needs?
-    const tempUiArr: Uint8Array = new Uint8Array(payload.length);
-    const mx: number = tempUiArr.length;
-
-    for (let i = 0; i < mx; ++i) {
-      tempUiArr[i] = payload.charCodeAt(i);
-    }
-
-    payload = new Blob([tempUiArr], {type: mimeType});
+    payload = new Blob([payload], {type: mimeType});
   }
 
   const blob = payload instanceof Blob ? payload : new Blob([payload], {type: mimeType});
@@ -82,14 +75,7 @@ export function download(data, strFileName, strMimeType): XMLHttpRequest | boole
     const binData = decoder(parts.pop());
     const type = parts[1];
 
-    const mx = binData.length;
-    const uiArr = new Uint8Array(mx);
-
-    for (let i = 0; i < mx; ++i) {
-      uiArr[i] = binData.charCodeAt(i);
-    }
-
-    return new Blob([uiArr], {type: type});
+    return new Blob([binData], {type: type});
   }
 
   function saver(saveUrl, winMode): boolean {

--- a/src/services/download-service/download.service.ts
+++ b/src/services/download-service/download.service.ts
@@ -1,0 +1,186 @@
+//download.js v4.21, by dandavis; 2008-2018. [MIT] see http://danml.com/download.html for tests/usage
+// v1 landed a FF+Chrome compatible way of downloading strings to local un-named files, upgraded to use a hidden frame and optional mime
+// v2 added named files via a[download], msSaveBlob, IE (10+) support, and window.URL support for larger+faster saves than dataURLs
+// v3 added dataURL and Blob Input, bind-toggle arity, and legacy dataURL fallback was improved with force-download mime and base64 support. 3.1 improved safari handling.
+// v4 adds AMD/UMD, commonJS, and plain browser support
+// v4.1 adds url download capability via solo URL argument (same domain/CORS only)
+// v4.2 adds semantic variable names, long (over 2MB) dataURL support, and hidden by default temp anchors
+// https://github.com/rndme/download
+
+(function(root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define([], factory);
+  } else if (typeof exports === 'object') {
+    // Node. Does not work with strict CommonJS, but
+    // only CommonJS-like environments that support module.exports,
+    // like Node.
+    module.exports = factory();
+  } else {
+    // Browser globals (root is window)
+    root.download = factory();
+  }
+})(this, function() {
+  return function download(data, strFileName, strMimeType) {
+    var self = window, // this script is only for browsers anyway...
+      defaultMime = 'application/octet-stream', // this default mime also triggers iframe downloads
+      mimeType = strMimeType || defaultMime,
+      payload = data,
+      url = !strFileName && !strMimeType && payload,
+      anchor = document.createElement('a'),
+      toString = function(a) {
+        return String(a);
+      },
+      myBlob = self.Blob || self.MozBlob || self.WebKitBlob || toString,
+      fileName = strFileName || 'download',
+      blob,
+      reader;
+    myBlob = myBlob.call ? myBlob.bind(self) : Blob;
+
+    if (String(this) === 'true') {
+      //reverse arguments, allowing download.bind(true, "text/xml", "export.xml") to act as a callback
+      payload = [payload, mimeType];
+      mimeType = payload[0];
+      payload = payload[1];
+    }
+
+    if (url && url.length < 2048) {
+      // if no filename and no mime, assume a url was passed as the only argument
+      fileName = url
+        .split('/')
+        .pop()
+        .split('?')[0];
+      anchor.href = url; // assign href prop to temp anchor
+      if (anchor.href.indexOf(url) !== -1) {
+        // if the browser determines that it's a potentially valid url path:
+        var ajax = new XMLHttpRequest();
+        ajax.open('GET', url, true);
+        ajax.responseType = 'blob';
+        ajax.onload = function(e) {
+          download(e.target.response, fileName, defaultMime);
+        };
+        setTimeout(function() {
+          ajax.send();
+        }, 0); // allows setting custom ajax headers using the return:
+        return ajax;
+      } // end if valid url?
+    } // end if url?
+
+    //go ahead and download dataURLs right away
+    if (/^data:([\w+-]+\/[\w+.-]+)?[,;]/.test(payload)) {
+      if (payload.length > 1024 * 1024 * 1.999 && myBlob !== toString) {
+        payload = dataUrlToBlob(payload);
+        mimeType = payload.type || defaultMime;
+      } else {
+        return navigator.msSaveBlob // IE10 can't do a[download], only Blobs:
+          ? navigator.msSaveBlob(dataUrlToBlob(payload), fileName)
+          : saver(payload); // everyone else can save dataURLs un-processed
+      }
+    } else {
+      //not data url, is it a string with special needs?
+      if (/([\x80-\xff])/.test(payload)) {
+        var i = 0,
+          tempUiArr = new Uint8Array(payload.length),
+          mx = tempUiArr.length;
+        for (i; i < mx; ++i) tempUiArr[i] = payload.charCodeAt(i);
+        payload = new myBlob([tempUiArr], {type: mimeType});
+      }
+    }
+    blob = payload instanceof myBlob ? payload : new myBlob([payload], {type: mimeType});
+
+    function dataUrlToBlob(strUrl) {
+      var parts = strUrl.split(/[:;,]/),
+        type = parts[1],
+        indexDecoder = strUrl.indexOf('charset') > 0 ? 3 : 2,
+        decoder = parts[indexDecoder] == 'base64' ? atob : decodeURIComponent,
+        binData = decoder(parts.pop()),
+        mx = binData.length,
+        i = 0,
+        uiArr = new Uint8Array(mx);
+
+      for (i; i < mx; ++i) uiArr[i] = binData.charCodeAt(i);
+
+      return new myBlob([uiArr], {type: type});
+    }
+
+    function saver(url, winMode) {
+      if ('download' in anchor) {
+        //html5 A[download]
+        anchor.href = url;
+        anchor.setAttribute('download', fileName);
+        anchor.className = 'download-js-link';
+        anchor.innerHTML = 'downloading...';
+        anchor.style.display = 'none';
+        anchor.addEventListener('click', function(e) {
+          e.stopPropagation();
+          this.removeEventListener('click', arguments.callee);
+        });
+        document.body.appendChild(anchor);
+        setTimeout(function() {
+          anchor.click();
+          document.body.removeChild(anchor);
+          if (winMode === true) {
+            setTimeout(function() {
+              self.URL.revokeObjectURL(anchor.href);
+            }, 250);
+          }
+        }, 66);
+        return true;
+      }
+
+      // handle non-a[download] safari as best we can:
+      if (/(Version)\/(\d+)\.(\d+)(?:\.(\d+))?.*Safari\//.test(navigator.userAgent)) {
+        if (/^data:/.test(url)) url = 'data:' + url.replace(/^data:([\w\/\-\+]+)/, defaultMime);
+        if (!window.open(url)) {
+          // popup blocked, offer direct download:
+          if (
+            confirm('Displaying New Document\n\nUse Save As... to download, then click back to return to this page.')
+          ) {
+            location.href = url;
+          }
+        }
+        return true;
+      }
+
+      //do iframe dataURL download (old ch+FF):
+      var f = document.createElement('iframe');
+      document.body.appendChild(f);
+
+      if (!winMode && /^data:/.test(url)) {
+        // force a mime that will download:
+        url = 'data:' + url.replace(/^data:([\w\/\-\+]+)/, defaultMime);
+      }
+      f.src = url;
+      setTimeout(function() {
+        document.body.removeChild(f);
+      }, 333);
+    } //end saver
+
+    if (navigator.msSaveBlob) {
+      // IE10+ : (has Blob, but not a[download] or URL)
+      return navigator.msSaveBlob(blob, fileName);
+    }
+
+    if (self.URL) {
+      // simple fast and modern way using Blob and URL:
+      saver(self.URL.createObjectURL(blob), true);
+    } else {
+      // handle non-Blob()+non-URL browsers:
+      if (typeof blob === 'string' || blob.constructor === toString) {
+        try {
+          return saver('data:' + mimeType + ';base64,' + self.btoa(blob));
+        } catch (y) {
+          return saver('data:' + mimeType + ',' + encodeURIComponent(blob));
+        }
+      }
+
+      // Blob but not URL support:
+      reader = new FileReader();
+      reader.onload = function(e) {
+        saver(this.result);
+      };
+      reader.readAsDataURL(blob);
+    }
+    return true;
+  }; /* end download() */
+});

--- a/src/services/download-service/download.service.ts
+++ b/src/services/download-service/download.service.ts
@@ -1,4 +1,4 @@
-//download.js v4.21, by dandavis; 2008-2018. [MIT] see http://danml.com/download.html for tests/usage
+// download.js v4.21, by dandavis; 2008-2018. [MIT] see http://danml.com/download.html for tests/usage
 // v1 landed a FF+Chrome compatible way of downloading strings to local un-named files, upgraded to use a hidden frame and optional mime
 // v2 added named files via a[download], msSaveBlob, IE (10+) support, and window.URL support for larger+faster saves than dataURLs
 // v3 added dataURL and Blob Input, bind-toggle arity, and legacy dataURL fallback was improved with force-download mime and base64 support. 3.1 improved safari handling.
@@ -7,180 +7,178 @@
 // v4.2 adds semantic variable names, long (over 2MB) dataURL support, and hidden by default temp anchors
 // https://github.com/rndme/download
 
-(function(root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    // AMD. Register as an anonymous module.
-    define([], factory);
-  } else if (typeof exports === 'object') {
-    // Node. Does not work with strict CommonJS, but
-    // only CommonJS-like environments that support module.exports,
-    // like Node.
-    module.exports = factory();
-  } else {
-    // Browser globals (root is window)
-    root.download = factory();
+export function download(data, strFileName, strMimeType): XMLHttpRequest | boolean {
+  const defaultMime = 'application/octet-stream'; // this default mime also triggers iframe downloads
+  const anchor = document.createElement('a');
+  let mimeType = strMimeType || defaultMime;
+  let payload = data;
+  let url = !strFileName && !strMimeType && payload;
+  let fileName = strFileName || 'download';
+  let reader;
+
+  if (String(this) === 'true') {
+    // reverse arguments, allowing download.bind(true, "text/xml", "export.xml") to act as a callback
+    payload = [payload, mimeType];
+    mimeType = payload[0];
+    payload = payload[1];
   }
-})(this, function() {
-  return function download(data, strFileName, strMimeType) {
-    var self = window, // this script is only for browsers anyway...
-      defaultMime = 'application/octet-stream', // this default mime also triggers iframe downloads
-      mimeType = strMimeType || defaultMime,
-      payload = data,
-      url = !strFileName && !strMimeType && payload,
-      anchor = document.createElement('a'),
-      toString = function(a) {
-        return String(a);
-      },
-      myBlob = self.Blob || self.MozBlob || self.WebKitBlob || toString,
-      fileName = strFileName || 'download',
-      blob,
-      reader;
-    myBlob = myBlob.call ? myBlob.bind(self) : Blob;
 
-    if (String(this) === 'true') {
-      //reverse arguments, allowing download.bind(true, "text/xml", "export.xml") to act as a callback
-      payload = [payload, mimeType];
-      mimeType = payload[0];
-      payload = payload[1];
-    }
+  if (url && url.length < 2048) {
+    // if no filename and no mime, assume a url was passed as the only argument
+    fileName = url
+      .split('/')
+      .pop()
+      .split('?')[0];
 
-    if (url && url.length < 2048) {
-      // if no filename and no mime, assume a url was passed as the only argument
-      fileName = url
-        .split('/')
-        .pop()
-        .split('?')[0];
-      anchor.href = url; // assign href prop to temp anchor
-      if (anchor.href.indexOf(url) !== -1) {
-        // if the browser determines that it's a potentially valid url path:
-        var ajax = new XMLHttpRequest();
-        ajax.open('GET', url, true);
-        ajax.responseType = 'blob';
-        ajax.onload = function(e) {
-          download(e.target.response, fileName, defaultMime);
-        };
-        setTimeout(function() {
-          ajax.send();
-        }, 0); // allows setting custom ajax headers using the return:
-        return ajax;
-      } // end if valid url?
-    } // end if url?
+    anchor.href = url; // assign href prop to temp anchor
 
-    //go ahead and download dataURLs right away
-    if (/^data:([\w+-]+\/[\w+.-]+)?[,;]/.test(payload)) {
-      if (payload.length > 1024 * 1024 * 1.999 && myBlob !== toString) {
-        payload = dataUrlToBlob(payload);
-        mimeType = payload.type || defaultMime;
-      } else {
-        return navigator.msSaveBlob // IE10 can't do a[download], only Blobs:
-          ? navigator.msSaveBlob(dataUrlToBlob(payload), fileName)
-          : saver(payload); // everyone else can save dataURLs un-processed
-      }
-    } else {
-      //not data url, is it a string with special needs?
-      if (/([\x80-\xff])/.test(payload)) {
-        var i = 0,
-          tempUiArr = new Uint8Array(payload.length),
-          mx = tempUiArr.length;
-        for (i; i < mx; ++i) tempUiArr[i] = payload.charCodeAt(i);
-        payload = new myBlob([tempUiArr], {type: mimeType});
-      }
-    }
-    blob = payload instanceof myBlob ? payload : new myBlob([payload], {type: mimeType});
+    if (anchor.href.indexOf(url) !== -1) {
+      // if the browser determines that it's a potentially valid url path:
+      const ajax = new XMLHttpRequest();
 
-    function dataUrlToBlob(strUrl) {
-      var parts = strUrl.split(/[:;,]/),
-        type = parts[1],
-        indexDecoder = strUrl.indexOf('charset') > 0 ? 3 : 2,
-        decoder = parts[indexDecoder] == 'base64' ? atob : decodeURIComponent,
-        binData = decoder(parts.pop()),
-        mx = binData.length,
-        i = 0,
-        uiArr = new Uint8Array(mx);
-
-      for (i; i < mx; ++i) uiArr[i] = binData.charCodeAt(i);
-
-      return new myBlob([uiArr], {type: type});
-    }
-
-    function saver(url, winMode) {
-      if ('download' in anchor) {
-        //html5 A[download]
-        anchor.href = url;
-        anchor.setAttribute('download', fileName);
-        anchor.className = 'download-js-link';
-        anchor.innerHTML = 'downloading...';
-        anchor.style.display = 'none';
-        anchor.addEventListener('click', function(e) {
-          e.stopPropagation();
-          this.removeEventListener('click', arguments.callee);
-        });
-        document.body.appendChild(anchor);
-        setTimeout(function() {
-          anchor.click();
-          document.body.removeChild(anchor);
-          if (winMode === true) {
-            setTimeout(function() {
-              self.URL.revokeObjectURL(anchor.href);
-            }, 250);
-          }
-        }, 66);
-        return true;
-      }
-
-      // handle non-a[download] safari as best we can:
-      if (/(Version)\/(\d+)\.(\d+)(?:\.(\d+))?.*Safari\//.test(navigator.userAgent)) {
-        if (/^data:/.test(url)) url = 'data:' + url.replace(/^data:([\w\/\-\+]+)/, defaultMime);
-        if (!window.open(url)) {
-          // popup blocked, offer direct download:
-          if (
-            confirm('Displaying New Document\n\nUse Save As... to download, then click back to return to this page.')
-          ) {
-            location.href = url;
-          }
-        }
-        return true;
-      }
-
-      //do iframe dataURL download (old ch+FF):
-      var f = document.createElement('iframe');
-      document.body.appendChild(f);
-
-      if (!winMode && /^data:/.test(url)) {
-        // force a mime that will download:
-        url = 'data:' + url.replace(/^data:([\w\/\-\+]+)/, defaultMime);
-      }
-      f.src = url;
-      setTimeout(function() {
-        document.body.removeChild(f);
-      }, 333);
-    } //end saver
-
-    if (navigator.msSaveBlob) {
-      // IE10+ : (has Blob, but not a[download] or URL)
-      return navigator.msSaveBlob(blob, fileName);
-    }
-
-    if (self.URL) {
-      // simple fast and modern way using Blob and URL:
-      saver(self.URL.createObjectURL(blob), true);
-    } else {
-      // handle non-Blob()+non-URL browsers:
-      if (typeof blob === 'string' || blob.constructor === toString) {
-        try {
-          return saver('data:' + mimeType + ';base64,' + self.btoa(blob));
-        } catch (y) {
-          return saver('data:' + mimeType + ',' + encodeURIComponent(blob));
-        }
-      }
-
-      // Blob but not URL support:
-      reader = new FileReader();
-      reader.onload = function(e) {
-        saver(this.result);
+      ajax.open('GET', url, true);
+      ajax.responseType = 'blob';
+      ajax.onload = (e: any): void => {
+        download(e.target.response, fileName, defaultMime);
       };
-      reader.readAsDataURL(blob);
+
+      setTimeout(() => {
+        ajax.send();
+      }, 0); // allows setting custom ajax headers using the return:
+
+      return ajax;
+    } // end if valid url?
+  } // end if url?
+
+  // go ahead and download dataURLs right away
+  if (/^data:([\w+-]+\/[\w+.-]+)?[,;]/.test(payload)) {
+    if (payload.length > 1024 * 1024 * 1.999) {
+      payload = dataUrlToBlob(payload);
+      mimeType = payload.type || defaultMime;
+    } else {
+      return navigator.msSaveBlob // IE10 can't do a[download], only Blobs:
+        ? navigator.msSaveBlob(dataUrlToBlob(payload), fileName)
+        : saver(payload, false); // everyone else can save dataURLs un-processed
     }
-    return true;
-  }; /* end download() */
-});
+  } else if (/([\x80-\xff])/.test(payload)) {
+    // not data url, is it a string with special needs?
+    const tempUiArr: Uint8Array = new Uint8Array(payload.length);
+    const mx: number = tempUiArr.length;
+
+    for (let i = 0; i < mx; ++i) {
+      tempUiArr[i] = payload.charCodeAt(i);
+    }
+
+    payload = new Blob([tempUiArr], {type: mimeType});
+  }
+
+  const blob = payload instanceof Blob ? payload : new Blob([payload], {type: mimeType});
+
+  function dataUrlToBlob(strUrl): Blob {
+    const parts = strUrl.split(/[:;,]/);
+    const indexDecoder = strUrl.indexOf('charset') > 0 ? 3 : 2;
+    const decoder = parts[indexDecoder] == 'base64' ? atob : decodeURIComponent;
+
+    const binData = decoder(parts.pop());
+    const type = parts[1];
+
+    const mx = binData.length;
+    const uiArr = new Uint8Array(mx);
+
+    for (let i = 0; i < mx; ++i) {
+      uiArr[i] = binData.charCodeAt(i);
+    }
+
+    return new Blob([uiArr], {type: type});
+  }
+
+  function saver(saveUrl, winMode): boolean {
+    if ('download' in anchor) {
+      const anchorClickHandler = (event): void => {
+        event.stopPropagation();
+
+        anchor.removeEventListener('click', anchorClickHandler);
+      };
+
+      // html5 A[download]
+      anchor.href = saveUrl;
+      anchor.setAttribute('download', fileName);
+      anchor.className = 'download-js-link';
+      anchor.innerHTML = 'downloading...';
+      anchor.style.display = 'none';
+      anchor.addEventListener('click', anchorClickHandler);
+
+      document.body.appendChild(anchor);
+
+      setTimeout(() => {
+        anchor.click();
+
+        document.body.removeChild(anchor);
+
+        if (winMode) {
+          setTimeout(() => {
+            URL.revokeObjectURL(anchor.href);
+          }, 250);
+        }
+      }, 66);
+
+      return true;
+    }
+
+    // handle non-a[download] safari as best we can:
+    if (/(Version)\/(\d+)\.(\d+)(?:\.(\d+))?.*Safari\//.test(navigator.userAgent)) {
+      if (/^data:/.test(url)) {
+        saveUrl = `data:${url.replace(/^data:([\w/\-+]+)/, defaultMime)}`;
+      }
+
+      if (!window.open(url)) {
+        // popup blocked, offer direct download:
+        // eslint-disable-next-line no-restricted-globals, no-alert
+        if (confirm('Displaying New Document\n\nUse Save As... to download, then click back to return to this page.')) {
+          // eslint-disable-next-line no-restricted-globals
+          location.href = saveUrl;
+        }
+      }
+
+      return true;
+    }
+
+    // do iframe dataURL download (old ch+FF):
+    const downloadIframe = document.createElement('iframe');
+    document.body.appendChild(downloadIframe);
+
+    if (!winMode && /^data:/.test(url)) {
+      // force a mime that will download:
+      url = `data:${url.replace(/^data:([\w/\-+]+)/, defaultMime)}`;
+    }
+
+    downloadIframe.src = url;
+
+    setTimeout(() => {
+      document.body.removeChild(downloadIframe);
+    }, 333);
+
+    return false;
+  } // end saver
+
+  if (navigator.msSaveBlob) {
+    // IE10+ : (has Blob, but not a[download] or URL)
+    return navigator.msSaveBlob(blob, fileName);
+  }
+
+  if (URL) {
+    // simple fast and modern way using Blob and URL:
+    saver(URL.createObjectURL(blob), true);
+  } else {
+    // Blob but not URL support:
+    reader = new FileReader();
+
+    reader.onload = (): void => {
+      saver(this.result, false);
+    };
+
+    reader.readAsDataURL(blob);
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Changes

1. Remove DownloadJS
2. Create Download Service Based on DownloadJS
3. Fix Exporting Diagrams with Umlauts

## Issues

Closes #1755 

PR: #1935

## How to test the changes

- Export any diagram containing umlauts
- Open the exported diagram
- **Notice that the umlauts still exist.**
