### PR TITLE
🐛 Fix Refreshing ProcessModels After Logout

### DIFF
--- a/src/services/authentication-service/electron.oidc-authentication-service.ts
+++ b/src/services/authentication-service/electron.oidc-authentication-service.ts
@@ -97,7 +97,10 @@ export class ElectronOidcAuthenticationService implements IAuthenticationService
     authorityUrl = this.formAuthority(authorityUrl);
 
     await this.showLogoutPopup(authorityUrl, solutionUri, identity, silent);
-    this.eventAggregator.publish(AuthenticationStateEvent.LOGOUT);
+
+    setTimeout(() => {
+      this.eventAggregator.publish(AuthenticationStateEvent.LOGOUT);
+    }, 0);
   }
 
   public async getUserIdentity(authorityUrl: string, identity: IIdentity): Promise<IUserIdentity | null> {


### PR DESCRIPTION
## Changes

1. Fix Refreshing ProcessModels After Logout

PR: #2004 

## How to test the changes

- Log in to the BPMN Studio with a user who does not has the permission to read process models
- Log out
- **Notice that the process models get displayed.**