### PR TITLE
✨ Add Description for Error Events

### DIFF
--- a/src/modules/design/property-panel/indextabs/general/sections/error-event/error-event.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/error-event/error-event.html
@@ -35,7 +35,7 @@
           <th>Code</th>
           <td>
             <input type="text" class="props-input" value.bind="selectedError.errorCode" change.delegate="updateErrorCode()" disabled.bind="!isEditable">
-            <small if.bind="isEndEvent">The Code the error should have.</small>
+            <small if.bind="isEndEvent">The code the error should have.</small>
             <small else>Optional. If set, only errors with a matching code are caught.</small>
           </td>
         </tr>

--- a/src/modules/design/property-panel/indextabs/general/sections/error-event/error-event.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/error-event/error-event.html
@@ -35,12 +35,14 @@
           <th>Code</th>
           <td>
             <input type="text" class="props-input" value.bind="selectedError.errorCode" change.delegate="updateErrorCode()" disabled.bind="!isEditable">
+            <small>Expected error code. Leave empty for any.</small>
           </td>
         </tr>
         <tr>
           <th>Message</th>
           <td>
             <input type="text" class="props-input" value.bind="errorMessageVariable" change.delegate="updateErrorMessage()" disabled.bind="!isEditable">
+            <small>Expected error message. Leave empty for any.</small>
           </td>
         </tr>
       </table>

--- a/src/modules/design/property-panel/indextabs/general/sections/error-event/error-event.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/error-event/error-event.html
@@ -35,14 +35,16 @@
           <th>Code</th>
           <td>
             <input type="text" class="props-input" value.bind="selectedError.errorCode" change.delegate="updateErrorCode()" disabled.bind="!isEditable">
-            <small>Expected error code. Leave empty for any.</small>
+            <small if.bind="isEndEvent">The Code the error should have.</small>
+            <small else>Optional. If set, only errors with a matching code are caught.</small>
           </td>
         </tr>
         <tr>
           <th>Message</th>
           <td>
             <input type="text" class="props-input" value.bind="errorMessageVariable" change.delegate="updateErrorMessage()" disabled.bind="!isEditable">
-            <small>Expected error message. Leave empty for any.</small>
+            <small if.bind="isEndEvent">Optional: The message the error should have.</small>
+            <small else>Optional. If set, only errors with a matching message are caught.</small>
           </td>
         </tr>
       </table>

--- a/src/modules/design/property-panel/indextabs/general/sections/error-event/error-event.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/error-event/error-event.ts
@@ -61,6 +61,7 @@ export class ErrorEventSection implements ISection {
     if (this.elementIsErrorEvent(element)) {
       return true;
     }
+
     return false;
   }
 

--- a/src/modules/design/property-panel/indextabs/general/sections/error-event/error-event.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/error-event/error-event.ts
@@ -51,6 +51,7 @@ export class ErrorEventSection implements ISection {
     this.modeler = model.modeler;
     this.linter = model.modeler.get('linting');
 
+    this.isEndEvent = this.elementIsEndEvent(model.elementInPanel);
     this.errors = await this.getErrors();
 
     this.init();
@@ -58,7 +59,6 @@ export class ErrorEventSection implements ISection {
 
   public isSuitableForElement(element: IShape): boolean {
     if (this.elementIsErrorEvent(element)) {
-      this.isEndEvent = this.elementIsEndEvent(element);
       return true;
     }
     return false;


### PR DESCRIPTION
## Changes

1. Add Description for Error Events

## Issues

Closes #1933 

PR: #1950

## How to test the changes

- Open any diagram
- Add an error-event
- Select an error
- **Notice that the input fields of the error event configuration have descriptions.**

<img width="327" alt="Bildschirmfoto 2020-01-22 um 15 47 19" src="https://user-images.githubusercontent.com/20394992/72903988-7a6d6100-3d2e-11ea-81cc-27e0a7873230.png">
