### PR TITLE
✨Add log information modal

### DIFF
--- a/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.html
+++ b/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.html
@@ -42,8 +42,7 @@
 
   <modal if.bind="showLogEntryModal"
           body-style="overflow: auto; min-height: 320px;"
-          modal-style="max-width: 700px;"
-          origin.bind="taskList">
+          modal-style="max-width: 700px; top: 5%;">
     <template replace-part="modal-header">
       <h3>
         Log Details
@@ -54,15 +53,15 @@
     </template>
     <template replace-part="modal-body">
       <table class="table table-striped table-bordered">
-        <tr repeat.for="property of logInformation" class="task-information__property">
-          <td>
+        <tr repeat.for="property of logInformation">
+          <td class="task-information__property">
             ${property[0]}
           </td>
           <td>
-            <textarea if.bind="property[0] === 'message'" class="table-message-textarea" value.bind="property[1]">
+            <textarea if.bind="property[0] === 'message' || property[0] === 'Token Payload' || property[0] === 'error'" class="table-message-textarea" value.bind="property[1]" readonly>
             </textarea>
             <span else>
-              ${property[1]}
+              ${property[1] || '-'}
             </span>
           </td>
         </tr>

--- a/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.html
+++ b/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.html
@@ -64,21 +64,34 @@
         <tr>
           <td class="log-information__property">Message</td>
           <td>
-            <textarea class="table-message-textarea" value.bind="logEntryForModal.message" readonly></textarea>
+            <pre class="table-pretag table-pretag--message"> ${logEntryForModal.message}</pre>
           </td>
         </tr>
         <tr>
           <td class="log-information__property">Token Payload</td>
           <td>
-            <textarea class="table-message-textarea" value.bind="getStringifiedObject(logEntryForModal.tokenPayload)" readonly></textarea>
+            <pre class="table-pretag table-pretag--message">${getStringifiedObject(logEntryForModal.tokenPayload)}</pre>
           </td>
         </tr>
-        <tr>
-          <td class="log-information__property">Error</td>
-          <td>
-            <textarea class="table-message-textarea" value.bind="getStringifiedObject(logEntryForModal.error)" readonly></textarea>
-          </td>
-        </tr>
+          <tr>
+            <td class="log-information__property">Error Name</td>
+            <td>${logEntryForModal.error.name || '-'}</td>
+          </tr>
+          <tr>
+            <td class="log-information__property">Error Message</td>
+            <td>${logEntryForModal.error.message || '-'}</td>
+          </tr>
+          <tr>
+            <td class="log-information__property">Error Code</td>
+            <td>${logEntryForModal.error.code || '-'}</td>
+          </tr>
+          <tr>
+            <td class="log-information__property">Error Info</td>
+            <td>
+              <pre if.bind="typeof logEntryForModal.error.additionalInformation === 'string'" class="table-pretag">${logEntryForModal.error.additionalInformation}</pre>
+              <pre else class="table-pretag">${getStringifiedObject(logEntryForModal.error.additionalInformation) || '-'}</pre>
+            </td>
+          </tr>
         <tr>
           <td class="log-information__property">Flownode Instance ID</td>
           <td>${logEntryForModal.flowNodeInstanceId || '-'}</td>

--- a/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.html
+++ b/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.html
@@ -20,6 +20,7 @@
           <th class="log-table__headline log-table__message-column" click.delegate="changeSortProperty(logSortProperty.Message)">
             Message <i if.bind="sortSettings.sortProperty === logSortProperty.Message" class.bind="sortSettings.ascending ? 'fas fa-caret-up' : ' fas fa-caret-down'"></i>
           </th>
+          <th class="log-table__headline log-table__details-column"></th>
         </tr>
       </thead class="log-table__header">
       <tbody class="log-table__body">
@@ -29,8 +30,43 @@
           <td class="log-table__table-entry log-table__flow-node-instance-id-column">${logEntry.flowNodeInstanceId || '-'}</td>
           <td class="log-table__table-entry log-table__log-level-column">${logEntry.logLevel.toUpperCase()}</td>
           <td class="log-table__table-entry log-table__message-column">${logEntry.message}</td>
