### PR TITLE
Hotfix: Fix Request Headers on HTTP Service Task (GET, DELETE)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bpmn-studio",
   "description": "An Aurelia application for designing BPMN diagrams, which can also be connected to a process engine to execute these diagrams.",
-  "version": "6.5.2",
+  "version": "6.5.3",
   "author": {
     "name": "process-engine",
     "email": "hello@process-engine.io",

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/components/http-service-task/http-service-task.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/components/http-service-task/http-service-task.html
@@ -7,7 +7,12 @@
         <tr>
           <th>Method</th>
           <td>
-            <select class="props-input props-select" value.bind="selectedHttpMethod" change.delegate="httpMethodChanged()" disabled.bind="!model.isEditable">
+            <select
+              class="props-input props-select"
+              value.bind="selectedHttpMethod"
+              change.delegate="httpMethodChanged()"
+              disabled.bind="!model.isEditable"
+            >
               <option value="null">-Choose Method-</option>
               <option value="get">GET</option>
               <option value="post">POST</option>
@@ -24,7 +29,8 @@
               class="props-input name-input"
               value.bind="selectedHttpUrl"
               change.delegate="selectedHttpParamsChanged()"
-              disabled.bind="!model.isEditable">
+              disabled.bind="!model.isEditable"
+            />
           </td>
         </tr>
         <tr class.bind="!selectedHttpUrl ? 'props-table__row--disabled' : ''">
@@ -34,10 +40,11 @@
               class="props-input-textarea name-input"
               value.bind="selectedHttpBody"
               change.delegate="selectedHttpParamsChanged()"
-              disabled.bind="!selectedHttpUrl || !model.isEditable"></textarea>
+              disabled.bind="!selectedHttpUrl || !model.isEditable"
+            ></textarea>
           </td>
         </tr>
-        <tr class.bind="!selectedHttpBody ? 'props-table__row--disabled' : ''">
+        <tr>
           <th>Content Type</th>
           <td>
             <input
@@ -45,10 +52,11 @@
               class="props-input name-input"
               value.bind="selectedHttpContentType"
               change.delegate="selectedHttpParamsChanged()"
-              disabled.bind="!selectedHttpBody || !model.isEditable">
+              disabled.bind="!model.isEditable"
+            />
           </td>
         </tr>
-        <tr class.bind="!selectedHttpBody ? 'props-table__row--disabled' : ''">
+        <tr>
           <th>Authorization</th>
           <td>
             <input
@@ -56,7 +64,8 @@
               class="props-input name-input"
               value.bind="selectedHttpAuth"
               change.delegate="selectedHttpParamsChanged()"
-              disabled.bind="!selectedHttpBody || !model.isEditable">
+              disabled.bind="!model.isEditable"
+            />
           </td>
         </tr>
       </table>

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/components/http-service-task/http-service-task.html
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/components/http-service-task/http-service-task.html
@@ -33,14 +33,14 @@
             />
           </td>
         </tr>
-        <tr class.bind="!selectedHttpUrl ? 'props-table__row--disabled' : ''">
+        <tr>
           <th>Body</th>
           <td>
             <textarea
               class="props-input-textarea name-input"
               value.bind="selectedHttpBody"
               change.delegate="selectedHttpParamsChanged()"
-              disabled.bind="!selectedHttpUrl || !model.isEditable"
+              disabled.bind="!model.isEditable"
             ></textarea>
           </td>
         </tr>

--- a/src/modules/design/property-panel/indextabs/general/sections/service-task/components/http-service-task/http-service-task.ts
+++ b/src/modules/design/property-panel/indextabs/general/sections/service-task/components/http-service-task/http-service-task.ts
@@ -73,7 +73,7 @@ export class HttpServiceTask {
     const property: IProperty = this.serviceTaskService.getProperty('method');
     property.value = this.selectedHttpMethod;
 
-    this.getParamsFromInput();
+    this.serviceTaskService.updateOrCreateProperty('params', this.getParamsFromInput());
     this.publishDiagramChange();
   }
 
@@ -107,10 +107,14 @@ export class HttpServiceTask {
   private getParamsFromInput(): string {
     const params = [];
     params.push(this.selectedHttpUrl);
-    if (this.selectedHttpBody) {
-      params.push(this.selectedHttpBody);
+    if (this.selectedHttpMethod !== 'get' && this.selectedHttpMethod !== 'delete') {
+      if (this.selectedHttpBody) {
+        params.push(this.selectedHttpBody);
+      } else if (this.selectedHttpMethod === 'post' || this.selectedHttpMethod === 'put') {
+        params.push({});
+      }
     }
-    if (this.selectedHttpBody && (this.selectedHttpContentType || this.selectedHttpAuth)) {
+    if (this.selectedHttpContentType || this.selectedHttpAuth) {
       params.push({
         headers: {
           'Content-Type': this.selectedHttpContentType ? this.selectedHttpContentType : undefined,
@@ -122,7 +126,7 @@ export class HttpServiceTask {
     let returnValue = `[${JSON.stringify(params[0])}`;
 
     if (params[1] != null) {
-      if (params[1].startsWith('{') && params[1].endsWith('}')) {
+      if (params[1].toString().startsWith('{') && params[1].toString().endsWith('}')) {
         returnValue += `, ${params[1]}`;
       } else {
         returnValue += `, ${JSON.stringify(params[1])}`;


### PR DESCRIPTION

## Changes

1. Erlaubt es alle Felder eines HTTP Service Tasks unabhängig von anderen Feldern zu setzen.
2. Setzt bei GET und DELETE Requests keinen Body, damit die Engine die zusammengefügten Parameter richtig parsen kann und somit auch Header für GET und DELETE nutzt. 
3. Fügt für POST und PUT einen leeren Body zu den Parametern hinzu, falls keiner angegeben ist. 

## Issues

PR: #2127 

## How to test the changes

- Schauen ob bei GET und DELETE Requests die angegebenen Header auch im Request am Server ankommen
- Schauen dass man auch einen Header setzen kann, ohne vorher einen Body angeben zu müssen
