### PR TITLE
✨ Notarize macOS builds

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -132,6 +132,8 @@ jobs:
       run: npm run electron-build-macos
       env:
         CSC_LINK: ${{ secrets.CSC_LINK }}
+        APPLE_USERNAME: ${{ secrets.APPLE_USERNAME }}
+        APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
 
     # - name: Run the Tests
     #   run: npm test

--- a/build/code-signing/mac/notarize.js
+++ b/build/code-signing/mac/notarize.js
@@ -1,0 +1,28 @@
+const {notarize} = require('electron-notarize');
+const {getReleaseChannelSuffix} = require('../../../electron-builder/release');
+
+exports.default = async function(context) {
+  if (context.electronPlatformName !== 'darwin') {
+    return;
+  }
+
+  if (!process.env.APPLE_USERNAME || !process.env.APPLE_PASSWORD) {
+    console.warn(
+      '[notarize]\tSkipping notarization: Environment variable "APPLE_USERNAME" and/or "APPLE_PASSWORD" not set.',
+    );
+    return;
+  }
+
+  const appOutDir = context.appOutDir;
+  const appName = context.packager.appInfo.productFilename;
+  const appBundleId = `com.electron.bpmn-studio${getReleaseChannelSuffix()}`;
+
+  console.log(`[notarize]\tNotarizing ${appName}`);
+
+  await notarize({
+    appBundleId: appBundleId,
+    appPath: `${appOutDir}/${appName}.app`,
+    appleId: process.env.APPLE_USERNAME,
+    appleIdPassword: process.env.APPLE_PASSWORD,
+  });
+};

--- a/electron-builder/alpha/electron-builder.yml
+++ b/electron-builder/alpha/electron-builder.yml
@@ -24,3 +24,4 @@ mac:
     - dmg
     - zip
   artifactName: 'bpmn-studio-setup-${version}.${ext}'
+afterSign: "build/code-signing/mac/notarize.js"

--- a/electron-builder/beta/electron-builder.yml
+++ b/electron-builder/beta/electron-builder.yml
@@ -24,3 +24,4 @@ mac:
     - dmg
     - zip
   artifactName: 'bpmn-studio-setup-${version}.${ext}'
+afterSign: "build/code-signing/mac/notarize.js"

--- a/electron-builder/stable/electron-builder.yml
+++ b/electron-builder/stable/electron-builder.yml
@@ -33,3 +33,4 @@ mac:
         - bpmn
       name: BPMN
   artifactName: 'bpmn-studio-setup-${version}.${ext}'
+afterSign: "build/code-signing/mac/notarize.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bpmn-studio",
-  "version": "6.5.0-alpha.4",
+  "version": "6.5.0-alpha.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6286,6 +6286,28 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-1.1.0.tgz",
       "integrity": "sha512-Z1qA/1oHNowGtSBIcWk0pcLEqYT/j+13xUw/MYOrBUOL4X7VN0i0KCTf5SqyvMPmW5pSPKbo28wkxMxzZ20YnQ=="
+    },
+    "electron-notarize": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/electron-notarize/-/electron-notarize-1.0.0.tgz",
+      "integrity": "sha512-dsib1IAquMn0onCrNMJ6gtEIZn/azG8hZMCYOuZIMVMUeRMgBYHK1s5TK9P8xAcrAjh/2aN5WYHzgVSWX314og==",
+      "requires": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.1"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^1.0.0"
+          }
+        }
+      }
     },
     "electron-notifications": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "bpmn-js-differ": "2.0.2",
     "dom-event-dispatch": "1.0.0",
     "electron-is-dev": "1.1.0",
+    "electron-notarize": "^1.0.0",
     "electron-notifications": "1.0.0",
     "electron-window-state": "^5.0.3",
     "fs-extra": "8.1.0",


### PR DESCRIPTION
## Changes

1. Notarize the macOS app after sign

## Issues

Closes #1989 

PR: #2112 

## How to test the changes

Folgende Voraussetzungen müssen erfüllt sein:
- Xcode 10 oder neuer (`xcodebuild -version`)
- macOS 10.13.6 oder neuer (`sw_vers`)

```
export APPLE_USERNAME='...'
export APPLE_PASSWORD='...'
export CSC_LINK=<Pfad zum Apple-Developer-Zertifikat>

npm run electron-build-macos
```

Die benötigten Daten finden sich in 1Password im "ProcessEngine"-Tresor.

Zertifikat: [Apple Developer Certificate Electron](https://5minds.1password.com/vaults/nqsd7iar7qxpuy62ji4zskbz4e/allitems/mxnl26i2mczoe2xo4ekcdiiiby)
Apple-ID: [Apple-ID -- Jenkins](https://5minds.1password.com/vaults/nqsd7iar7qxpuy62ji4zskbz4e/allitems/zl754qdbbfepxdp6uybewrorl4)

Der Erfolg der Beglaubigung kann wie folgt geprüft werden:

```
codesign --test-requirement="=notarized" --verify --verbose dist/electron/mac/BPMN Studio.app
```

Erwartetes Ergebnis:

```
dist/electron/mac/BPMN Studio.app: valid on disk
dist/electron/mac/BPMN Studio.app: satisfies its Designated Requirement
dist/electron/mac/BPMN Studio.app: explicit requirement satisfied
```