+          <td class="log-table__table-entry log-table__details-column">
+            <button class="btn btn-default task-list-continue-button" click.delegate="openLogEntryModal(logEntry)">
+              Details
+            </button>
+          </td>
         </tr>
       </tbody>
     </table>
   </div>
+
+  <modal if.bind="showLogEntryModal"
+          body-style="overflow: auto; min-height: 320px;"
+          modal-style="max-width: 700px;"
+          origin.bind="taskList">
+    <template replace-part="modal-header">
+      <h3>
+        Log Details
+      </h3>
+      <btn class="button task-list__close-modal-button task-list__close-task-information-modal-button">
+        <i class="fas fa-times" click.delegate="showLogEntryModal = false"></i>
+      </btn>
+    </template>
+    <template replace-part="modal-body">
+      <table class="table table-striped table-bordered">
+        <tr repeat.for="property of logInformation" class="task-information__property">
+          <td>
+            ${property[0]}
+          </td>
+          <td>
+            <textarea if.bind="property[0] === 'message'" class="table-message-textarea" value.bind="property[1]">
+            </textarea>
+            <span else>
+              ${property[1]}
+            </span>
+          </td>
+        </tr>
+      </table>
+    </template>
+  </modal>
 </template>

--- a/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.html
+++ b/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.html
@@ -59,13 +59,11 @@
         </tr>
         <tr>
           <td class="log-information__property">Log Level</td>
-          <td class="log-information__property">${logEntryForModal.logLevel}</td>
+          <td>${logEntryForModal.logLevel}</td>
         </tr>
         <tr>
           <td class="log-information__property">Message</td>
-          <td>
-            ${logEntryForModal.message}
-          </td>
+          <td>${logEntryForModal.message}</td>
         </tr>
         <tr>
           <td class="log-information__property">Token Payload</td>
@@ -73,25 +71,25 @@
             <pre class="table-pretag">${getStringifiedObject(logEntryForModal.tokenPayload)}</pre>
           </td>
         </tr>
-          <tr>
-            <td class="log-information__property">Error Name</td>
-            <td>${logEntryForModal.error.name || '-'}</td>
-          </tr>
-          <tr>
-            <td class="log-information__property">Error Message</td>
-            <td>${logEntryForModal.error.message || '-'}</td>
-          </tr>
-          <tr>
-            <td class="log-information__property">Error Code</td>
-            <td>${logEntryForModal.error.code || '-'}</td>
-          </tr>
-          <tr>
-            <td class="log-information__property">Error Info</td>
-            <td>
-              <pre if.bind="typeof logEntryForModal.error.additionalInformation === 'string'" class="table-pretag">${logEntryForModal.error.additionalInformation}</pre>
-              <pre else class="table-pretag">${getStringifiedObject(logEntryForModal.error.additionalInformation) || '-'}</pre>
-            </td>
-          </tr>
+        <tr>
+          <td class="log-information__property">Error Name</td>
+          <td>${logEntryForModal.error.name || '-'}</td>
+        </tr>
+        <tr>
+          <td class="log-information__property">Error Message</td>
+          <td>${logEntryForModal.error.message || '-'}</td>
+        </tr>
+        <tr>
+          <td class="log-information__property">Error Code</td>
+          <td>${logEntryForModal.error.code || '-'}</td>
+        </tr>
+        <tr>
+          <td class="log-information__property">Error Info</td>
+          <td>
+            <pre if.bind="typeof logEntryForModal.error.additionalInformation === 'string'" class="table-pretag">${logEntryForModal.error.additionalInformation}</pre>
+            <pre else class="table-pretag">${getStringifiedObject(logEntryForModal.error.additionalInformation) || '-'}</pre>
+          </td>
+        </tr>
         <tr>
           <td class="log-information__property">Flownode Instance ID</td>
           <td>${logEntryForModal.flowNodeInstanceId || '-'}</td>
@@ -114,7 +112,7 @@
         </tr>
         <tr>
           <td class="log-information__property">Event Name</td>
-          <td class="log-information__property">${logEntryForModal.measuredAt}</td>
+          <td>${logEntryForModal.measuredAt}</td>
         </tr>
       </table>
     </template>

