### PR TITLE
🐛Fix open already opened diagrams with file association

### DIFF
--- a/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.ts
+++ b/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.ts
@@ -23,6 +23,7 @@ import {getPortListByVersion} from '../../../services/default-ports-module/defau
 import {HttpFetchClient} from '../../fetch-http-client/http-fetch-client';
 import {solutionIsRemoteSolution} from '../../../services/solution-is-remote-solution-module/solution-is-remote-solution.module';
 import {isRunningInElectron} from '../../../services/is-running-in-electron-module/is-running-in-electron.module';
+import {OpenDiagramStateService} from '../../../services/solution-explorer-services/open-diagram-state.service';
 
 type RemoteSolutionListEntry = {
   uri: string;
@@ -44,7 +45,7 @@ enum SupportedProtocols {
  *  - Refreshing on login/logout
  *  - Updating the remote processengine uri if needed
  */
-@inject(EventAggregator, 'NotificationService', Router, 'SolutionService', 'HttpFetchClient')
+@inject(EventAggregator, 'NotificationService', Router, 'SolutionService', 'HttpFetchClient', 'OpenDiagramStateService')
 export class SolutionExplorerPanel {
   @observable public selectedProtocol: string = 'http://';
 
@@ -69,6 +70,7 @@ export class SolutionExplorerPanel {
   private ipcRenderer: any | null = null;
   private subscriptions: Array<Subscription> = [];
   private solutionService: ISolutionService;
+  private openDiagramStateService: OpenDiagramStateService;
   private remoteSolutionHistoryStatusPollingTimer: NodeJS.Timer;
   private remoteSolutionHistoryStatusIsPolling: boolean;
 
@@ -80,12 +82,14 @@ export class SolutionExplorerPanel {
     router: Router,
     solutionService: ISolutionService,
     httpFetchClient: HttpFetchClient,
+    openDiagramStateService: OpenDiagramStateService,
   ) {
     this.eventAggregator = eventAggregator;
     this.notificationService = notificationService;
     this.router = router;
     this.solutionService = solutionService;
     this.httpFetchClient = httpFetchClient;
+    this.openDiagramStateService = openDiagramStateService;
 
     if (isRunningInElectron()) {
       this.ipcRenderer = (window as any).nodeRequire('electron').ipcRenderer;
@@ -626,9 +630,14 @@ export class SolutionExplorerPanel {
       // The diagram may already be opened.
       const diagram: IDiagram | null = await this.solutionExplorerList.getOpenedDiagramByURI(uri);
       const solution: ISolutionEntry = this.solutionExplorerList.getOpenDiagramSolutionEntry();
+      const diagramState = this.openDiagramStateService.loadDiagramState(uri);
 
       const diagramWithURIIsAlreadyOpened: boolean = diagram !== null;
       if (diagramWithURIIsAlreadyOpened) {
+        if (diagramState.metadata.isChanged === true) {
+          diagram.xml = diagramState.data.xml;
+        }
+
         return this.navigateToDetailView(diagram, solution);
       }
 

--- a/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.ts
+++ b/src/modules/solution-explorer/solution-explorer-panel/solution-explorer-panel.ts
@@ -218,18 +218,21 @@ export class SolutionExplorerPanel {
     });
 
     const persistedOpenDiagrams: Array<IDiagram> = this.solutionService.getOpenDiagrams();
-    persistedOpenDiagrams.forEach(async (diagram: IDiagram) => {
+    for (const persistedOpenDiagram of persistedOpenDiagrams) {
       try {
-        await this.solutionExplorerList.openDiagram(diagram.uri);
+        await this.solutionExplorerList.openDiagram(persistedOpenDiagram.uri);
       } catch {
         // Do nothing
       }
-    });
+    }
+
+    if (isRunningInElectron()) {
+      this.registerElectronHooks();
+    }
   }
 
   public async attached(): Promise<void> {
     if (isRunningInElectron()) {
-      this.registerElectronHooks();
       document.addEventListener('drop', this.openDiagramOnDropBehaviour);
     }
 
@@ -649,6 +652,7 @@ export class SolutionExplorerPanel {
 
   private electronFileOpeningHook = async (_: Event, pathToFile: string): Promise<void> => {
     const uri: string = pathToFile;
+
     this.openDiagramOrDisplayError(uri);
   };
 

--- a/src/services/solution-explorer-services/open-diagrams-solution-explorer.service.ts
+++ b/src/services/solution-explorer-services/open-diagrams-solution-explorer.service.ts
@@ -190,7 +190,7 @@ export class OpenDiagramsSolutionExplorerService implements ISolutionExplorerSer
               const xml: string = fs.readFileSync(diagram.uri, 'utf8');
 
               const diagramWasChangedByStudio: boolean =
-                (change !== undefined && (change.change === 'save' && change.xml === xml)) ||
+                (change !== undefined && change.change === 'save' && change.xml === xml) ||
                 (change !== undefined && change.change === 'create');
 
               const diagramWasNotChangedOutsideOfTheStudio: boolean = diagram.xml === xml;


### PR DESCRIPTION
## Changes

1. Fix bug where unsaved changes are overwritten after open the diagram with file association
2. Fix bug where an already opened diagram gets opened although

## Issues

PR: #1955 

## How to test the changes

- build the stable version of this branch
- open it to set the file association
- open a diagram
- close the studio
- open the same diagram with the command line
- see that the diagram is not opened twice in `Open Diagrams` solution
- make some changes to the diagram
- navigate/open another diagram
- open the changed diagram with the command line
- see that the studio opens the diagram
