### PR TITLE
🐛Fix bug where duplicating a diagram provides an invalid diagram name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bpmn-studio-alpha",
   "description": "An Aurelia application for designing BPMN diagrams, which can also be connected to a process engine to execute these diagrams.",
-  "version": "6.0.0-alpha.58",
+  "version": "6.1.0",
   "author": {
     "name": "process-engine",
     "email": "hello@process-engine.io",

--- a/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
+++ b/src/modules/solution-explorer/solution-explorer-solution/solution-explorer-solution.ts
@@ -33,6 +33,7 @@ import {SaveDiagramService} from '../../../services/save-diagram-service/save-di
 import {HttpFetchClient} from '../../fetch-http-client/http-fetch-client';
 import {solutionIsRemoteSolution} from '../../../services/solution-is-remote-solution-module/solution-is-remote-solution.module';
 import {isRunningInElectron} from '../../../services/is-running-in-electron-module/is-running-in-electron.module';
+import {getInvalidCharacters} from '../../../services/xml-id-validation-module/xml-id-validation-module';
 
 const ENTER_KEY: string = 'Enter';
 const ESCAPE_KEY: string = 'Escape';
@@ -589,8 +590,14 @@ export class SolutionExplorerSolution {
       return diagram.name !== newName;
     };
 
+    const invalidCharacters = getInvalidCharacters(this.diagramInContextMenu.name);
+    let currentDiagramName = this.diagramInContextMenu.name;
+    for (const invalidCharacter of invalidCharacters) {
+      currentDiagramName = currentDiagramName.replace(invalidCharacter, '_');
+    }
+
     while (newNameFound === false) {
-      newName = `${this.diagramInContextMenu.name} (${diagramNumber})`;
+      newName = `${currentDiagramName}_${diagramNumber}`;
 
       newNameFound = this.openedDiagrams.every(isDiagramNameNotEqualToNewName);
 

--- a/src/services/xml-id-validation-module/xml-id-validation-module.ts
+++ b/src/services/xml-id-validation-module/xml-id-validation-module.ts
@@ -65,7 +65,7 @@ function escapeRegExp(string): string {
   return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-function getInvalidCharacters(input: string): Array<string> {
+export function getInvalidCharacters(input: string): Array<string> {
   const qNameValidationRegex: RegExp = /^[\w-.]/i;
   const inputLetters: Array<string> = input.split('');
   const invalidCharacters: Array<string> = inputLetters.filter((letter: string) => {


### PR DESCRIPTION
## Changes

1. Check if diagram name has invalid characters and replace them

## Issues

Closes #2067 

PR: #2068 

## How to test the changes

try to reproduce the referenced issue