--- a/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.html
+++ b/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.html
@@ -47,14 +47,14 @@
       <h3>
         Log Details
       </h3>
-      <btn class="button task-list__close-modal-button task-list__close-task-information-modal-button">
+      <btn class="button log-viewer__close-modal-button">
         <i class="fas fa-times" click.delegate="showLogEntryModal = false"></i>
       </btn>
     </template>
     <template replace-part="modal-body">
       <table class="table table-striped table-bordered">
         <tr repeat.for="property of logInformation">
-          <td class="task-information__property">
+          <td class="log-information__property">
             ${property[0]}
           </td>
           <td>

--- a/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.html
+++ b/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.html
@@ -70,13 +70,13 @@
         <tr>
           <td class="log-information__property">Token Payload</td>
           <td>
-            <textarea class="table-message-textarea" value.bind="getStringyfiedObject(logEntryForModal.tokenPayload)" readonly></textarea>
+            <textarea class="table-message-textarea" value.bind="getStringifiedObject(logEntryForModal.tokenPayload)" readonly></textarea>
           </td>
         </tr>
         <tr>
           <td class="log-information__property">Error</td>
           <td>
-            <textarea class="table-message-textarea" value.bind="getStringyfiedObject(logEntryForModal.error)" readonly></textarea>
+            <textarea class="table-message-textarea" value.bind="getStringifiedObject(logEntryForModal.error)" readonly></textarea>
           </td>
         </tr>
         <tr>

--- a/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.html
+++ b/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.html
@@ -53,17 +53,55 @@
     </template>
     <template replace-part="modal-body">
       <table class="table table-striped table-bordered">
-        <tr repeat.for="property of logInformation">
-          <td class="log-information__property">
-            ${property[0]}
-          </td>
+        <tr>
+          <td class="log-information__property">Timestamp</td>
+          <td>${getDateStringFromTimestamp(logEntryForModal.timeStamp)}</td>
+        </tr>
+        <tr>
+          <td class="log-information__property">Log Level</td>
+          <td class="log-information__property">${logEntryForModal.logLevel}</td>
+        </tr>
+        <tr>
+          <td class="log-information__property">Message</td>
           <td>
-            <textarea if.bind="property[0] === 'message' || property[0] === 'Token Payload' || property[0] === 'error'" class="table-message-textarea" value.bind="property[1]" readonly>
-            </textarea>
-            <span else>
-              ${property[1] || '-'}
-            </span>
+            <textarea class="table-message-textarea" value.bind="logEntryForModal.message" readonly></textarea>
           </td>
+        </tr>
+        <tr>
+          <td class="log-information__property">Token Payload</td>
+          <td>
+            <textarea class="table-message-textarea" value.bind="getStringyfiedObject(logEntryForModal.tokenPayload)" readonly></textarea>
+          </td>
+        </tr>
+        <tr>
+          <td class="log-information__property">Error</td>
+          <td>
+            <textarea class="table-message-textarea" value.bind="getStringyfiedObject(logEntryForModal.error)" readonly></textarea>
+          </td>
+        </tr>
+        <tr>
+          <td class="log-information__property">Flownode Instance ID</td>
+          <td>${logEntryForModal.flowNodeInstanceId || '-'}</td>
+        </tr>
+        <tr>
+          <td class="log-information__property">Flownode ID</td>
+          <td>${logEntryForModal.flowNodeId || '-'}</td>
+        </tr>
+        <tr>
+          <td class="log-information__property">Process Model ID</td>
+          <td>${logEntryForModal.processModelId}</td>
+        </tr>
+        <tr>
+          <td class="log-information__property">Process Instance ID</td>
+          <td>${logEntryForModal.processInstanceId}</td>
+        </tr>
+        <tr>
+          <td class="log-information__property">Correlation ID</td>
+          <td>${logEntryForModal.correlationId}</td>
+        </tr>
+        <tr>
+          <td class="log-information__property">Event Name</td>
+          <td class="log-information__property">${logEntryForModal.measuredAt}</td>
         </tr>
       </table>
     </template>

