### PR TITLE
♻️ Use UUID for DefintionId

### DIFF
--- a/src/services/diagram-creation-service/diagram-creation.service.ts
+++ b/src/services/diagram-creation-service/diagram-creation.service.ts
@@ -1,5 +1,7 @@
 import {inject} from 'aurelia-framework';
 
+import uuid from 'node-uuid';
+
 import {IModdleElement, IProcessRef} from '@process-engine/bpmn-elements_contracts';
 import * as bundle from '@process-engine/bpmn-js-custom-bundle';
 import {IDiagram} from '@process-engine/solutionexplorer.contracts';
@@ -90,6 +92,8 @@ export class DiagramCreationService implements IDiagramCreationService {
   }
 
   private getInitialProcessXML(processModelId: string): string {
+    const definitionId = uuid.v4();
+
     return `<?xml version="1.0" encoding="UTF-8"?>
     <bpmn:definitions
       xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
@@ -97,7 +101,7 @@ export class DiagramCreationService implements IDiagramCreationService {
       xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
-      id="Definition_1"
+      id="${definitionId}"
       targetNamespace="http://bpmn.io/schema/bpmn"
       exporter="BPMN Studio"
       exporterVersion="1">

--- a/src/services/diagram-creation-service/diagram-creation.service.ts
+++ b/src/services/diagram-creation-service/diagram-creation.service.ts
@@ -101,7 +101,7 @@ export class DiagramCreationService implements IDiagramCreationService {
       xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
-      id="${definitionId}"
+      id="Definition_${definitionId}"
       targetNamespace="http://bpmn.io/schema/bpmn"
       exporter="BPMN Studio"
       exporterVersion="1">


### PR DESCRIPTION
## Changes

1. Use UUID for DefinitionID

## Issues

Closes #1997 

PR: #1999

## How to test the changes

- Create a new diagram
- Open up the XML View
- Have a look at the DefinitionId
- **Notice that the DefinitionId is a UUID.**