### PR TITLE
🐛Fix bug where the http-service-task section 

### DIFF
--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/components/http-service-task/http-service-task.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/components/http-service-task/http-service-task.ts
@@ -115,7 +115,12 @@ export class HttpServiceTask {
   }
 
   private fillVariablesFromParam(params: string): void {
-    const parsedParams = JSON.parse(params);
+    let parsedParams = {};
+    try {
+      parsedParams = JSON.parse(params);
+    } catch {
+      // Do nothing
+    }
     this.selectedHttpUrl = parsedParams[0];
     this.selectedHttpBody =
       typeof parsedParams[1] === 'object' ? JSON.stringify(parsedParams[1], null, 2) : parsedParams[1];


### PR DESCRIPTION

## Changes

1. Fix bug where the http-service-task section has crashed if the params could not be parsed

## Issues

PR: #NumberOfThisPR

## How to test the changes

select an http service task where the `params` property is empty or just a string 
