### PR TITLE
🐛 Fix wrong information in help text

### DIFF
--- a/src/services/help-modal-service/help-texts/usertask-usage.ts
+++ b/src/services/help-modal-service/help-texts/usertask-usage.ts
@@ -31,7 +31,7 @@ export const UserTaskUsage: HelpText = {
   - Label: The displayed name of the form field
   - Default Value: The default value of the form field
 
-  The values for \`label\` and \`default value\` can be anything.
+  The values for \`label\` and \`default value\` can be anything except on a Date form field. If it is a date form field, the default value must correspond to the <a href="https://en.wikipedia.org/wiki/ISO_8601#Dates" target="_blank">ISO 8601 date standard</a>.
   However, you can also use token expressions.
 
   **Example:**


### PR DESCRIPTION
## Changes

1. Fix wrong information about default values of date form fields 

## Issues

Closes #2115 

PR: #2118

## How to test the changes

open the help text for user tasks
