### PR TITLE
✨Support not Qname valid diagrams

### DIFF
--- a/aurelia_project/environments/dev.ts
+++ b/aurelia_project/environments/dev.ts
@@ -85,6 +85,7 @@ export default {
       bindKeyboard: 'design:keyboard:bind',
       unbindKeyboard: 'design:keyboard:unbind',
       fitViewport: 'design:detailview:fitviewport',
+      showIncompatibleDiagramModal: 'design:incompatiblediagram',
     },
     diffView: {
       changeDiffMode: 'diffview:diffmode:change',

--- a/src/modules/design/bpmn-diff-view/bpmn-diff-view.ts
+++ b/src/modules/design/bpmn-diff-view/bpmn-diff-view.ts
@@ -35,7 +35,7 @@ import environment from '../../../environment';
 import {ElementNameService} from '../../../services/elementname-service/elementname.service';
 import {NotificationService} from '../../../services/notification-service/notification.service';
 import {SolutionService} from '../../../services/solution-service/solution.service';
-import {getValidXml} from '../../../services/xml-id-validation-module/xml-id-validation-module';
+import {getIllegalIdErrors, getValidXml} from '../../../services/xml-id-validation-module/xml-id-validation-module';
 
 @inject('NotificationService', EventAggregator, 'SolutionService')
 export class BpmnDiffView {
@@ -561,17 +561,14 @@ export class BpmnDiffView {
 
     const result = await viewer.importXML(xml);
     const {warnings} = result;
-    if (warnings.length !== 0) {
-      const illegalIdErrors = warnings.filter((warning) => {
-        return warning.error?.message?.startsWith('illegal ID');
-      });
 
-      if (illegalIdErrors.length > 0) {
-        const {xml: newXml} = getValidXml(xml, illegalIdErrors);
-        await this.importXml(newXml, viewer);
-        return;
-      }
+    const illegalIdErrors = getIllegalIdErrors(warnings);
+    if (illegalIdErrors.length > 0) {
+      const {xml: newXml} = getValidXml(xml, illegalIdErrors);
+      await this.importXml(newXml, viewer);
+      return;
     }
+
     this.fitDiagramToViewport(viewer);
   }
 

--- a/src/modules/design/bpmn-diff-view/bpmn-diff-view.ts
+++ b/src/modules/design/bpmn-diff-view/bpmn-diff-view.ts
@@ -35,6 +35,7 @@ import environment from '../../../environment';
 import {ElementNameService} from '../../../services/elementname-service/elementname.service';
 import {NotificationService} from '../../../services/notification-service/notification.service';
 import {SolutionService} from '../../../services/solution-service/solution.service';
+import {getValidXml} from '../../../services/xml-id-validation-module/xml-id-validation-module';
 
 @inject('NotificationService', EventAggregator, 'SolutionService')
 export class BpmnDiffView {
@@ -558,7 +559,19 @@ export class BpmnDiffView {
       return;
     }
 
-    await viewer.importXML(xml);
+    const result = await viewer.importXML(xml);
+    const {warnings} = result;
+    if (warnings.length !== 0) {
+      const illegalIdErrors = warnings.filter((warning) => {
+        return warning.error?.message?.startsWith('illegal ID');
+      });
+
+      if (illegalIdErrors.length > 0) {
+        const {xml: newXml} = getValidXml(xml, illegalIdErrors);
+        await this.importXml(newXml, viewer);
+        return;
+      }
+    }
     this.fitDiagramToViewport(viewer);
   }
 

--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -38,6 +38,7 @@ import {DiagramExportService, DiagramPrintService} from './services/index';
 import {UserConfigService} from '../../../services/user-config-service/user-config.service';
 import {solutionIsRemoteSolution} from '../../../services/solution-is-remote-solution-module/solution-is-remote-solution.module';
 import {isRunningInElectron} from '../../../services/is-running-in-electron-module/is-running-in-electron.module';
+import {getValidXml} from '../../../services/xml-id-validation-module/xml-id-validation-module';
 
 const sideBarRightSize: number = 35;
 
@@ -741,6 +742,25 @@ export class BpmnIo {
       const result = await this.modeler.importXML(xml);
       const {warnings} = result;
       if (warnings.length !== 0) {
+        const illegalIdErrors = warnings.filter((warning) => {
+          return warning.error?.message?.startsWith('illegal ID');
+        });
+
+        if (illegalIdErrors.length > 0) {
+          const validationResult = getValidXml(xml, illegalIdErrors);
+          this.xml = validationResult.xml;
+          await this.modeler.importXML(this.xml);
+
+          if (!this.solutionIsRemote) {
+            this.eventAggregator.publish(
+              environment.events.bpmnio.showIncompatibleDiagramModal,
+              validationResult.renamedIds,
+            );
+          }
+        }
+      }
+
+      if (warnings.length !== 0) {
         console.warn(warnings);
       }
     } catch (error) {
@@ -755,7 +775,14 @@ export class BpmnIo {
       const result = await this.viewer.importXML(xml);
       const {warnings} = result;
       if (warnings.length !== 0) {
-        console.warn(warnings);
+        const illegalIdErrors = warnings.filter((warning) => {
+          return warning.error?.message?.startsWith('illegal ID');
+        });
+
+        if (illegalIdErrors.length > 0) {
+          const {xml: newXml} = getValidXml(xml, illegalIdErrors);
+          await this.importXmlIntoViewer(newXml);
+        }
       }
     } catch (error) {
       throw new Error(

--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -38,7 +38,7 @@ import {DiagramExportService, DiagramPrintService} from './services/index';
 import {UserConfigService} from '../../../services/user-config-service/user-config.service';
 import {solutionIsRemoteSolution} from '../../../services/solution-is-remote-solution-module/solution-is-remote-solution.module';
 import {isRunningInElectron} from '../../../services/is-running-in-electron-module/is-running-in-electron.module';
-import {getValidXml} from '../../../services/xml-id-validation-module/xml-id-validation-module';
+import {getIllegalIdErrors, getValidXml} from '../../../services/xml-id-validation-module/xml-id-validation-module';
 
 const sideBarRightSize: number = 35;
 
@@ -741,22 +741,18 @@ export class BpmnIo {
     try {
       const result = await this.modeler.importXML(xml);
       const {warnings} = result;
-      if (warnings.length !== 0) {
-        const illegalIdErrors = warnings.filter((warning) => {
-          return warning.error?.message?.startsWith('illegal ID');
-        });
 
-        if (illegalIdErrors.length > 0) {
-          const validationResult = getValidXml(xml, illegalIdErrors);
-          this.xml = validationResult.xml;
-          await this.modeler.importXML(this.xml);
+      const illegalIdErrors = getIllegalIdErrors(warnings);
+      if (illegalIdErrors.length > 0) {
+        const validationResult = getValidXml(xml, illegalIdErrors);
+        this.xml = validationResult.xml;
+        await this.modeler.importXML(this.xml);
 
-          if (!this.solutionIsRemote) {
-            this.eventAggregator.publish(
-              environment.events.bpmnio.showIncompatibleDiagramModal,
-              validationResult.renamedIds,
-            );
-          }
+        if (!this.solutionIsRemote) {
+          this.eventAggregator.publish(
+            environment.events.bpmnio.showIncompatibleDiagramModal,
+            validationResult.renamedIds,
+          );
         }
       }
 
@@ -774,15 +770,11 @@ export class BpmnIo {
     try {
       const result = await this.viewer.importXML(xml);
       const {warnings} = result;
-      if (warnings.length !== 0) {
-        const illegalIdErrors = warnings.filter((warning) => {
-          return warning.error?.message?.startsWith('illegal ID');
-        });
 
-        if (illegalIdErrors.length > 0) {
-          const {xml: newXml} = getValidXml(xml, illegalIdErrors);
-          await this.importXmlIntoViewer(newXml);
-        }
+      const illegalIdErrors = getIllegalIdErrors(warnings);
+      if (illegalIdErrors.length > 0) {
+        const {xml: newXml} = getValidXml(xml, illegalIdErrors);
+        await this.importXmlIntoViewer(newXml);
       }
     } catch (error) {
       throw new Error(

--- a/src/modules/design/design.html
+++ b/src/modules/design/design.html
@@ -114,7 +114,7 @@
     <modal if.bind="showIncompatibleWarning"
           header-text="Incompatible Diagram">
       <template replace-part="modal-body">
-        <p>The given diagram was incompatible because it contained IDs that were not QName compliant. BPMN Studio has automatically changed these incompatible IDs to compatible IDs. These changes have been not been saved to disk yet. You can save them at your discretion.</p>
+        <p>The given diagram contains IDs, that are not QName compliant. Since BPMN Studio only supports QName compliant IDs, the affected IDs were adjusted accordingly.</p>
 
         <div>
           <span>The following IDs were renamed:</span>

--- a/src/modules/design/design.html
+++ b/src/modules/design/design.html
@@ -124,8 +124,8 @@
         </div>
       </template>
       <template replace-part="modal-footer">
-        <button type="button" class="btn btn-default" data-dismiss="modal" click.delegate="showIncompatibleWarning = false">Cancel</button>
-        <button type="button" class="btn btn-primary" data-dismiss="modal" click.delegate="saveUnsavedChangesToFixIncompatibility()">Save Changes</button>
+        <button type="button" class="btn btn-default" data-dismiss="modal" click.delegate="saveUnsavedChangesToFixIncompatibility()">Save and show diagram</button>
+        <button type="button" class="btn btn-primary" data-dismiss="modal" click.delegate="showIncompatibleWarning = false">Show diagram</button>
       </template>
     </modal>
   </div>

--- a/src/modules/design/design.html
+++ b/src/modules/design/design.html
@@ -119,7 +119,7 @@
         <div>
           <span>The following IDs were renamed:</span>
           <ul>
-            <li repeat.for="renamedId of renamedIds">${renamedId.previousId} to ${renamedId.newId}</li>
+            <li repeat.for="renamedId of renamedIds"><code>${renamedId.previousId}</code> to <code>${renamedId.newId}</code></li>
           </ul>
         </div>
       </template>

--- a/src/modules/design/design.html
+++ b/src/modules/design/design.html
@@ -114,7 +114,7 @@
     <modal if.bind="showIncompatibleWarning"
           header-text="Incompatible Diagram">
       <template replace-part="modal-body">
-        <p>The given diagram was incompatible because it contained IDs that were not QName compliant. BPMN Studio has automatically changed these incompatible IDs to compatible IDs. The diagram now has unsaved changes that can be saved at your own risk.</p>
+        <p>The given diagram was incompatible because it contained IDs that were not QName compliant. BPMN Studio has automatically changed these incompatible IDs to compatible IDs. These changes have been not been saved to disk yet. You can save them at your discretion.</p>
 
         <div>
           <span>The following IDs were renamed:</span>

--- a/src/modules/design/design.html
+++ b/src/modules/design/design.html
@@ -110,5 +110,23 @@
         <button type="button" class="btn btn-primary" data-dismiss="modal" id="js-choose-diagram" click.delegate="setDiffDestination(selectedDiagram.solutionUri, selectedDiagram.diagram.name)">Compare</button>
       </template>
     </modal>
+
+    <modal if.bind="showIncompatibleWarning"
+          header-text="Incompatible Diagram">
+      <template replace-part="modal-body">
+        <p>The given diagram was incompatible because it contained IDs that were not QName compliant. BPMN Studio has automatically changed these incompatible IDs to compatible IDs. The diagram now has unsaved changes that can be saved at your own risk.</p>
+
+        <div>
+          <span>The following IDs were renamed:</span>
+          <ul>
+            <li repeat.for="renamedId of renamedIds">${renamedId.previousId} to ${renamedId.newId}</li>
+          </ul>
+        </div>
+      </template>
+      <template replace-part="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal" click.delegate="showIncompatibleWarning = false">Cancel</button>
+        <button type="button" class="btn btn-primary" data-dismiss="modal" click.delegate="saveUnsavedChangesToFixIncompatibility()">Save Changes</button>
+      </template>
+    </modal>
   </div>
 </template>

--- a/src/modules/design/design.ts
+++ b/src/modules/design/design.ts
@@ -46,12 +46,14 @@ export class Design {
   public propertyPanelShown: boolean = false;
   public showPropertyPanelButton: boolean = true;
   public showDiffDestinationButton: boolean = false;
+  public showIncompatibleWarning: boolean = false;
   public design: Design = this;
 
   public diagramDetail: DiagramDetail;
   public filteredSolutions: Array<ISolution> = [];
   public diagramArray: Array<IDiagram | object> = [];
   public selectedDiagram: DiagramWithSolution;
+  public renamedIds: Array<any> = [];
 
   private eventAggregator: EventAggregator;
   private notificationService: NotificationService;
@@ -213,6 +215,10 @@ export class Design {
         this.xmlForDiff = newXml;
         this.activeDiagram.xml = newXml;
       }),
+      this.eventAggregator.subscribe(environment.events.bpmnio.showIncompatibleDiagramModal, (renamedIds) => {
+        this.renamedIds = renamedIds;
+        this.showIncompatibleWarning = true;
+      }),
     ];
 
     if (isRunningInElectron()) {
@@ -243,6 +249,11 @@ export class Design {
     this.eventAggregator.publish(environment.events.diffView.setDiffDestination, [diffDestination, diagramName]);
 
     this.showSelectDiagramModal = false;
+  }
+
+  public async saveUnsavedChangesToFixIncompatibility(): Promise<void> {
+    await this.diagramDetail.saveDiagram();
+    this.showIncompatibleWarning = false;
   }
 
   public async openSelectDiagramModal(): Promise<void> {

--- a/src/modules/design/property-panel/property-panel.ts
+++ b/src/modules/design/property-panel/property-panel.ts
@@ -103,6 +103,10 @@ export class PropertyPanel {
       return element.$type === 'bpmn:Process';
     });
 
+    if (process == null) {
+      return;
+    }
+
     const processHasFlowElements: boolean = process.flowElements !== undefined && process.flowElements !== null;
 
     if (processHasFlowElements) {

--- a/src/modules/inspect/heatmap/heatmap.ts
+++ b/src/modules/inspect/heatmap/heatmap.ts
@@ -15,7 +15,7 @@ import {
 
 import {IFlowNodeAssociation, IHeatmapService} from './contracts';
 import {solutionIsRemoteSolution} from '../../../services/solution-is-remote-solution-module/solution-is-remote-solution.module';
-import {getValidXml} from '../../../services/xml-id-validation-module/xml-id-validation-module';
+import {getIllegalIdErrors, getValidXml} from '../../../services/xml-id-validation-module/xml-id-validation-module';
 
 @inject('HeatmapService')
 export class Heatmap {
@@ -77,16 +77,13 @@ export class Heatmap {
 
     const result = await this.modeler.importXML(this.activeDiagram.xml);
     const {warnings} = result;
-    if (warnings.length !== 0) {
-      const illegalIdErrors = warnings.filter((warning) => {
-        return warning.error?.message?.startsWith('illegal ID');
-      });
 
-      if (illegalIdErrors.length > 0) {
-        const {xml: newXml} = getValidXml(this.activeDiagram.xml, illegalIdErrors);
-        await this.modeler.importXML(newXml);
-      }
+    const illegalIdErrors = getIllegalIdErrors(warnings);
+    if (illegalIdErrors.length > 0) {
+      const {xml: newXml} = getValidXml(this.activeDiagram.xml, illegalIdErrors);
+      await this.modeler.importXML(newXml);
     }
+
     const elementRegistry: IElementRegistry = this.modeler.get('elementRegistry');
     /*
      * TODO: Refactoring opportunity; HeatmapService could use a fluent API; This is how it would look like:

--- a/src/modules/inspect/heatmap/heatmap.ts
+++ b/src/modules/inspect/heatmap/heatmap.ts
@@ -15,6 +15,7 @@ import {
 
 import {IFlowNodeAssociation, IHeatmapService} from './contracts';
 import {solutionIsRemoteSolution} from '../../../services/solution-is-remote-solution-module/solution-is-remote-solution.module';
+import {getValidXml} from '../../../services/xml-id-validation-module/xml-id-validation-module';
 
 @inject('HeatmapService')
 export class Heatmap {
@@ -74,8 +75,18 @@ export class Heatmap {
       },
     });
 
-    await this.modeler.importXML(this.activeDiagram.xml);
+    const result = await this.modeler.importXML(this.activeDiagram.xml);
+    const {warnings} = result;
+    if (warnings.length !== 0) {
+      const illegalIdErrors = warnings.filter((warning) => {
+        return warning.error?.message?.startsWith('illegal ID');
+      });
 
+      if (illegalIdErrors.length > 0) {
+        const {xml: newXml} = getValidXml(this.activeDiagram.xml, illegalIdErrors);
+        await this.modeler.importXML(newXml);
+      }
+    }
     const elementRegistry: IElementRegistry = this.modeler.get('elementRegistry');
     /*
      * TODO: Refactoring opportunity; HeatmapService could use a fluent API; This is how it would look like:

--- a/src/modules/live-execution-tracker/live-execution-tracker.ts
+++ b/src/modules/live-execution-tracker/live-execution-tracker.ts
@@ -32,7 +32,7 @@ import environment from '../../environment';
 import {NotificationService} from '../../services/notification-service/notification.service';
 import {TaskDynamicUi} from '../task-dynamic-ui/task-dynamic-ui';
 import {ILiveExecutionTrackerService, RequestError} from './contracts/index';
-import {getValidXml} from '../../services/xml-id-validation-module/xml-id-validation-module';
+import {getIllegalIdErrors, getValidXml} from '../../services/xml-id-validation-module/xml-id-validation-module';
 
 type RouteParameters = {
   diagramName: string;
@@ -857,15 +857,11 @@ export class LiveExecutionTracker {
 
     const result = await this.diagramViewer.importXML(xml);
     const {warnings} = result;
-    if (warnings.length !== 0) {
-      const illegalIdErrors = warnings.filter((warning) => {
-        return warning.error?.message?.startsWith('illegal ID');
-      });
 
-      if (illegalIdErrors.length > 0) {
-        const {xml: newXml} = getValidXml(xml, illegalIdErrors);
-        await this.importXmlIntoDiagramViewer(newXml);
-      }
+    const illegalIdErrors = getIllegalIdErrors(warnings);
+    if (illegalIdErrors.length > 0) {
+      const {xml: newXml} = getValidXml(xml, illegalIdErrors);
+      await this.importXmlIntoDiagramViewer(newXml);
     }
   }
 
@@ -886,15 +882,11 @@ export class LiveExecutionTracker {
 
     const result = await this.diagramPreviewViewer.importXML(xml);
     const {warnings} = result;
-    if (warnings.length !== 0) {
-      const illegalIdErrors = warnings.filter((warning) => {
-        return warning.error?.message?.startsWith('illegal ID');
-      });
 
-      if (illegalIdErrors.length > 0) {
-        const {xml: newXml} = getValidXml(xml, illegalIdErrors);
-        await this.importXmlIntoDiagramPreviewViewer(newXml);
-      }
+    const illegalIdErrors = getIllegalIdErrors(warnings);
+    if (illegalIdErrors.length > 0) {
+      const {xml: newXml} = getValidXml(xml, illegalIdErrors);
+      await this.importXmlIntoDiagramPreviewViewer(newXml);
     }
   }
 

--- a/src/services/deploy-diagram-service/deploy-diagram.service.ts
+++ b/src/services/deploy-diagram-service/deploy-diagram.service.ts
@@ -121,7 +121,7 @@ export class DeployDiagramService {
 
     const processModel: IModdleElement = rootElements.find((definition: IModdleElement) => {
       return definition.$type === 'bpmn:Process';
-      });
+    });
     const processModelId: string = processModel.id;
 
     return processModelId;

--- a/src/services/xml-id-validation-module/xml-id-validation-module.ts
+++ b/src/services/xml-id-validation-module/xml-id-validation-module.ts
@@ -1,3 +1,15 @@
+export function getIllegalIdErrors(warnings: Array<any>): Array<any> {
+  if (warnings.length !== 0) {
+    const illegalIdErrors = warnings.filter((warning) => {
+      return warning.error?.message?.startsWith('illegal ID');
+    });
+
+    return illegalIdErrors;
+  }
+
+  return [];
+}
+
 export function getValidXml(xml: string, illegalIdErrors: Array<any>): any {
   let newXml = xml;
   const renamedIds: Array<any> = [];

--- a/src/services/xml-id-validation-module/xml-id-validation-module.ts
+++ b/src/services/xml-id-validation-module/xml-id-validation-module.ts
@@ -1,0 +1,57 @@
+export function getValidXml(xml: string, illegalIdErrors: Array<any>): any {
+  let newXml = xml;
+  const renamedIds: Array<any> = [];
+  for (const idError of illegalIdErrors) {
+    const errorId = (idError.error.message as string).substring(12, idError.error.message.length - 1);
+    const qNameRegex: RegExp = /^([a-z][\w-.]*:)?[a-z_][\w-.]*$/i;
+
+    const invalidChars = getInvalidCharacters(errorId);
+
+    let newId = errorId;
+    for (const invalidChar of invalidChars) {
+      newId = newId.replace(invalidChar, '_');
+    }
+
+    const invalidFirstCharacterRegex: RegExp = /^[\d-.:]/i;
+    if (newId.match(invalidFirstCharacterRegex) != null) {
+      newId = `_${newId}`;
+    }
+
+    const endsWithAllowedCharactersRegex: RegExp = /[\w-.]*$/i;
+    if (!endsWithAllowedCharactersRegex.test(newId)) {
+      newId = `${newId}_`;
+    }
+
+    if (qNameRegex.test(newId)) {
+      const escapedRegexString = escapeRegExp(errorId);
+      const idRegex = new RegExp(`"${escapedRegexString}"`, 'g');
+      newXml = newXml.replace(idRegex, `"${newId}"`);
+
+      renamedIds.push({
+        previousId: errorId,
+        newId: newId,
+      });
+    }
+  }
+
+  return {
+    xml: newXml,
+    renamedIds: renamedIds,
+  };
+}
+
+function escapeRegExp(string): string {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function getInvalidCharacters(input: string): Array<string> {
+  const qNameValidationRegex: RegExp = /^[\w-.]/i;
+  const inputLetters: Array<string> = input.split('');
+  const invalidCharacters: Array<string> = inputLetters.filter((letter: string) => {
+    const letterIsInvalid: boolean = letter.match(qNameValidationRegex) == null;
+
+    return letterIsInvalid;
+  });
+
+  return invalidCharacters;
+}

--- a/src/services/xml-id-validation-module/xml-id-validation-module.ts
+++ b/src/services/xml-id-validation-module/xml-id-validation-module.ts
@@ -2,7 +2,7 @@ export function getValidXml(xml: string, illegalIdErrors: Array<any>): any {
   let newXml = xml;
   const renamedIds: Array<any> = [];
   for (const idError of illegalIdErrors) {
-    const errorId = (idError.error.message as string).substring(12, idError.error.message.length - 1);
+    const errorId = idError.error.message.substring(12, idError.error.message.length - 1);
     const qNameRegex: RegExp = /^([a-z][\w-.]*:)?[a-z_][\w-.]*$/i;
 
     const invalidChars = getInvalidCharacters(errorId);

--- a/src/services/xml-id-validation-module/xml-id-validation-module.ts
+++ b/src/services/xml-id-validation-module/xml-id-validation-module.ts
@@ -1,13 +1,19 @@
 export function getValidXml(xml: string, illegalIdErrors: Array<any>): any {
   let newXml = xml;
   const renamedIds: Array<any> = [];
-  for (const idError of illegalIdErrors) {
-    const errorId = idError.error.message.substring(12, idError.error.message.length - 1);
+  for (const illegalIdError of illegalIdErrors) {
+    /**
+     * The error message e.g. looks like "illegal ID <Auf Rückmeldung warten>"
+     *  We need to get the ID between the "<>" characters. It starts after the first 12 characters.
+     */
+    const idStartIndex = 12;
+    const idEndIndex = illegalIdError.error.message.length - 1;
+    const idWhichCausedTheError = illegalIdError.error.message.substring(idStartIndex, idEndIndex);
     const qNameRegex: RegExp = /^([a-z][\w-.]*:)?[a-z_][\w-.]*$/i;
 
-    const invalidChars = getInvalidCharacters(errorId);
+    const invalidChars = getInvalidCharacters(idWhichCausedTheError);
 
-    let newId = errorId;
+    let newId = idWhichCausedTheError;
     for (const invalidChar of invalidChars) {
       newId = newId.replace(invalidChar, '_');
     }
@@ -23,12 +29,12 @@ export function getValidXml(xml: string, illegalIdErrors: Array<any>): any {
     }
 
     if (qNameRegex.test(newId)) {
-      const escapedRegexString = escapeRegExp(errorId);
+      const escapedRegexString = escapeRegExp(idWhichCausedTheError);
       const idRegex = new RegExp(`"${escapedRegexString}"`, 'g');
       newXml = newXml.replace(idRegex, `"${newId}"`);
 
       renamedIds.push({
-        previousId: errorId,
+        previousId: idWhichCausedTheError,
         newId: newId,
       });
     }

--- a/src/services/xml-id-validation-module/xml-id-validation-module.ts
+++ b/src/services/xml-id-validation-module/xml-id-validation-module.ts
@@ -42,8 +42,8 @@ export function getValidXml(xml: string, illegalIdErrors: Array<any>): any {
 
     if (qNameRegex.test(newId)) {
       const escapedRegexString = escapeRegExp(idWhichCausedTheError);
-      const idRegex = new RegExp(`"${escapedRegexString}"`, 'g');
-      newXml = newXml.replace(idRegex, `"${newId}"`);
+      const idRegex = new RegExp(`(id|Ref)="${escapedRegexString}"`, 'g');
+      newXml = newXml.replace(idRegex, `$1="${newId}"`);
 
       renamedIds.push({
         previousId: idWhichCausedTheError,


### PR DESCRIPTION
## Changes

1. Add and use getValidXml function if a diagram contains invalid IDs.
2. Show "Incompatible Diagram" warning modal on the design view.

<img width="548" alt="Bildschirmfoto 2020-07-15 um 14 58 59" src="https://user-images.githubusercontent.com/17065920/87547766-dac0d800-c6ab-11ea-968b-e63dfee11393.png">




## Issues

PR: #2053 

## How to test the changes

open a diagram with an incompatible ID e.g a whitespace character.
