### PR TITLE
🐛Fix xml id validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bpmn-studio",
+  "name": "bpmn-studio-alpha",
   "description": "An Aurelia application for designing BPMN diagrams, which can also be connected to a process engine to execute these diagrams.",
   "version": "6.0.0-alpha.52",
   "author": {

--- a/src/modules/design/bpmn-io/bpmn-io.ts
+++ b/src/modules/design/bpmn-io/bpmn-io.ts
@@ -746,7 +746,7 @@ export class BpmnIo {
       if (illegalIdErrors.length > 0) {
         const validationResult = getValidXml(xml, illegalIdErrors);
         this.xml = validationResult.xml;
-        await this.modeler.importXML(this.xml);
+        await this.importXmlIntoModeler(this.xml);
 
         if (!this.solutionIsRemote) {
           this.eventAggregator.publish(

--- a/src/modules/design/design.html
+++ b/src/modules/design/design.html
@@ -125,7 +125,7 @@
       </template>
       <template replace-part="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal" click.delegate="saveUnsavedChangesToFixIncompatibility()">Save and show diagram</button>
-        <button type="button" class="btn btn-primary" data-dismiss="modal" click.delegate="showIncompatibleWarning = false">Show diagram</button>
+        <button type="button" class="btn btn-primary" data-dismiss="modal" click.delegate="closeIncompatibilityModal()">Show diagram</button>
       </template>
     </modal>
   </div>

--- a/src/modules/design/design.ts
+++ b/src/modules/design/design.ts
@@ -216,7 +216,16 @@ export class Design {
         this.activeDiagram.xml = newXml;
       }),
       this.eventAggregator.subscribe(environment.events.bpmnio.showIncompatibleDiagramModal, (renamedIds) => {
-        this.renamedIds = renamedIds;
+        for (const renamedId of renamedIds) {
+          const idExistInRenamedIds = this.renamedIds.some(
+            (id) => id.previousId === renamedId.previousId && id.newId === renamedId.newId,
+          );
+          if (idExistInRenamedIds) {
+            continue;
+          }
+
+          this.renamedIds.push(renamedId);
+        }
         this.showIncompatibleWarning = true;
       }),
     ];
@@ -254,6 +263,12 @@ export class Design {
   public async saveUnsavedChangesToFixIncompatibility(): Promise<void> {
     await this.diagramDetail.saveDiagram();
     this.showIncompatibleWarning = false;
+    this.renamedIds = [];
+  }
+
+  public closeIncompatibilityModal(): void {
+    this.showIncompatibleWarning = false;
+    this.renamedIds = [];
   }
 
   public async openSelectDiagramModal(): Promise<void> {

--- a/src/services/xml-id-validation-module/xml-id-validation-module.ts
+++ b/src/services/xml-id-validation-module/xml-id-validation-module.ts
@@ -42,8 +42,11 @@ export function getValidXml(xml: string, illegalIdErrors: Array<any>): any {
 
     if (qNameRegex.test(newId)) {
       const escapedRegexString = escapeRegExp(idWhichCausedTheError);
-      const idRegex = new RegExp(`(id|Ref)="${escapedRegexString}"`, 'g');
+      const idRegex = new RegExp(`(id|Ref|bpmnElement)="${escapedRegexString}"`, 'g');
+      const flowNodeRefRegex = new RegExp(`Ref>${escapedRegexString}<`, 'g');
+
       newXml = newXml.replace(idRegex, `$1="${newId}"`);
+      newXml = newXml.replace(flowNodeRefRegex, `Ref>${newId}<`);
 
       renamedIds.push({
         previousId: idWhichCausedTheError,


### PR DESCRIPTION
## Changes

1. Call importXmlIntoModeler instead of modeler.importXML to handle illegal ID errors
2. Fix bug where the ID was not set at every reference
3. Fix bug where not all IDs were shown in the incompatible warning modal

## Issues

PR: #2062 

## How to test the changes

try to import this diagram:
[22.bpmn.zip](https://github.com/process-engine/bpmn-studio/files/5016026/22.bpmn.zip)

