### PR TITLE
Hotfix: Zu Lange Pfade in den Engine Node Modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -262,9 +262,9 @@
       }
     },
     "@atlas-engine/fullstack_server": {
-      "version": "11.2.0-hotfix-cab487-kjsbxwss",
-      "resolved": "https://registry.npmjs.org/@atlas-engine/fullstack_server/-/fullstack_server-11.2.0-hotfix-cab487-kjsbxwss.tgz",
-      "integrity": "sha512-MSiotRB/VN0b7IpFlpBE3XrDs3qg8Ao791OqjG/KlJrWVLFJpjFoz6glue1zdJmT2gTzvmJyfn8gBddgmtfXiA==",
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@atlas-engine/fullstack_server/-/fullstack_server-11.2.1.tgz",
+      "integrity": "sha512-Ti7yXnn0kp2MnqDbH4XUV3KwHMfMxi72qTiQLsmxMQFj2FAXz8J381oCz8rUnu/d6bjXEIi9Ugo9u8S0npWiZw==",
       "requires": {
         "@atlas-engine/api.endpoint.http": "2.2.0",
         "@atlas-engine/api.repository.embedded": "2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bpmn-studio",
-  "version": "6.5.0-beta.4",
+  "version": "6.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -189,15 +189,15 @@
       }
     },
     "@atlas-engine/database.adapter.sequelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@atlas-engine/database.adapter.sequelize/-/database.adapter.sequelize-1.2.0.tgz",
-      "integrity": "sha512-U2gGL4aV1wYm2eq2QR5w29RA2sT9BsjnAxXD9aSrt9caJ3E69e8tntAwu96CvuKOuBzg2UHIdQpSIZaysWeMjA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@atlas-engine/database.adapter.sequelize/-/database.adapter.sequelize-1.2.1.tgz",
+      "integrity": "sha512-e6gvsACL1iEC2ejJgKO0TqzBCMIXV3YBeTDSTbBlXS/CGH+2lw247bL9NpOh7i/XGxET9S3iJoUMdbak2wCl2w==",
       "requires": {
         "@atlas-engine/configuration_service": "^2.0.0",
         "@atlas-engine/error_provider": "^1.0.5",
         "@atlas-engine/event_aggregator": "^2.0.0",
         "@atlas-engine/iam.contracts": "^1.1.0",
-        "@atlas-engine/persistence.contracts": "1.2.0-beta.1",
+        "@atlas-engine/persistence.contracts": "^1.2.0",
         "@atlas-engine/process_model": "^2.0.0",
         "async-lock": "1.2.4",
         "bcryptjs": "2.4.3",
@@ -211,17 +211,6 @@
         "uuid": "^8.3.0"
       },
       "dependencies": {
-        "@atlas-engine/persistence.contracts": {
-          "version": "1.2.0-beta.1",
-          "resolved": "https://registry.npmjs.org/@atlas-engine/persistence.contracts/-/persistence.contracts-1.2.0-beta.1.tgz",
-          "integrity": "sha512-IzkZWSPyr0DmngFL/5MWbSiyAoLLv3phCGy1jDIdRn1cwyW56sYvskCc4iU+qJ9z7TiKL4oz9FFJ5zmFjOYyWA==",
-          "requires": {
-            "@atlas-engine/event_aggregator": "2.0.0",
-            "@atlas-engine/iam.contracts": "1.1.0",
-            "@atlas-engine/process_model": "2.0.0",
-            "moment": "^2.29.0"
-          }
-        },
         "async-lock": {
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.2.4.tgz",
@@ -273,9 +262,9 @@
       }
     },
     "@atlas-engine/fullstack_server": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@atlas-engine/fullstack_server/-/fullstack_server-11.2.0.tgz",
-      "integrity": "sha512-+mrOuEpcbTws7E130X3RRpRuQ3crToQXoiNFSL0UnbD10VAuz6JCgOuLNNa36mOxPp/o3lnzj0TvSTUOAMOLgw==",
+      "version": "11.2.0-hotfix-cab487-kjsbxwss",
+      "resolved": "https://registry.npmjs.org/@atlas-engine/fullstack_server/-/fullstack_server-11.2.0-hotfix-cab487-kjsbxwss.tgz",
+      "integrity": "sha512-MSiotRB/VN0b7IpFlpBE3XrDs3qg8Ao791OqjG/KlJrWVLFJpjFoz6glue1zdJmT2gTzvmJyfn8gBddgmtfXiA==",
       "requires": {
         "@atlas-engine/api.endpoint.http": "2.2.0",
         "@atlas-engine/api.repository.embedded": "2.2.0",
@@ -285,11 +274,11 @@
         "@atlas-engine/configuration_service": "2.0.0",
         "@atlas-engine/core_domain.process_model_execution": "2.2.0",
         "@atlas-engine/core_domain.runtime_repository.embedded": "2.2.0",
-        "@atlas-engine/database.adapter.sequelize": "1.2.0",
+        "@atlas-engine/database.adapter.sequelize": "1.2.1",
         "@atlas-engine/event_aggregator": "2.0.0",
         "@atlas-engine/http_extension": "2.0.2",
         "@atlas-engine/iam": "2.0.0",
-        "@atlas-engine/logging.adapter.file_system": "1.2.0",
+        "@atlas-engine/logging.adapter.file_system": "1.2.1",
         "@atlas-engine/persistence.contracts": "1.2.0",
         "@atlas-engine/process_engine_proxy": "2.2.0",
         "@atlas-engine/process_model": "2.0.0",
@@ -378,9 +367,9 @@
           }
         },
         "socket.io-parser": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.1.tgz",
