### PR TITLE
🐛 Fix the empty error message input field

### DIFF
--- a/src/modules/design/property-panel/indextabs/general/sections/error-event/error-event.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/error-event/error-event.ts
@@ -183,6 +183,8 @@ export class ErrorEventSection implements ISection {
       this.selectedError = this.errors.find((error: IError) => {
         return error.id === this.selectedId;
       });
+
+      this.errorMessageVariable = errorElement.errorMessageVariable;
     } else {
       this.selectedError = null;
       this.selectedId = null;


### PR DESCRIPTION
## Changes

1.  Fix the empty error message input field

## Issues

PR: #1952 

## How to test the changes

- add an error element to the diagram
- add an error
- fill the error message input field
- select another element
- select the previous selected error element
- see that the error message is displayed

