### PR TITLE
💄 Fix Style of 'props-table' Headlines

### DIFF
--- a/src/modules/design/property-panel/styles/sections.scss
+++ b/src/modules/design/property-panel/styles/sections.scss
@@ -28,9 +28,10 @@
 
 .props-table th {
   width: 40px;
-  padding: 5px 10px 5px 0;
+  padding: 11px 10px 11px 0;
   font-weight: normal;
   color: #a5a5a5;
+  vertical-align: baseline;
 }
 
 .props-table td {


### PR DESCRIPTION
## Changes

1. Fix Style of 'props-table' Headlines

## Issues

Closes https://github.com/process-engine/bpmn-studio/pull/1950#issuecomment-578597683

PR: #1953

## How to test the changes

<img width="195" alt="Bildschirmfoto 2020-01-28 um 09 59 11" src="https://user-images.githubusercontent.com/20394992/73249269-d6b00500-41b4-11ea-8729-49c2e67087b7.png">