-          "integrity": "sha512-1QLvVAe8dTz+mKmZ07Swxt+LAo4Y1ff50rlyoEx00TQmDFVQYPfcqGvIDJLGaBdhdNCecXtyKpD+EgKGcmmbuQ==",
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.2.tgz",
+          "integrity": "sha512-FJvDBuOALxdCI9qwRrO/Rfp9yfndRtc1jSgVgV8FDraihmSP/MLGD5PEuJrNfjALvcQ+vMDM/33AWOYP/JSjDg==",
           "requires": {
             "component-emitter": "~1.3.0",
             "debug": "~3.1.0",
@@ -468,13 +457,13 @@
       "integrity": "sha512-R4ZNzaTCl6EFdWNUU085VdkXdE5IOlqwRILIGttOqChBwgbcSo6z725VVa46uv4L9uWuHQ3A70JwoGzrrjC5jw=="
     },
     "@atlas-engine/logging.adapter.file_system": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@atlas-engine/logging.adapter.file_system/-/logging.adapter.file_system-1.2.0.tgz",
-      "integrity": "sha512-OmvxgxnnLl04WzyvkQPZRjcMg7TFNGfo0dM7e0fYUuc5N6H9Jt1/p1pV4F0akI+OOkvXnb3rdyDq5WRDtzPrLA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@atlas-engine/logging.adapter.file_system/-/logging.adapter.file_system-1.2.1.tgz",
+      "integrity": "sha512-jWR1LngeCSmRrvmSf+w9aq368HvQhVdg72h9ja1N4qIPn7NcZ5fYQ0r/EhhRKbdNvxKEywP7Tf1nEbXbn8FwXw==",
       "requires": {
         "@atlas-engine/configuration_service": "2.0.0",
         "@atlas-engine/error_provider": "^1.0.5",
-        "@atlas-engine/persistence.contracts": "1.2.0-beta.1",
+        "@atlas-engine/persistence.contracts": "^1.2.0",
         "async-lock": "1.2.4",
         "bluebird": "3.7.2",
         "inversify": "5.0.1",
@@ -482,17 +471,6 @@
         "reflect-metadata": "0.1.13"
       },
       "dependencies": {
-        "@atlas-engine/persistence.contracts": {
-          "version": "1.2.0-beta.1",
-          "resolved": "https://registry.npmjs.org/@atlas-engine/persistence.contracts/-/persistence.contracts-1.2.0-beta.1.tgz",
-          "integrity": "sha512-IzkZWSPyr0DmngFL/5MWbSiyAoLLv3phCGy1jDIdRn1cwyW56sYvskCc4iU+qJ9z7TiKL4oz9FFJ5zmFjOYyWA==",
-          "requires": {
-            "@atlas-engine/event_aggregator": "2.0.0",
-            "@atlas-engine/iam.contracts": "1.1.0",
-            "@atlas-engine/process_model": "2.0.0",
-            "moment": "^2.29.0"
-          }
-        },
         "async-lock": {
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.2.4.tgz",
@@ -4691,12 +4669,12 @@
       }
     },
     "call-bind": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
-      "integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.1.tgz",
+      "integrity": "sha512-tvAvUwNcRikl3RVF20X9lsYmmepsovzTWeJiXjO0PkJp15uy/6xKFZOQtuiSULwYW+6ToZBprphCgWXC2dSgcQ==",
       "requires": {
         "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.0"
+        "get-intrinsic": "^1.0.2"
       }
     },
     "callsite": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@atlas-engine/fullstack_server": "hotfix~v11.2.1",
+    "@atlas-engine/fullstack_server": "11.2.1",
     "@essential-projects/errors_ts": "^1.6.1",
     "@fortawesome/fontawesome-free": "5.11.2",
     "@process-engine/bpmn-js-custom-bundle": "2.11.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@atlas-engine/fullstack_server": "11.2.0",
+    "@atlas-engine/fullstack_server": "hotfix~v11.2.1",
     "@essential-projects/errors_ts": "^1.6.1",
     "@fortawesome/fontawesome-free": "5.11.2",
     "@process-engine/bpmn-js-custom-bundle": "2.11.0",


### PR DESCRIPTION
## Beschreibung

Fixt ein Issue in der Engine, dass zu lange Pfade für ein Windows ohne Long-Path Option erzeugt hat.

## Relevante Issues und/oder PRs

Related to https://github.com/atlas-engine/AtlasEngine/pull/310

## Wie lassen sich die Änderungen testen?

- BPMN Studio unter WIndows starten, bei deaktivierter "LongPath" Option
- Das Studio sollte starten