### PR TITLE
🐛 Fix wrong package name while building installer

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "electron-build-windows": "npm run electron-build-windows-installer && npm run electron-build-windows-portable",
     "electron-build-windows-installer": "npm run electron-prepare && electron-builder --config build/electron-builder.yml --publish never --windows nsis && npm run electron-cleanup",
     "electron-build-windows-portable": "cross-env IS_PORTABLE_BUILD=true npm run electron-prepare && electron-builder --config build/electron-builder.yml --publish never --windows portable && cross-env IS_PORTABLE_BUILD=true npm run electron-cleanup",
-    "electron-pack-windows": "electron-builder --config build/electron-builder.yml --publish never --windows nsis --prepackaged dist/electron/win-unpacked",
+    "electron-pack-windows": "node electron-builder/set-name-in-package-json.js && electron-builder --config build/electron-builder.yml --publish never --windows nsis --prepackaged dist/electron/win-unpacked && npm run electron-cleanup",
     "electron-build-macos": "npm run electron-prepare && electron-builder --config build/electron-builder.yml --publish never --macos && npm run electron-cleanup",
     "electron-cleanup": "node electron-builder/reset-name-in-package-json.js",
     "electron-prepare": "node electron-builder/set-name-in-package-json.js && npm run build && node electron-builder/prepare-electron-build.js",


### PR DESCRIPTION
## Changes

1. Fix wrong package name while building the installer

## Issues

PR: #2110 

## How to test the changes

> Describe how others can test your changes (not required when fixing typos, linter errors and such)
