### PR TITLE
🐛Fix viewport when switching from a local diagram to a diagram on a remote solution

### DIFF
--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -781,7 +781,7 @@ export class BpmnIo {
       const viewerViewbox: IViewbox = viewerCanvas.viewbox();
       const viewerDiagramIsVisible: boolean = viewerViewbox.height > 0 && viewerViewbox.width > 0;
 
-      if (viewerDiagramIsVisible || force) {
+      if (viewerDiagramIsVisible) {
         viewerCanvas.zoom('fit-viewport', 'auto');
       }
     } else if (modelerDiagramIsVisible || force) {

--- a/src/modules/design/design.ts
+++ b/src/modules/design/design.ts
@@ -148,7 +148,6 @@ export class Design {
     const routeViewIsDetail: boolean = routeParameters.view === 'detail';
     const routeViewIsXML: boolean = routeParameters.view === 'xml';
     const routeViewIsDiff: boolean = routeParameters.view === 'diff';
-    this.routeView = routeParameters.view;
 
     if (routeViewIsDetail) {
       this.showXML = false;
@@ -158,7 +157,9 @@ export class Design {
       this.showPropertyPanelButton = true;
 
       this.eventAggregator.publish(environment.events.bpmnio.bindKeyboard);
-      this.eventAggregator.publish(environment.events.bpmnio.fitViewport);
+      if (this.routeView === 'diff' || this.routeView === 'xml') {
+        this.eventAggregator.publish(environment.events.bpmnio.fitViewport);
+      }
     } else if (routeViewIsXML) {
       this.showDetail = false;
       this.showXML = true;
@@ -180,6 +181,8 @@ export class Design {
 
       this.showDiffView();
     }
+
+    this.routeView = routeParameters.view;
 
     this.eventAggregator.publish(environment.events.navBar.noValidationError);
   }


### PR DESCRIPTION
## Changes

1. Remove force option for setting viewer viewport
2. Fix publishing event to fit the viewport

Fixes this bug:
![viewport-bug](https://user-images.githubusercontent.com/17065920/87317104-da4b0480-c526-11ea-8546-74376dc08f03.gif)

## Issues

PR: #2052 

## How to test the changes

- try to reproduce the behavior on the gif above
