### PR TITLE
🐛 Fix Handling ErrorMessges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bpmn-studio",
-  "version": "6.0.0-beta.7",
+  "version": "6.0.0-alpha.28",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1052,9 +1052,9 @@
       }
     },
     "@process-engine/bpmn-elements_contracts": {
-      "version": "2.1.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@process-engine/bpmn-elements_contracts/-/bpmn-elements_contracts-2.1.0-beta.1.tgz",
-      "integrity": "sha512-85IFF5fwjtuWA4RQfoSg2n9mCdTSynCg60XNHdz7vibO0ZIz20jxc7RQUn4fI+nrYYBO9hvewKt6TLDRxG2lZg==",
+      "version": "2.1.0-feature-2af061-kaxp51kc",
+      "resolved": "https://registry.npmjs.org/@process-engine/bpmn-elements_contracts/-/bpmn-elements_contracts-2.1.0-feature-2af061-kaxp51kc.tgz",
+      "integrity": "sha512-d439pwPz1zdFkYHNw9DLS1C+h7K+uMBnqFhA8rVuY8x9kCxmASsjjqmMbvTuEeq/goIreY0sinG04RmQSuUdVw==",
       "dev": true
     },
     "@process-engine/bpmn-js-bpmnlint": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1052,9 +1052,9 @@
       }
     },
     "@process-engine/bpmn-elements_contracts": {
-      "version": "2.1.0-feature-2af061-kaxp51kc",
-      "resolved": "https://registry.npmjs.org/@process-engine/bpmn-elements_contracts/-/bpmn-elements_contracts-2.1.0-feature-2af061-kaxp51kc.tgz",
-      "integrity": "sha512-d439pwPz1zdFkYHNw9DLS1C+h7K+uMBnqFhA8rVuY8x9kCxmASsjjqmMbvTuEeq/goIreY0sinG04RmQSuUdVw==",
+      "version": "2.1.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/@process-engine/bpmn-elements_contracts/-/bpmn-elements_contracts-2.1.0-alpha.5.tgz",
+      "integrity": "sha512-1luB+yGBrYCZmk+XchzAI/yEjYutIRGBo1TSDuKZ8DUbEyP2N/28v6pi1Xz2KJT8PY8hOoE8zrRT96gpORC14w==",
       "dev": true
     },
     "@process-engine/bpmn-js-bpmnlint": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@essential-projects/eslint-config": "^1.2.3",
     "@essential-projects/http_contracts": "^2.5.0",
     "@essential-projects/iam_contracts": "^3.6.3",
-    "@process-engine/bpmn-elements_contracts": "feature~fix_handling_error-messages",
+    "@process-engine/bpmn-elements_contracts": "2.1.0-alpha.5",
     "@process-engine/management_api_contracts": "13.2.0",
     "@process-engine/solutionexplorer.contracts": "1.2.0",
     "@process-engine/solutionexplorer.repository.contracts": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@essential-projects/eslint-config": "^1.2.3",
     "@essential-projects/http_contracts": "^2.5.0",
     "@essential-projects/iam_contracts": "^3.6.3",
-    "@process-engine/bpmn-elements_contracts": "2.1.0-beta.1",
+    "@process-engine/bpmn-elements_contracts": "feature~fix_handling_error-messages",
     "@process-engine/management_api_contracts": "13.2.0",
     "@process-engine/solutionexplorer.contracts": "1.2.0",
     "@process-engine/solutionexplorer.repository.contracts": "4.5.0",

--- a/src/modules/design/property-panel/indextabs/general/sections/error-event/error-event.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/error-event/error-event.ts
@@ -98,7 +98,7 @@ export class ErrorEventSection implements ISection {
 
   public updateErrorMessage(): void {
     const selectedError: IError = this.getSelectedError();
-    selectedError.$attrs['camunda:errorMessage'] = this.errorMessageVariable;
+    selectedError.errorMessage = this.errorMessageVariable;
     this.publishDiagramChange();
   }
 
@@ -255,12 +255,12 @@ export class ErrorEventSection implements ISection {
   }
 
   private persistErrorMessageInError(errorElement: IErrorEventDefinition): void {
-    const errorMessageExistOnError = this.selectedError.$attrs['camunda:errorMessage'] != null;
+    const errorMessageExistOnError = this.selectedError.errorMessage != null;
     if (errorMessageExistOnError) {
-      this.errorMessageVariable = this.selectedError.$attrs['camunda:errorMessage'];
-    } else {
+      this.errorMessageVariable = this.selectedError.errorMessage;
+    } else if (errorElement.errorMessageVariable) {
       this.errorMessageVariable = errorElement.errorMessageVariable;
-      this.selectedError.$attrs['camunda:errorMessage'] = this.errorMessageVariable;
+      this.selectedError.errorMessage = this.errorMessageVariable;
       delete errorElement.errorMessageVariable;
     }
   }


### PR DESCRIPTION
## Changes

1. Fix Handling ErrorMessges

PR: #2036

## How to test

- Create a diagram with an ErrorBoundaryEvent
- Create a new error
- **Do not configure a message**
- Run the diagram
- **Notice that the ErrorBoundaryEvent works as it should.**