--- a/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.html
+++ b/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.html
@@ -42,7 +42,7 @@
 
   <modal if.bind="showLogEntryModal"
           body-style="overflow: auto; min-height: 320px;"
-          modal-style="max-width: 700px; top: 5%;">
+          modal-style="top: 10%; height: 77%; max-height: 90%; max-width: 700px;">
     <template replace-part="modal-header">
       <h3>
         Log Details
@@ -64,13 +64,13 @@
         <tr>
           <td class="log-information__property">Message</td>
           <td>
-            <pre class="table-pretag table-pretag--message"> ${logEntryForModal.message}</pre>
+            ${logEntryForModal.message}
           </td>
         </tr>
         <tr>
           <td class="log-information__property">Token Payload</td>
           <td>
-            <pre class="table-pretag table-pretag--message">${getStringifiedObject(logEntryForModal.tokenPayload)}</pre>
+            <pre class="table-pretag">${getStringifiedObject(logEntryForModal.tokenPayload)}</pre>
           </td>
         </tr>
           <tr>

--- a/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.html
+++ b/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.html
@@ -3,8 +3,8 @@
   <div class="log-viewer">
     <h3 if.bind="log.length === 0" class="log-table__empty-message">No logs for this correlation available.</h3>
     <table else class="table table-striped table-hover log-table">
-      <thead>
-        <tr class="log-table__headlines">
+      <thead class="log-table__head">
+        <tr class="log-table__table-row">
           <th class="log-table__headline log-table__time-column" click.delegate="changeSortProperty(logSortProperty.Time)">
             Time <i if.bind="sortSettings.sortProperty === logSortProperty.Time" class.bind="sortSettings.ascending ? 'fas fa-caret-up' : ' fas fa-caret-down'"></i>
           </th>
@@ -17,19 +17,19 @@
           <th class="log-table__headline log-table__log-level-column" click.delegate="changeSortProperty(logSortProperty.LogLevel)">
             Level <i if.bind="sortSettings.sortProperty === logSortProperty.LogLevel" class.bind="sortSettings.ascending ? 'fas fa-caret-up' : ' fas fa-caret-down'"></i>
           </th>
-          <th class="log-table__headline log-table__message-column" click.delegate="changeSortProperty(logSortProperty.Message)">
+          <th class="log-table__headline" click.delegate="changeSortProperty(logSortProperty.Message)">
             Message <i if.bind="sortSettings.sortProperty === logSortProperty.Message" class.bind="sortSettings.ascending ? 'fas fa-caret-up' : ' fas fa-caret-down'"></i>
           </th>
           <th class="log-table__headline log-table__details-column"></th>
         </tr>
-      </thead class="log-table__header">
+      </thead>
       <tbody class="log-table__body">
         <tr class="log-table__table-row" repeat.for="logEntry of sortedLog">
           <td class="log-table__table-entry log-table__time-column">${getDateStringFromTimestamp(logEntry.timeStamp)}</td>
           <td class="log-table__table-entry log-table__flow-node-id-column">${logEntry.flowNodeId || '-'}</td>
           <td class="log-table__table-entry log-table__flow-node-instance-id-column">${logEntry.flowNodeInstanceId || '-'}</td>
           <td class="log-table__table-entry log-table__log-level-column">${logEntry.logLevel.toUpperCase()}</td>
-          <td class="log-table__table-entry log-table__message-column">${logEntry.message}</td>
+          <td class="log-table__table-entry">${logEntry.message}</td>
           <td class="log-table__table-entry log-table__details-column">
             <button class="btn btn-default task-list-continue-button" click.delegate="openLogEntryModal(logEntry)">
               Details

--- a/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.scss
+++ b/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.scss
@@ -12,11 +12,6 @@
   user-select: text;
 }
 
