### PR TITLE
🐛Fix open and highlight diagram from think view

### DIFF
--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -663,7 +663,7 @@ export class SolutionExplorerSolution {
     return (
       !this.displayedSolutionEntry.isOpenDiagram &&
       this.openedSolution &&
-      !this.isUriFromRemoteSolution(this.openedSolution.uri)
+      !solutionIsRemoteSolution(this.openedSolution.uri)
     );
   }
 
@@ -741,7 +741,7 @@ export class SolutionExplorerSolution {
   }
 
   public async openDiagram(diagram: IDiagram): Promise<void> {
-    const diagramIsFromLocalSolution: boolean = !this.isUriFromRemoteSolution(diagram.uri);
+    const diagramIsFromLocalSolution: boolean = !solutionIsRemoteSolution(diagram.uri);
 
     if (diagramIsFromLocalSolution) {
       const diagramIsNotYetOpened: boolean = !this.openDiagramService
@@ -1536,7 +1536,7 @@ export class SolutionExplorerSolution {
         // The solution may have changed on the file system.
         await this.updateSolution();
 
-        const isRemoteSolution: boolean = this.isUriFromRemoteSolution(this.openedSolution.uri);
+        const isRemoteSolution: boolean = solutionIsRemoteSolution(this.openedSolution.uri);
 
         let expectedDiagramUri: string;
         if (isRemoteSolution) {
@@ -1552,9 +1552,5 @@ export class SolutionExplorerSolution {
       .withMessage('A diagram with that name already exists.')
       .on(this.diagramRenamingState)
       .on(this.diagramCreationState);
-  }
-
-  private isUriFromRemoteSolution(uri: string): boolean {
-    return solutionIsRemoteSolution(uri);
   }
 }

--- a/src/modules/think/diagram-list/diagram-list.html
+++ b/src/modules/think/diagram-list/diagram-list.html
@@ -10,7 +10,7 @@
             <th>Process Name</th>
           </tr>
           <tr repeat.for="diagram of allDiagrams" class="diagram-list-item">
-            <td class="process-name-table-entry" id="diagram-${diagram.name}" title="${diagram.name}" click.delegate="showDetails(diagram.name)">${diagram.name}</td>
+            <td class="process-name-table-entry" id="diagram-${diagram.name}" title="${diagram.name}" click.delegate="openDiagram(diagram)">${diagram.name}</td>
           </tr>
         </table>
       </div>


### PR DESCRIPTION
## Changes

1. Add diagram to Open Diagrams before navigating to it
2. Fix bug where the opened diagram does not get highlighted

## Issues

Closes #1958
Closes #1956 

PR: #1962 

## How to test the changes

- open a local solution
- open the think view
- click on a diagram of the table
- see that it has been opened as `Open Diagrams`
- see that it is highlighted