### PR TITLE
🐛 Fix maximum callstack size error

### DIFF
--- a/src/modules/custom_elements/modal/modal.ts
+++ b/src/modules/custom_elements/modal/modal.ts
@@ -13,16 +13,17 @@ export class ModalCustomElement {
 
   private modalRef: HTMLDivElement;
 
-  public attached(): void {
+  public bind(): void {
     document.addEventListener('focusin', this.focusEventListener);
   }
 
-  public detached(): void {
+  public unbind(): void {
     document.removeEventListener('focusin', this.focusEventListener);
   }
 
   private focusEventListener = (event): void => {
-    const focussedElementIsInModalOrTheModal = this.modalRef.contains(event.target);
+    const focussedElementIsInModalOrTheModal =
+      this.modalRef.contains(event.target) || event.target.className.includes('modal show show-modal');
 
     if (!focussedElementIsInModalOrTheModal) {
       this.modalRef.focus();

--- a/src/modules/navbar/navbar.ts
+++ b/src/modules/navbar/navbar.ts
@@ -435,6 +435,7 @@ export class NavBar {
     const noDiagramIsActive: boolean = this.activeDiagram === undefined;
     if (noDiagramIsActive) {
       this.ipcRenderer.send('close_bpmn-studio');
+      return;
     }
 
     if (solutionIsRemoteSolution(this.activeSolutionEntry.uri)) {

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.html
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.html
@@ -102,13 +102,13 @@
   <!--Delete Diagram Modal-->
   <delete-diagram-modal active-diagram="activeDiagram" view-model.ref="deleteDiagramModal"></delete-diagram-modal>
 
-  <modal show.bind="showCloseModal"
+  <modal if.bind="showCloseModal"
          header-text="Document Contains Changes"
          body-text="Your diagram has unsaved changes. Save changes to diagram before closing?">
     <template replace-part="modal-footer">
-      <button type="button" class="btn btn-default" data-dismiss="modal" id="cancelButtonCloseView">Cancel</button>
-      <button type="button" class="btn btn-secondary" data-dismiss="modal" id="dontSaveButtonCloseView">Don't save</button>
-      <button type="button" class="btn btn-primary" data-dismiss="modal" id="saveButtonCloseView">Save</button>
+      <button type="button" class="btn btn-default" data-dismiss="modal" click.delegate="cancelFunction()">Cancel</button>
+      <button type="button" class="btn btn-secondary" data-dismiss="modal" click.delegate="dontSaveFunction()">Don't save</button>
+      <button type="button" class="btn btn-primary" data-dismiss="modal" click.delegate="saveFunction()">Save</button>
     </template>
   </modal>
 

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -991,6 +991,10 @@ export class SolutionExplorerSolution {
   }
 
   private async closeOpenDiagram(diagramToClose: IDiagram): Promise<void> {
+    if (!this.displayedSolutionEntry.isOpenDiagram) {
+      return;
+    }
+
     const openDiagramService: OpenDiagramsSolutionExplorerService = this
       .solutionService as OpenDiagramsSolutionExplorerService;
 

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -144,6 +144,10 @@ export class SolutionExplorerSolution {
 
   private shouldRefreshOnTokenRefresh: boolean = false;
 
+  private saveFunction: EventListenerOrEventListenerObject;
+  private dontSaveFunction: EventListenerOrEventListenerObject;
+  private cancelFunction: EventListenerOrEventListenerObject;
+
   constructor(
     router: Router,
     eventAggregator: EventAggregator,
@@ -1013,21 +1017,16 @@ export class SolutionExplorerSolution {
     }
 
     const modalResult: Promise<CloseModalResult> = new Promise((resolve: Function): CloseModalResult | void => {
-      const dontSaveFunction: EventListenerOrEventListenerObject = async (): Promise<void> => {
-        this.showCloseModal = false;
-
-        document.getElementById('dontSaveButtonCloseView').removeEventListener('click', dontSaveFunction);
-        document.getElementById('saveButtonCloseView').removeEventListener('click', saveFunction);
-        document.getElementById('cancelButtonCloseView').removeEventListener('click', cancelFunction);
-
+      this.dontSaveFunction = async (): Promise<void> => {
         if (diagramToSaveIsNotActiveDiagram && shouldNavigate) {
           await this.navigateBack();
         }
 
         resolve(CloseModalResult.Delete);
+        this.showCloseModal = false;
       };
 
-      const saveFunction: EventListenerOrEventListenerObject = async (): Promise<void> => {
+      this.saveFunction = async (): Promise<void> => {
         this.eventAggregator.subscribeOnce(environment.events.diagramWasSaved, async () => {
           if (shouldNavigate) {
             await this.navigateBack();
@@ -1039,30 +1038,16 @@ export class SolutionExplorerSolution {
         this.eventAggregator.publish(environment.events.diagramDetail.saveDiagram);
 
         this.showCloseModal = false;
-
-        document.getElementById('dontSaveButtonCloseView').removeEventListener('click', dontSaveFunction);
-        document.getElementById('saveButtonCloseView').removeEventListener('click', saveFunction);
-        document.getElementById('cancelButtonCloseView').removeEventListener('click', cancelFunction);
       };
 
-      const cancelFunction: EventListenerOrEventListenerObject = async (): Promise<void> => {
-        this.showCloseModal = false;
-
-        document.getElementById('dontSaveButtonCloseView').removeEventListener('click', dontSaveFunction);
-        document.getElementById('saveButtonCloseView').removeEventListener('click', saveFunction);
-        document.getElementById('cancelButtonCloseView').removeEventListener('click', cancelFunction);
-
+      this.cancelFunction = async (): Promise<void> => {
         if (diagramToSaveIsNotActiveDiagram && shouldNavigate) {
           await this.navigateBack();
         }
 
         resolve(CloseModalResult.Cancel);
+        this.showCloseModal = false;
       };
-
-      // register onClick handler
-      document.getElementById('dontSaveButtonCloseView').addEventListener('click', dontSaveFunction);
-      document.getElementById('saveButtonCloseView').addEventListener('click', saveFunction);
-      document.getElementById('cancelButtonCloseView').addEventListener('click', cancelFunction);
 
       this.showCloseModal = true;
     });

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -490,6 +490,14 @@ export class SolutionExplorerSolution {
       event.stopPropagation();
     }
 
+    if (diagram == null) {
+      return undefined;
+    }
+
+    if (!this.displayedSolutionEntry.isOpenDiagram) {
+      return undefined;
+    }
+
     const diagramState: IDiagramState = this.openDiagramStateService.loadDiagramState(diagram.uri);
     const diagramHasUnsavedChanges: boolean = diagramState !== null && diagramState.metadata.isChanged;
 


### PR DESCRIPTION

## Changes

1. Fix bug where the focus listener does not get removed
2. Fix bug where the diagram could be undefined and a bug where the method is called for wrong solutions
3. Fix bug where closeOpenDiagram is called for all solutions instead only for the open diagram solution
4. Use show bind and remove registering click handlers to handle the modal button clicks 

## Issues

Fixes this bug:
<img width="1412" alt="Bildschirmfoto 2020-08-03 um 13 15 24" src="https://user-images.githubusercontent.com/17065920/89194325-807aaf00-d5a7-11ea-8c87-24b7c5fb1831.png">


PR: #2063

## How to test the changes

try to reproduce this video:

[Aug-03-2020 13-13-23.mp4.zip](https://github.com/process-engine/bpmn-studio/files/5016609/Aug-03-2020.13-13-23.mp4.zip)