-.log-table__headlines {
-  display: flex;
-  width: 100%;
-}
-
 .log-table__headline {
   padding: 8px;
   overflow: hidden;
@@ -29,13 +24,18 @@
 
 .log-table__body {
   display: block;
-  height: 100%;
+  height: calc(100% - 40px);
   overflow: auto;
 }
 
+.log-table__head {
+  display: block;
+}
+
 .log-table__table-row {
-  display: flex;
+  display: table;
   width: 100%;
+  table-layout: fixed;
 }
 
 .log-table__table-entry {
@@ -65,10 +65,6 @@
   width: 200px;
 }
 
-.log-table__message-column {
-  width: calc(100% - 650px);
-}
-
 .log-table__details-column {
   width: 100px;
 }
@@ -79,16 +75,6 @@
   top: 50%;
   transform: translate(-50%, -50%);
   user-select: none;
-}
-
-.table-message-textarea {
-  width: 495px;
-  height: 50px;
-  max-height: 120px;
-  margin-top: 0px;
-  margin-bottom: 0px;
-  border: none;
-  background: inherit;
 }
 
 .table-pretag {

--- a/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.scss
+++ b/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.scss
@@ -92,13 +92,7 @@
 }
 
 .table-pretag {
-  height: 80px;
   width: 495px;
-  max-height: 120px;
-}
-
-.table-pretag--message {
-  height: 50px;
 }
 
 .log-viewer__close-modal-button {

--- a/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.scss
+++ b/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.scss
@@ -82,11 +82,11 @@
 }
 
 .table-message-textarea {
+  width: 495px;
+  height: 50px;
+  max-height: 120px;
   margin-top: 0px;
   margin-bottom: 0px;
-  height: 120px;
-  max-height: 120px;
   border: none;
-  resize: none;
-  width: 495px;
+  background: inherit;
 }

--- a/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.scss
+++ b/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.scss
@@ -90,3 +90,13 @@
   border: none;
   background: inherit;
 }
+
+.log-viewer__close-modal-button {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+}
+
+.log-information__property {
+  text-transform: capitalize;
+}

--- a/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.scss
+++ b/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.scss
@@ -91,6 +91,16 @@
   background: inherit;
 }
 
+.table-pretag {
+  height: 80px;
+  width: 495px;
+  max-height: 120px;
+}
+
+.table-pretag--message {
+  height: 50px;
+}
+
 .log-viewer__close-modal-button {
   position: absolute;
   top: 20px;

--- a/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.scss
+++ b/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.scss
@@ -66,7 +66,11 @@
 }
 
 .log-table__message-column {
-  width: calc(100% - 600px);
+  width: calc(100% - 800px);
+}
+
+.log-table__details-column {
+  width: 150px;
 }
 
 .log-table__empty-message {
@@ -75,4 +79,14 @@
   top: 50%;
   transform: translate(-50%, -50%);
   user-select: none;
+}
+
+.table-message-textarea {
+  margin-top: 0px;
+  margin-bottom: 0px;
+  height: 120px;
+  max-height: 120px;
+  border: none;
+  resize: none;
+  width: 495px;
 }

