### PR TITLE
🐛Fix broken modeler canvas

### DIFF
--- a/aurelia_project/environments/dev.ts
+++ b/aurelia_project/environments/dev.ts
@@ -84,6 +84,7 @@ export default {
       propertyPanelActive: 'design:propertypanel:active',
       bindKeyboard: 'design:keyboard:bind',
       unbindKeyboard: 'design:keyboard:unbind',
+      fitViewport: 'design:detailview:fitviewport',
     },
     diffView: {
       changeDiffMode: 'diffview:diffmode:change',

--- a/src/modules/design/design.ts
+++ b/src/modules/design/design.ts
@@ -151,13 +151,14 @@ export class Design {
     this.routeView = routeParameters.view;
 
     if (routeViewIsDetail) {
-      this.showDetail = true;
       this.showXML = false;
       this.showDiff = false;
-      this.showPropertyPanelButton = true;
       this.showDiffDestinationButton = false;
+      this.showDetail = true;
+      this.showPropertyPanelButton = true;
 
       this.eventAggregator.publish(environment.events.bpmnio.bindKeyboard);
+      this.eventAggregator.publish(environment.events.bpmnio.fitViewport);
     } else if (routeViewIsXML) {
       this.showDetail = false;
       this.showXML = true;


### PR DESCRIPTION
## Changes

1. Fix bug where the modeler canvas is broken when switching between diagrams if the XML view is open and subsequently open the detail/diagram view.

## Issues

PR: #2034 

## How to test the changes

- open a diagrams detail view
- open the XML view
- choose another diagram
- open the diagrams detail view
- see that the diagram is shown correctly
