### PR TITLE
🐛Use dynamic ui on dashboard if the user is not authorized to see the correlation

### DIFF
--- a/src/modules/inspect/dashboard/contracts/IDashboardRepository.ts
+++ b/src/modules/inspect/dashboard/contracts/IDashboardRepository.ts
@@ -1,6 +1,7 @@
 import {DataModels} from '@process-engine/management_api_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 import {Subscription} from '@essential-projects/event_aggregator_contracts';
+import {Correlation} from '@process-engine/management_api_contracts/dist/data_models/correlation';
 import {TaskList} from './index';
 
 export interface IDashboardRepository {
@@ -123,4 +124,5 @@ export interface IDashboardRepository {
   onCronjobExecuted(identity: IIdentity, callback: Function): Promise<Subscription>;
   onCronjobRemoved(identity: IIdentity, callback: Function): Promise<Subscription>;
   removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void>;
+  getCorrelationById(identity: IIdentity, correlationId: string): Promise<Correlation>;
 }

--- a/src/modules/inspect/dashboard/contracts/IDashboardRepository.ts
+++ b/src/modules/inspect/dashboard/contracts/IDashboardRepository.ts
@@ -125,4 +125,10 @@ export interface IDashboardRepository {
   onCronjobRemoved(identity: IIdentity, callback: Function): Promise<Subscription>;
   removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void>;
   getCorrelationById(identity: IIdentity, correlationId: string): Promise<Correlation>;
+  finishEmptyActivity(
+    identity: IIdentity,
+    processInstanceId: string,
+    correlationId: string,
+    emptyActivityInstanceId: string,
+  ): Promise<void>;
 }

--- a/src/modules/inspect/dashboard/contracts/IDashboardService.ts
+++ b/src/modules/inspect/dashboard/contracts/IDashboardService.ts
@@ -102,4 +102,10 @@ export interface IDashboardService {
   onCronjobUpdated(identity: IIdentity, callback: Function): Promise<Subscription>;
   onCronjobRemoved(identity: IIdentity, callback: Function): Promise<Subscription>;
   getCorrelationById(identity: IIdentity, correlationId: string): Promise<Correlation>;
+  finishEmptyActivity(
+    identity: IIdentity,
+    processInstanceId: string,
+    correlationId: string,
+    emptyActivityInstanceId: string,
+  ): Promise<void>;
 }

--- a/src/modules/inspect/dashboard/contracts/IDashboardService.ts
+++ b/src/modules/inspect/dashboard/contracts/IDashboardService.ts
@@ -4,6 +4,7 @@ import {IIdentity} from '@essential-projects/iam_contracts';
 import {Subscription} from '@essential-projects/event_aggregator_contracts';
 import {DataModels} from '@process-engine/management_api_contracts';
 
+import {Correlation} from '@process-engine/management_api_contracts/dist/data_models/correlation';
 import {TaskList} from './index';
 
 export interface IDashboardService {
@@ -100,4 +101,5 @@ export interface IDashboardService {
   onCronjobStopped(identity: IIdentity, callback: Function): Promise<Subscription>;
   onCronjobUpdated(identity: IIdentity, callback: Function): Promise<Subscription>;
   onCronjobRemoved(identity: IIdentity, callback: Function): Promise<Subscription>;
+  getCorrelationById(identity: IIdentity, correlationId: string): Promise<Correlation>;
 }

--- a/src/modules/inspect/dashboard/repositories/dashboard.repository.ts
+++ b/src/modules/inspect/dashboard/repositories/dashboard.repository.ts
@@ -320,6 +320,20 @@ export class DashboardRepository implements IDashboardRepository {
     );
   }
 
+  public finishEmptyActivity(
+    identity: IIdentity,
+    processInstanceId: string,
+    correlationId: string,
+    emptyActivityInstanceId: string,
+  ): Promise<void> {
+    return this.managementApiClient.finishEmptyActivity(
+      identity,
+      processInstanceId,
+      correlationId,
+      emptyActivityInstanceId,
+    );
+  }
+
   public removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void> {
     return this.managementApiClient.removeSubscription(identity, subscription);
   }

--- a/src/modules/inspect/dashboard/repositories/dashboard.repository.ts
+++ b/src/modules/inspect/dashboard/repositories/dashboard.repository.ts
@@ -3,6 +3,7 @@ import {IIdentity} from '@essential-projects/iam_contracts';
 import {Subscription} from '@essential-projects/event_aggregator_contracts';
 import {NotFoundError} from '@essential-projects/errors_ts';
 
+import {Correlation} from '@process-engine/management_api_contracts/dist/data_models/correlation';
 import {IDashboardRepository} from '../contracts/IDashboardRepository';
 import {TaskList, TaskListEntry, TaskSource, TaskType} from '../contracts/index';
 import {applyPagination} from '../../../../services/pagination-module/pagination.module';
@@ -19,9 +20,9 @@ export class DashboardRepository implements IDashboardRepository {
     offset: number = 0,
     limit: number = 0,
   ): Promise<DataModels.Cronjobs.CronjobList> {
-    const cronjobs: Array<
-      DataModels.Cronjobs.CronjobConfiguration
-    > = (await this.managementApiClient.getAllActiveCronjobs(identity)) as any;
+    const cronjobs: Array<DataModels.Cronjobs.CronjobConfiguration> = (await this.managementApiClient.getAllActiveCronjobs(
+      identity,
+    )) as any;
 
     return {
       cronjobs: applyPagination(cronjobs, offset, limit),
@@ -37,9 +38,9 @@ export class DashboardRepository implements IDashboardRepository {
     const activeCorrelations: Array<DataModels.Correlations.Correlation> = (await this.getActiveCorrelations(identity))
       .correlations;
 
-    const processInstancesForCorrelations: Array<
-      Array<DataModels.Correlations.ProcessInstance>
-    > = activeCorrelations.map((correlation) => {
+    const processInstancesForCorrelations: Array<Array<
+      DataModels.Correlations.ProcessInstance
+    >> = activeCorrelations.map((correlation) => {
       const processInstances: Array<DataModels.Correlations.ProcessInstance> = correlation.processInstances.map(
         (processInstance) => {
           processInstance.correlationId = correlation.id;
@@ -516,6 +517,10 @@ export class DashboardRepository implements IDashboardRepository {
     };
 
     return taskList;
+  }
+
+  public getCorrelationById(identity: IIdentity, correlationId: string): Promise<Correlation> {
+    return this.managementApiClient.getCorrelationById(identity, correlationId);
   }
 
   private mapTasksToTaskListEntry(tasks: Array<TaskSource>, targetType: TaskType): Array<TaskListEntry> {

--- a/src/modules/inspect/dashboard/services/dashboard.service.ts
+++ b/src/modules/inspect/dashboard/services/dashboard.service.ts
@@ -214,12 +214,26 @@ export class DashboardService implements IDashboardService {
     userTaskInstanceId: string,
     userTaskResult: DataModels.UserTasks.UserTaskResult,
   ): Promise<void> {
-    return this.managementApiClient.finishUserTask(
+    return this.dashboardRepository.finishUserTask(
       identity,
       processInstanceId,
       correlationId,
       userTaskInstanceId,
       userTaskResult,
+    );
+  }
+
+  public finishEmptyActivity(
+    identity: IIdentity,
+    processInstanceId: string,
+    correlationId: string,
+    emptyActivityInstanceId: string,
+  ): Promise<void> {
+    return this.dashboardRepository.finishEmptyActivity(
+      identity,
+      processInstanceId,
+      correlationId,
+      emptyActivityInstanceId,
     );
   }
 

--- a/src/modules/inspect/dashboard/services/dashboard.service.ts
+++ b/src/modules/inspect/dashboard/services/dashboard.service.ts
@@ -5,6 +5,7 @@ import {DataModels, IManagementApiClient} from '@process-engine/management_api_c
 import {EventAggregator} from 'aurelia-event-aggregator';
 import {IIdentity} from '@essential-projects/iam_contracts';
 import {Subscription} from '@essential-projects/event_aggregator_contracts';
+import {Correlation} from '@process-engine/management_api_contracts/dist/data_models/correlation';
 import environment from '../../../../environment';
 import {ISolutionEntry} from '../../../../contracts';
 import {IDashboardRepository} from '../contracts/IDashboardRepository';
@@ -244,5 +245,9 @@ export class DashboardService implements IDashboardService {
 
   public onCronjobExecuted(identity: IIdentity, callback: Function): Promise<Subscription> {
     return this.dashboardRepository.onCronjobExecuted(identity, callback);
+  }
+
+  public getCorrelationById(identity: IIdentity, correlationId: string): Promise<Correlation> {
+    return this.dashboardRepository.getCorrelationById(identity, correlationId);
   }
 }

--- a/src/modules/inspect/task-list/task-list.html
+++ b/src/modules/inspect/task-list/task-list.html
@@ -55,6 +55,7 @@
     </template>
     <template replace-part="modal-body">
       <task-dynamic-ui view-model.ref="origin.dynamicUi"
+                      correlation-id.bind="correlationId"
                       process-instance-id.bind="processInstanceId"
                       process-model-id.bind="processModelId"
                       task-id.bind="taskId"

--- a/src/modules/inspect/task-list/task-list.html
+++ b/src/modules/inspect/task-list/task-list.html
@@ -1,6 +1,7 @@
 <template>
   <require from="./task-list.css"></require>
   <require from="../../pagination/pagination"></require>
+  <require from="../../task-dynamic-ui/task-dynamic-ui"></require>
 
   <div class="task-list-container" id="taskListContainer">
     <h4 class="task-list-header">Tasks</h4>
@@ -44,4 +45,24 @@
       <img src="src/resources/images/gears.svg" class="loading-spinner">
     </div>
   </div>
+
+  <modal if.bind="showDynamicUiModal"
+        css="display: ${showDynamicUiModal ? 'block' : 'none'};"
+        body-style="overflow: auto;"
+        origin.bind="taskList">
+    <template replace-part="modal-header">
+      <btn class="button task-list__close-modal-button task-list__close-dynamic-ui-modal-button"><i class="fas fa-times" click.delegate="closeDynamicUiModal()"></i></btn>
+    </template>
+    <template replace-part="modal-body">
+      <task-dynamic-ui view-model.ref="origin.dynamicUi"
+                      process-instance-id.bind="processInstanceId"
+                      process-model-id.bind="processModelId"
+                      task-id.bind="taskId"
+                      is-modal="true"
+                      close-modal.trigger="closeDynamicUiModal()"
+                      active-solution-entry.bind="activeSolutionEntry">
+      </task-dynamic-ui>
+    </template>
+  </modal>
+
 </template>

--- a/src/modules/inspect/task-list/task-list.scss
+++ b/src/modules/inspect/task-list/task-list.scss
@@ -36,3 +36,12 @@
 .task-list__no-tasks-text--error {
   color: darkred;
 }
+
+.task-list__close-modal-button {
+  position: absolute;
+  right: 20px;
+}
+
+.task-list__close-dynamic-ui-modal-button {
+  top: 5px;
+}

--- a/src/modules/inspect/task-list/task-list.ts
+++ b/src/modules/inspect/task-list/task-list.ts
@@ -41,6 +41,7 @@ export class TaskList {
   @bindable public processModelId: string;
   @bindable public taskId: string;
   @bindable public processInstanceId: string;
+  @bindable public correlationId: string;
 
   private activeSolutionUri: string;
   private dashboardService: IDashboardService;
@@ -143,6 +144,8 @@ export class TaskList {
         this.processModelId = processModelId;
         this.processInstanceId = processInstanceId;
         this.taskId = id;
+        this.correlationId = correlationId;
+
         this.showDynamicUiModal = true;
         return;
       }


### PR DESCRIPTION
## Changes

1. Add DynamicUI Modal to the Dashboard
2. Use the modal if the user is not authorized to see the correlation

## Issues

Closes #1973 

PR: #1974 

## How to test the changes

- deploy and start a process with a user
- grant a second user the `can_read_process_model` and the lane name used before, as claims
- log in with the second user
- goto the inspect/dashboard view
- click on continue on the waiting task and finish it from the dashboard
