### PR TITLE
✨ Make width of payload modal resizable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bpmn-studio",
-  "version": "6.0.0-beta.15",
+  "version": "6.0.0-alpha.50",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.html
@@ -23,7 +23,8 @@
   </div>
 
   <modal if.bind="showModal"
-         header-text="Editing: Payload">
+         header-text="Editing: Payload"
+         modal-style="width: max-content; max-width: 90%;">
     <template replace-part="modal-body" autofocus>
       <textarea class="form-control payload" value.bind="selectedPayload" change.delegate="payloadChanged()" rows="10" aria-multiline="true" autofocus wrap="soft" disabled.bind="!model.isEditable"></textarea>
     </template>

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.scss
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/components/external-task/external-task.scss
@@ -10,4 +10,7 @@
 .payload {
   min-height: 55px;
   max-height: 400px;
+  min-width: 470px;
+  max-width: 100%;
+  resize: both;
 }


### PR DESCRIPTION
## Changes

1. Make width of payload modal resizable

## Issues

Closes #2049 

PR: #2059

## How to test the changes

- Create a diagram
- Add a ServiceTask
- Select 'External Task' as kind
- Click on the 'Enlarge' button of the payload field
- Resize the textarea