--- a/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.scss
+++ b/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.scss
@@ -66,11 +66,11 @@
 }
 
 .log-table__message-column {
-  width: calc(100% - 800px);
+  width: calc(100% - 650px);
 }
 
 .log-table__details-column {
-  width: 150px;
+  width: 100px;
 }
 
 .log-table__empty-message {

--- a/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.ts
+++ b/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.ts
@@ -28,23 +28,26 @@ export class LogViewer {
   }
 
   public openLogEntryModal(logEntry: DataModels.Logging.LogEntry): void {
-    console.log(logEntry);
-    // const logInformationObject = this.convertToLogInformationObject(logEntry);
-    this.logInformation = Object.entries(logEntry);
+    const logInformationObject = this.convertToLogInformationObject(logEntry);
+    this.logInformation = Object.entries(logInformationObject);
     this.showLogEntryModal = true;
   }
 
-  // private convertToTaskInformationObject(task: TaskListEntry): any {
-  //   return {
-  //     name: task.name,
-  //     id: task.id,
-  //     type: task.taskType,
-  //     'Flownode Instance ID': task.flowNodeInstanceId,
-  //     'Process Model ID': task.processModelId,
-  //     'Correlation ID': task.correlationId,
-  //     'Process Instance ID': task.processInstanceId,
-  //   };
-  // }
+  private convertToLogInformationObject(logEntry: DataModels.Logging.LogEntry): any {
+    return {
+      'Time Stamp': logEntry.timeStamp,
+      'Log Level': logEntry.logLevel.toUpperCase(),
+      message: logEntry.message,
+      'Token Payload': JSON.stringify(logEntry.tokenPayload, null, 2),
+      error: JSON.stringify(logEntry.error, null, 2),
+      'Flownode Instance ID': logEntry.flowNodeInstanceId,
+      'Flownode ID': logEntry.flowNodeId,
+      'Process Model ID': logEntry.processModelId,
+      'Process Instance ID': logEntry.processInstanceId,
+      'Correlation ID': logEntry.correlationId,
+      'Measured At': logEntry.measuredAt,
+    };
+  }
 
   public async processInstanceChanged(): Promise<void> {
     const noProcessInstanceSet: boolean = this.processInstance === undefined;

--- a/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.ts
+++ b/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.ts
@@ -4,10 +4,9 @@ import {DataModels} from '@process-engine/management_api_contracts';
 
 import {ILogSortSettings, ISolutionEntry, LogSortProperty} from '../../../../../../../contracts/index';
 import {getBeautifiedDate} from '../../../../../../../services/date-service/date.service';
-import {NotificationService} from '../../../../../../../services/notification-service/notification.service';
 import {IInspectProcessInstanceService} from '../../../../contracts';
 
-@inject('NotificationService', 'InspectProcessInstanceService')
+@inject('InspectProcessInstanceService')
 export class LogViewer {
   @bindable public log: Array<DataModels.Logging.LogEntry>;
   @bindable public processInstance: DataModels.Correlations.ProcessInstance;
@@ -19,13 +18,33 @@ export class LogViewer {
     sortProperty: LogSortProperty.Time,
   };
 
-  private notificationService: NotificationService;
+  public showLogEntryModal: boolean = false;
+  public logInformation: Array<[string, string]>;
+
   private inspectProcessInstanceService: IInspectProcessInstanceService;
 
-  constructor(notificationService: NotificationService, inspectProcessInstanceService: IInspectProcessInstanceService) {
-    this.notificationService = notificationService;
+  constructor(inspectProcessInstanceService: IInspectProcessInstanceService) {
     this.inspectProcessInstanceService = inspectProcessInstanceService;
   }
+
+  public openLogEntryModal(logEntry: DataModels.Logging.LogEntry): void {
+    console.log(logEntry);
+    // const logInformationObject = this.convertToLogInformationObject(logEntry);
+    this.logInformation = Object.entries(logEntry);
+    this.showLogEntryModal = true;
+  }
+
+  // private convertToTaskInformationObject(task: TaskListEntry): any {
+  //   return {
+  //     name: task.name,
+  //     id: task.id,
+  //     type: task.taskType,
+  //     'Flownode Instance ID': task.flowNodeInstanceId,
+  //     'Process Model ID': task.processModelId,
+  //     'Correlation ID': task.correlationId,
+  //     'Process Instance ID': task.processInstanceId,
+  //   };
+  // }
 
   public async processInstanceChanged(): Promise<void> {
     const noProcessInstanceSet: boolean = this.processInstance === undefined;

--- a/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.ts
+++ b/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.ts
@@ -36,16 +36,16 @@ export class LogViewer {
   private convertToLogInformationObject(logEntry: DataModels.Logging.LogEntry): any {
     return {
       'Time Stamp': logEntry.timeStamp,
-      'Log Level': logEntry.logLevel.toUpperCase(),
+      'Event Name': logEntry.measuredAt,
       message: logEntry.message,
-      'Token Payload': JSON.stringify(logEntry.tokenPayload, null, 2),
-      error: JSON.stringify(logEntry.error, null, 2),
-      'Flownode Instance ID': logEntry.flowNodeInstanceId,
-      'Flownode ID': logEntry.flowNodeId,
+      'Correlation ID': logEntry.correlationId,
       'Process Model ID': logEntry.processModelId,
       'Process Instance ID': logEntry.processInstanceId,
-      'Correlation ID': logEntry.correlationId,
-      'Measured At': logEntry.measuredAt,
+      'Flownode ID': logEntry.flowNodeId,
+      'Flownode Instance ID': logEntry.flowNodeInstanceId,
+      'Token Payload': JSON.stringify(logEntry.tokenPayload, null, 2),
+      error: JSON.stringify(logEntry.error, null, 2),
+      'Log Level': logEntry.logLevel.toUpperCase(),
     };
   }
 

--- a/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.ts
+++ b/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.ts
@@ -36,16 +36,16 @@ export class LogViewer {
   private convertToLogInformationObject(logEntry: DataModels.Logging.LogEntry): any {
     return {
       'Time Stamp': logEntry.timeStamp,
-      'Event Name': logEntry.measuredAt,
+      'Log Level': logEntry.logLevel.toUpperCase(),
       message: logEntry.message,
-      'Correlation ID': logEntry.correlationId,
-      'Process Model ID': logEntry.processModelId,
-      'Process Instance ID': logEntry.processInstanceId,
-      'Flownode ID': logEntry.flowNodeId,
-      'Flownode Instance ID': logEntry.flowNodeInstanceId,
       'Token Payload': JSON.stringify(logEntry.tokenPayload, null, 2),
       error: JSON.stringify(logEntry.error, null, 2),
-      'Log Level': logEntry.logLevel.toUpperCase(),
+      'Flownode Instance ID': logEntry.flowNodeInstanceId,
+      'Flownode ID': logEntry.flowNodeId,
+      'Process Model ID': logEntry.processModelId,
+      'Process Instance ID': logEntry.processInstanceId,
+      'Correlation ID': logEntry.correlationId,
+      'Measured At': logEntry.measuredAt,
     };
   }
 

--- a/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.ts
+++ b/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.ts
@@ -19,7 +19,7 @@ export class LogViewer {
   };
 
   public showLogEntryModal: boolean = false;
-  public logInformation: Array<[string, string]>;
+  public logEntryForModal: DataModels.Logging.LogEntry;
 
   private inspectProcessInstanceService: IInspectProcessInstanceService;
 
@@ -28,25 +28,12 @@ export class LogViewer {
   }
 
   public openLogEntryModal(logEntry: DataModels.Logging.LogEntry): void {
-    const logInformationObject = this.convertToLogInformationObject(logEntry);
-    this.logInformation = Object.entries(logInformationObject);
+    this.logEntryForModal = logEntry;
     this.showLogEntryModal = true;
   }
 
-  private convertToLogInformationObject(logEntry: DataModels.Logging.LogEntry): any {
-    return {
-      'Time Stamp': logEntry.timeStamp,
-      'Log Level': logEntry.logLevel.toUpperCase(),
-      message: logEntry.message,
-      'Token Payload': JSON.stringify(logEntry.tokenPayload, null, 2),
-      error: JSON.stringify(logEntry.error, null, 2),
-      'Flownode Instance ID': logEntry.flowNodeInstanceId,
-      'Flownode ID': logEntry.flowNodeId,
-      'Process Model ID': logEntry.processModelId,
-      'Process Instance ID': logEntry.processInstanceId,
-      'Correlation ID': logEntry.correlationId,
-      'Measured At': logEntry.measuredAt,
-    };
+  public getStringyfiedObject(object: any): string {
+    return JSON.stringify(object, null, 2);
   }
 
   public async processInstanceChanged(): Promise<void> {

--- a/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.ts
+++ b/src/modules/inspect/inspect-process-instance/components/inspect-panel/components/log-viewer/log-viewer.ts
@@ -32,7 +32,7 @@ export class LogViewer {
     this.showLogEntryModal = true;
   }
 
-  public getStringyfiedObject(object: any): string {
+  public getStringifiedObject(object: any): string {
     return JSON.stringify(object, null, 2);
   }
 


### PR DESCRIPTION
## Changes

1. Add an information modal for log entries

## Issues

Closes #2010 

PR: #2027 

## How to test the changes

<img width="699" alt="Bildschirmfoto 2020-05-04 um 08 54 00" src="https://user-images.githubusercontent.com/17065920/80943263-15261300-8de7-11ea-8dd2-1de92844ae9a.png">


Open the log viewer for a process instance and click on the `Details` button
