### PR TITLE
✨Hold focus in modals

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -75,6 +75,14 @@ router-view {
   color: #333;
 }
 
+.btn-default:hover:enabled {
+  background-color: #eee;
+}
+
+.btn-default:not(:disabled):focus {
+  border-color: black;
+}
+
 .btn-primary,
 .btn-primary:disabled {
   background: #5d8a3c;
@@ -88,10 +96,6 @@ router-view {
 }
 .btn-primary:not(:disabled):not(.disabled):active:focus {
   box-shadow: 0 0 0 0.2rem rgba(95, 142, 20, 0.5);
-}
-
-.btn-default:hover:enabled {
-  background-color: #eee;
 }
 
 .btn:focus {

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,7 +32,7 @@ export function configure(aurelia: Aurelia): void {
 
   aurelia.use
     .standardConfiguration()
-    .globalResources('modules/custom_elements/modal/modal.html')
+    .feature('modules/custom_elements/modal')
     .feature('modules/fetch-http-client')
     .feature('services/dynamic-ui-service')
     .feature('services/notification-service')

--- a/src/modules/config-panel/config-panel.html
+++ b/src/modules/config-panel/config-panel.html
@@ -22,11 +22,9 @@
     <button class="btn btn-default" click.delegate="cancelUpdate()">Cancel</button>
     <button class="btn btn-primary" click.delegate="updateSettings()" disabled.bind="!uriIsValid || uriIsEmpty">Save</button>
   </div>
-  <modal show.bind="showRestartModal"
-         header-text="BPMN Studio needs to restart">
-    <template replace-part="modal-body">
-      A restart is required in order to apply the changes.
-    </template>
+  <modal if.bind="showRestartModal"
+         header-text="BPMN Studio needs to restart"
+         body-text="A restart is required in order to apply the changes.">
     <template replace-part="modal-footer">
       <button type="button" class="btn btn-default" data-dismiss="modal" click.delegate="restartLater()">Restart later (manually)</button>
       <button type="button" class="btn btn-primary" data-dismiss="modal" click.delegate="restartNow()">Restart now</button>

--- a/src/modules/custom_elements/modal/index.ts
+++ b/src/modules/custom_elements/modal/index.ts
@@ -1,0 +1,3 @@
+export function configure(config): void {
+  config.globalResources('./modal');
+}

--- a/src/modules/custom_elements/modal/modal.html
+++ b/src/modules/custom_elements/modal/modal.html
@@ -1,7 +1,7 @@
-<template bindable="modalStyle,contentStyle,headerStyle,bodyStyle,footerStyle,headerText,bodyText,footerText,origin">
+<template>
   <require from="./modal.css"></require>
 
-  <div class="modal show show-modal" tabindex="-1" role="dialog">
+  <div ref="modalRef" class="modal show show-modal" tabindex="-1" role="dialog">
     <div class="modal-dialog modal-style" style.bind="modalStyle" role="document">
       <div class="modal-content" style.bind="contentStyle">
         <div class="modal-header" style.bind="headerStyle">

--- a/src/modules/custom_elements/modal/modal.ts
+++ b/src/modules/custom_elements/modal/modal.ts
@@ -1,0 +1,31 @@
+import {bindable} from 'aurelia-framework';
+
+export class ModalCustomElement {
+  @bindable public modalStyle;
+  @bindable public contentStyle;
+  @bindable public headerStyle;
+  @bindable public bodyStyle;
+  @bindable public footerStyle;
+  @bindable public headerText;
+  @bindable public bodyText;
+  @bindable public footerText;
+  @bindable public origin;
+
+  private modalRef: HTMLDivElement;
+
+  public attached(): void {
+    document.addEventListener('focusin', this.focusEventListener);
+  }
+
+  public detached(): void {
+    document.removeEventListener('focusin', this.focusEventListener);
+  }
+
+  private focusEventListener = (event): void => {
+    const focussedElementIsInModalOrTheModal = this.modalRef.contains(event.target);
+
+    if (!focussedElementIsInModalOrTheModal) {
+      this.modalRef.focus();
+    }
+  };
+}

--- a/src/modules/deploy-modals/deploy-modals.html
+++ b/src/modules/deploy-modals/deploy-modals.html
@@ -17,7 +17,7 @@
   </modal>
 
 
-  <modal show.bind="showOverwriteDiagramModal"
+  <modal if.bind="showOverwriteDiagramModal"
          header-text="Warning: Diagram already exists!" data-test-diagram-already-exist>
     <template replace-part="modal-body">
       The target solution already contains a diagram with that name and ID.<br>

--- a/src/modules/design/design.html
+++ b/src/modules/design/design.html
@@ -31,7 +31,7 @@
       </div>
     </div>
 
-    <modal show.bind="showSaveForStartModal"
+    <modal if.bind="showSaveForStartModal"
           header-text="Document Contains Changes"
           body-text="Your process has unsaved changes. Save changes to diagram before starting the process?">
       <template replace-part="modal-footer">
@@ -40,7 +40,7 @@
       </template>
     </modal>
 
-    <modal show.bind="showStartWithOptionsModal"
+    <modal if.bind="showStartWithOptionsModal"
           header-text="Start Options"
           body-text="Your process has unsaved changes. Save changes to diagram before starting the process?"
           origin.bind="design">
@@ -77,7 +77,7 @@
       </template>
     </modal>
 
-    <modal show.bind="showStartEventModal"
+    <modal if.bind="showStartEventModal"
           header-text="Select initial StartEvent"
           body-text="Your process has unsaved changes. Save changes to diagram before starting the process?">
       <template replace-part="modal-body">
@@ -96,7 +96,7 @@
       </template>
     </modal>
 
-    <modal show.bind="showSelectDiagramModal"
+    <modal if.bind="showSelectDiagramModal"
           header-text="Choose a Diagram"
           id="js-chooseDiagram-modal">
       <template replace-part="modal-body">

--- a/src/modules/design/property-panel/indextabs/general/sections/basics/basics.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/basics/basics.html
@@ -37,7 +37,7 @@
     </div>
   </div>
 
-  <modal show.bind="showModal"
+  <modal if.bind="showModal"
          header-text="Editing: Docs">
     <template replace-part="modal-body" autofocus>
       <textarea class="form-control docs" value.bind="elementDocumentation" change.delegate="updateDocumentation()" rows="10" aria-multiline="true" autofocus wrap="soft" disabled.bind="!isEditable"></textarea>

--- a/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/call-activity/call-activity.html
@@ -41,7 +41,7 @@
     </div>
   </div>
 
-  <modal show.bind="showPayloadModal"
+  <modal if.bind="showPayloadModal"
          header-text="Editing: Payload">
     <template replace-part="modal-body" autofocus>
       <textarea class="form-control script-task" value.bind="payload" rows="10" aria-multiline="true" autofocus wrap="soft" disabled.bind="!isEditable"></textarea>

--- a/src/modules/design/property-panel/indextabs/general/sections/pool/pool.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/pool/pool.html
@@ -35,7 +35,7 @@
     </div>
   </div>
 
-  <modal show.bind="showModal"
+  <modal if.bind="showModal"
          header-text="Warning: Editing Process ID">
     <template replace-part="modal-body">
       Changing a process ID can potentially break your deployments! Only perform this action if you know what you are doing!

--- a/src/modules/design/property-panel/indextabs/general/sections/script-task/script-task.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/script-task/script-task.html
@@ -19,7 +19,7 @@
     </div>
   </div>
 
-  <modal show.bind="showModal"
+  <modal if.bind="showModal"
          header-text="Editing: Script Task">
     <template replace-part="modal-body" autofocus>
       <textarea class="form-control script-task" value.bind="businessObjInPanel.script" change.delegate="updateScript()" rows="10" aria-multiline="true" autofocus wrap="soft" disabled.bind="!isEditable"></textarea>

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.html
@@ -22,7 +22,7 @@
     </div>
   </div>
 
-  <modal show.bind="showModal"
+  <modal if.bind="showModal"
          header-text="Editing: Payload">
     <template replace-part="modal-body" autofocus>
       <textarea class="form-control payload" value.bind="selectedPayload" change.delegate="payloadChanged()" rows="10" aria-multiline="true" autofocus wrap="soft" disabled.bind="!model.isEditable"></textarea>

--- a/src/modules/live-execution-tracker/live-execution-tracker.html
+++ b/src/modules/live-execution-tracker/live-execution-tracker.html
@@ -59,7 +59,7 @@
     </template>
   </modal>
 
-  <modal show.bind="showDiagramPreviewViewer"
+  <modal if.bind="showDiagramPreviewViewer"
          modal-style="top: 10%; bottom: 10%; left: 10%; right: 10%; margin: 0; position: absolute; max-width: 100%;"
          css="display: ${showDiagramPreviewViewer ? 'block' : 'none'};"
          body-style="overflow: auto; width: 100%; height: 100%; padding: 0;"

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.html
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.html
@@ -111,7 +111,7 @@
       <button type="button" class="btn btn-primary" data-dismiss="modal" id="saveButtonCloseView">Save</button>
     </template>
   </modal>
-  
+
   <modal if.bind="isSavingDiagrams"
          body-style="min-height: 230px"
          header-text="Saving Diagrams">

--- a/src/services/help-modal-service/help-modal-service.ts
+++ b/src/services/help-modal-service/help-modal-service.ts
@@ -26,13 +26,14 @@ export class HelpModalService {
     const node = document.createElement('div');
 
     const removeModalFn = (): void => {
+      document.removeEventListener('focusin', this.focusEventListener);
       document.body.removeChild(node);
     };
 
     const helpText = this.helpTextService.getHelpTextById(helpTextId);
 
     node.innerHTML = `
-<div class="modal show show-modal" tabindex="-1" role="dialog">
+<div class="modal show show-modal" tabindex="-1" role="dialog" id="help-modal">
   <div class="modal-dialog modal-style" style="display: flex; top: 10%; max-height: 80%;" role="document">
     <div class="modal-content" style="height: unset;">
       <div class="modal-header">
@@ -46,6 +47,16 @@ export class HelpModalService {
 <div class="modal-backdrop fade in"></div>`;
 
     document.body.appendChild(node);
+    document.addEventListener('focusin', this.focusEventListener);
     document.getElementById('help-modal-close-button').onclick = removeModalFn;
   }
+
+  private focusEventListener = (event): void => {
+    const helpModalElement = document.getElementById('help-modal');
+    const focussedElementIsInModalOrTheModal = helpModalElement.contains(event.target);
+
+    if (!focussedElementIsInModalOrTheModal) {
+      helpModalElement.focus();
+    }
+  };
 }


### PR DESCRIPTION
## Changes

1. Add focus CSS for btn-default
2. Use if bind instead of show bind on modals
3. Set the focus to the modal if it runs out of the modal

## Issues

PR: #2030
