### PR TITLE
🐛 Fix opening diagrams with invalid definition id

### DIFF
--- a/src/services/xml-id-validation-module/xml-id-validation-module.ts
+++ b/src/services/xml-id-validation-module/xml-id-validation-module.ts
@@ -76,3 +76,35 @@ export function getInvalidCharacters(input: string): Array<string> {
 
   return invalidCharacters;
 }
+
+export function tryToFindIllegalIdsAndGenerateError(xml: string): Array<any> {
+  const qNameRegex: RegExp = /^([a-z][\w-.]*:)?[a-z_][\w-.]*$/i;
+
+  const idRegex: RegExp = /id="([^"]*)"/gm;
+  const allIdParts = xml.match(idRegex);
+
+  if (allIdParts != null) {
+    const mappedIds = allIdParts.map((idString) => {
+      const id = idString.replace('id="', '').replace(/"$/g, '');
+
+      return id;
+    });
+
+    const filteredInvalidIds = mappedIds.filter((id) => {
+      const isInvalid = !qNameRegex.test(id);
+      return isInvalid;
+    });
+
+    return [
+      ...filteredInvalidIds.map((invalidId) => {
+        return {
+          error: {
+            message: `illegal ID <${invalidId}>`,
+          },
+        };
+      }),
+    ];
+  }
+
+  return [];
+}


### PR DESCRIPTION
## Changes

1. Fix bug where opening a diagram with an invalid definition ID does not work.

## Issues

PR: #2091 

## How to test the changes

try to open e.g. this diagram:

[core_domain_retry_processinstance.bpmn.zip](https://github.com/process-engine/bpmn-studio/files/5318039/core_domain_retry_processinstance.bpmn.zip)

