### PR TITLE
🐛 Prevent IDs That Contain Spaces

### DIFF
--- a/src/modules/design/property-panel/indextabs/general/sections/basics/basics.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/basics/basics.ts
@@ -264,6 +264,8 @@ export class BasicsSection implements ISection {
       .then()
       .satisfies((id: string) => this.formIdIsUnique(id) && this.isProcessIdUnique(id) && this.isDefinitionIdUnique(id))
       .withMessage('ID already exists.')
+      .satisfies((id: string) => !id.includes(' '))
+      .withMessage('ID must not contain spaces.')
       .on(this);
   }
 

--- a/src/modules/design/property-panel/indextabs/general/sections/basics/basics.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/basics/basics.ts
@@ -261,11 +261,11 @@ export class BasicsSection implements ISection {
       .displayName('elementId')
       .required()
       .withMessage('ID cannot be blank.')
+      .satisfies((id: string) => !id.includes(' '))
+      .withMessage('ID must not contain spaces.')
       .then()
       .satisfies((id: string) => this.formIdIsUnique(id) && this.isProcessIdUnique(id) && this.isDefinitionIdUnique(id))
       .withMessage('ID already exists.')
-      .satisfies((id: string) => !id.includes(' '))
-      .withMessage('ID must not contain spaces.')
       .on(this);
   }
 


### PR DESCRIPTION
## Changes

1. Prevent IDs That Contain Spaces

## Issues

Related #1943 

PR: #1944

## How to test the changes

- Open any diagram
- Select any element
- Try to add spaces to the element id